### PR TITLE
Use the File class in the root namespace

### DIFF
--- a/lib/generators/active_fedora/config/fedora/fedora_generator.rb
+++ b/lib/generators/active_fedora/config/fedora/fedora_generator.rb
@@ -2,7 +2,7 @@ require 'rails/generators'
 
 module ActiveFedora
   class Config::FedoraGenerator < Rails::Generators::Base
-    source_root File.expand_path('../templates', __FILE__)
+    source_root ::File.expand_path('../templates', __FILE__)
 
     def generate
       copy_file('fedora.yml', 'config/fedora.yml')


### PR DESCRIPTION
Otherwise it's trying to call ActiveFedora::File.expand_path
which is not a method