### PR TITLE
Provide the URI as part of the error message when object recreation is a...

### DIFF
--- a/lib/active_fedora/core.rb
+++ b/lib/active_fedora/core.rb
@@ -36,7 +36,7 @@ module ActiveFedora
     def initialize(attributes_or_resource_or_url = nil, &block)
       init_internals
       attributes = initialize_resource_and_attributes(attributes_or_resource_or_url)
-      raise IllegalOperation, "Attempting to recreate existing ldp_source" unless ldp_source.new?
+      raise IllegalOperation, "Attempting to recreate existing ldp_source: `#{ldp_source.subject}'" unless ldp_source.new?
       assert_content_model
       load_attached_files
       self.attributes = attributes if attributes

--- a/spec/integration/base_spec.rb
+++ b/spec/integration/base_spec.rb
@@ -46,7 +46,7 @@ describe "A base object with metadata" do
     end
     describe "when trying to create it again" do
       it "should raise an error" do
-        expect { MockAFBaseRelationship.create(id: @release.id) }.to raise_error(ActiveFedora::IllegalOperation)
+        expect { MockAFBaseRelationship.create(id: @release.id) }.to raise_error(ActiveFedora::IllegalOperation, "Attempting to recreate existing ldp_source: `#{@release.uri}'")
         @release.reload
         expect(@release.foo.person).to include('test foo content')
       end


### PR DESCRIPTION
...ttempted