### PR TITLE
reindex_everything should ignore non-RDF sources

### DIFF
--- a/lib/active_fedora/indexing.rb
+++ b/lib/active_fedora/indexing.rb
@@ -79,6 +79,9 @@ module ActiveFedora
 
       def get_descendent_uris(uri)
         resource = Ldp::Resource::RdfSource.new(ActiveFedora.fedora.connection, uri)
+        # GET could be slow if it's a big resource, we're using HEAD to avoid this problem,
+        # but this causes more requests to Fedora.
+        return [] unless Ldp::Response.rdf_source?(resource.head)
         immediate_descendent_uris = resource.graph.query(predicate: ::RDF::LDP.contains).map { |descendent| descendent.object.to_s }
         all_descendents_uris = [uri]
         immediate_descendent_uris.each do |descendent_uri|

--- a/spec/integration/indexing_spec.rb
+++ b/spec/integration/indexing_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+@@last_id = 0
+
+describe ActiveFedora::Base do
+  describe "get_descendent_uris" do
+
+    before :each do
+      ids.each do |id|
+        ActiveFedora::Base.create id: id
+      end
+    end
+
+    def root_uri(ids=[])
+      ActiveFedora::Base.id_to_uri(ids.first)
+    end
+
+    context 'when there there are no descendents' do
+
+      let(:ids) { ['foo'] }
+
+      it 'returns an array containing only the URI passed to it' do
+        expect(ActiveFedora::Base.get_descendent_uris(root_uri(ids))).to eq ids.map {|id| ActiveFedora::Base.id_to_uri(id) }
+      end
+    end
+
+    context 'when there are > 1 descendents' do
+
+      let(:ids) { ['foo', 'foo/bar', 'foo/bar/chu'] }
+
+      it 'returns an array containing the URI passed to it, as well as all descendent URIs' do
+        expect(ActiveFedora::Base.get_descendent_uris(root_uri(ids))).to eq ids.map {|id| ActiveFedora::Base.id_to_uri(id) }
+      end
+    end
+
+    context 'when some of the decendants are not RDFSources' do
+      let(:ids) { ['foo', 'foo/bar'] }
+      let(:datastream) { ActiveFedora::Datastream.new(ActiveFedora::Base.id_to_uri('foo/bar/bax')) }
+
+      before do
+        datastream.content = "Hello!!!"
+        datastream.save
+      end
+
+      it "should not put the datastream in the decendants list" do
+        expect(ActiveFedora::Base.get_descendent_uris(root_uri(ids))).not_to include datastream.uri
+      end
+    end
+  end
+end

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -20,37 +20,6 @@ describe ActiveFedora::Base do
     end
   end
 
-  describe "get_descendent_uris" do
-
-    before :each do
-      ids.each do |id|
-        ActiveFedora::Base.create id: id
-      end
-    end
-
-    def root_uri(ids=[])
-      ActiveFedora::Base.id_to_uri(ids.first)
-    end
-
-    context 'when there there are no descendents' do
-
-      let(:ids) { ['foo'] }
-
-      it 'returns an array containing only the URI passed to it' do
-        expect(ActiveFedora::Base.get_descendent_uris(root_uri(ids))).to eq ids.map {|id| ActiveFedora::Base.id_to_uri(id) }
-      end
-    end
-
-    context 'when there are > 1 descendents' do
-
-      let(:ids) { ['foo', 'foo/bar', 'foo/bar/chu'] }
-
-      it 'returns an array containing the URI passed to it, as well as all descendent URIs' do
-        expect(ActiveFedora::Base.get_descendent_uris(root_uri(ids))).to eq ids.map {|id| ActiveFedora::Base.id_to_uri(id) }
-      end
-    end
-  end
-
   describe "With a test class" do
     before :each do
       class FooHistory < ActiveFedora::Base


### PR DESCRIPTION
Because they don't have parsable graphs.