### PR TITLE
Encodes file name in HTTP header to allow for special characters in filename

### DIFF
--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -219,7 +219,7 @@ module ActiveFedora
     def fetch_original_name_from_headers
       return if new_record?
       m = ldp_source.head.headers['Content-Disposition'].match(/filename="(?<filename>[^"]*)";/)
-      m[:filename]
+      URI.decode(m[:filename])
     end
 
     def fetch_mime_type
@@ -253,7 +253,7 @@ module ActiveFedora
         return unless content_changed?
         payload = behaves_like_io?(content) ? content.read : content
         headers = { 'Content-Type' => mime_type }
-        headers['Content-Disposition'] = "attachment; filename=\"#{@original_name}\"" if @original_name
+        headers['Content-Disposition'] = "attachment; filename=\"#{URI.encode(@original_name)}\"" if @original_name
         # Setting the content-length is required until we figure out why Faraday 
         # is not doing this automatically for files uploaded via ActionDispatch.
         headers['Content-Length'] = payload.size.to_s if uploaded_file?(payload)

--- a/spec/unit/file_spec.rb
+++ b/spec/unit/file_spec.rb
@@ -189,12 +189,23 @@ describe ActiveFedora::Datastream do
     context "when it's saved" do
       let(:parent) { ActiveFedora::Base.create }
       before do
-        parent.add_file_datastream('one1two2threfour', dsid: 'abcd', mime_type: 'video/webm', original_name: "my_image.png")
+        parent.add_file_datastream('one1two2threfour', dsid: 'abcd', mime_type: 'video/webm', original_name: 'my image.png')
         parent.save!
       end
 
       it "should have original_name" do
-        expect(parent.reload.abcd.original_name).to eq 'my_image.png'
+        expect(parent.reload.abcd.original_name).to eq 'my image.png'
+      end      
+    end
+
+    context "with special characters" do 
+      let(:parent) { ActiveFedora::Base.create }
+      before do
+        parent.add_file_datastream('one1two2threfour', dsid: 'abcd', mime_type: 'video/webm', original_name:'my "image".png')
+        parent.save!
+      end
+      it "should save OK and preserve name" do
+        expect(parent.reload.abcd.original_name).to eq 'my "image".png'
       end
     end
   end


### PR DESCRIPTION
Takes care of issue #693 