### PR TITLE
Load singular datastream attributes from solr

### DIFF
--- a/lib/active_fedora/loadable_from_json.rb
+++ b/lib/active_fedora/loadable_from_json.rb
@@ -15,9 +15,11 @@ module ActiveFedora
         @hash.fetch(terminology.first, [])
       end
 
+      # It is expected that the singular filter gets applied after fetching the value from this
+      # resource, so cast everything back to an array.
       def update_indexed_attributes hash
         hash.each do |k, v|
-          @hash[k.first] = v
+          @hash[k.first] = Array(v)
         end
       end
 

--- a/spec/integration/solr_instance_loader_spec.rb
+++ b/spec/integration/solr_instance_loader_spec.rb
@@ -35,6 +35,7 @@ describe ActiveFedora::SolrInstanceLoader do
         expect(subject.title).to eq 'My Title'
         expect(subject.description).to match_array ['first desc', 'second desc']
         expect(subject.another_id).to eq another.id
+        expect(subject.bar).to eq 'quix'
       end
 
       it "should not be mutable" do


### PR DESCRIPTION
Previously only the first character of singular datastream attributes
was being returned when the object was loaded from solr.