### PR TITLE
Deprecate the three and four arg constructor to add_file

### DIFF
--- a/lib/active_fedora/attached_files.rb
+++ b/lib/active_fedora/attached_files.rb
@@ -88,7 +88,14 @@ module ActiveFedora
     # @option opts [String] :prefix The path prefix (for auto-generated path)
     # @option opts [String] :mime_type The Mime-Type of the file
     # @option opts [String] :original_name The original name of the file (used for Content-Disposition)
-    def add_file(file, opts={})
+    def add_file(file, *args)
+      opts = if args.size == 1
+        args.first
+      else
+        Deprecation.warn AttachedFiles, "The second option to add_file should be a hash. Passing the file path is deprecated and will be removed in active-fedora 10.0.", caller
+        { path: args[0], original_name: args[1], mime_type: args[2] }
+      end
+
       if opts[:dsid]
         Deprecation.warn AttachedFiles, "The :dsid option to add_file is deprecated and will be removed in active-fedora 10.0. Use :path instead", caller
         opts[:path] = opts[:dsid]

--- a/spec/unit/attached_files_spec.rb
+++ b/spec/unit/attached_files_spec.rb
@@ -133,6 +133,24 @@ describe ActiveFedora::AttachedFiles do
       end
     end
 
+    context "the deprecated 3 args erasure" do
+      it "should build the reflection" do
+        expect(Deprecation).to receive(:warn)
+        container.add_file('blah', 'content', 'name.png')
+        expect(container.content).to be_instance_of Bar
+        expect(container.content.content).to eq 'blah'
+      end
+    end
+
+    context "the deprecated 4 args erasure" do
+      it "should build the reflection" do
+        expect(Deprecation).to receive(:warn)
+        container.add_file('blah', 'content', 'name.png', 'image/png')
+        expect(container.content).to be_instance_of Bar
+        expect(container.content.content).to eq 'blah'
+      end
+    end
+
     context "no reflection matches the :path property" do
       it "should create a singleton reflection and build it" do
         container.add_file('blah', path: 'fizz')


### PR DESCRIPTION
This gives a helpful migration path instead of an error when add_file is
called with 3 or 4 arguments instead of the expected 2