### PR TITLE
Fixes bug that prevented ActiveFedora from deserializing classes 

### DIFF
--- a/lib/active_fedora/core.rb
+++ b/lib/active_fedora/core.rb
@@ -116,6 +116,9 @@ module ActiveFedora
       end
 
     module ClassMethods
+
+      SLASH = '/'.freeze
+
       def generated_association_methods
         @generated_association_methods ||= begin
           mod = const_set(:GeneratedAssociationMethods, Module.new)
@@ -138,8 +141,10 @@ module ActiveFedora
         if translate_id_to_uri
           translate_id_to_uri.call(id)
         else
-          id = "/#{id}" unless id.start_with? '/'
-          id = ActiveFedora.fedora.base_path + id unless id.start_with? "#{ActiveFedora.fedora.base_path}/"
+          id = "/#{id}" unless id.start_with? SLASH
+          unless ActiveFedora.fedora.base_path == SLASH || id.start_with?("#{ActiveFedora.fedora.base_path}/")
+            id = ActiveFedora.fedora.base_path + id 
+          end
           ActiveFedora.fedora.host + id
         end
       end

--- a/spec/unit/core_spec.rb
+++ b/spec/unit/core_spec.rb
@@ -104,6 +104,20 @@ describe ActiveFedora::Base do
 
       it { should eq "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/foo/123456w" }
     end
+
+    context "with an empty base path" do
+      it "should produce a valid URI" do
+        allow(ActiveFedora.fedora).to receive(:base_path).and_return("/")    
+        expect(subject).to eq("#{ActiveFedora.fedora.host}/#{id}")
+      end
+    end
+
+    context "with a really empty base path" do
+      it "should produce a valid URI" do
+        allow(ActiveFedora.fedora).to receive(:base_path).and_return("")    
+        expect(subject).to eq("#{ActiveFedora.fedora.host}/#{id}")
+      end
+    end
   end
 
   describe "uri_to_id" do
@@ -123,4 +137,5 @@ describe ActiveFedora::Base do
       it { should eq '123456w' }
     end
   end
+
 end


### PR DESCRIPTION
correctly when the base_path setting in fedora.yaml was not set.

Takes care of https://github.com/projecthydra/active_fedora/issues/657

Note: When I removed the base_path from config/fedora.yml and ran all tests I got 20+ failing tests. I spot checked several of them and the issues where because the tests were hard-coded to expect a /test/ on the URL or because the cleaner didn't know how to clean from fedora/rest rather than fedora/rest/test. I didn't think this should be an issue with the code given the new tests that evaluate the new changes. 