### PR TITLE
Avoid unnecessary HEAD request on file retrieval. Fixes #493

### DIFF
--- a/lib/active_fedora/associations/builder/contains.rb
+++ b/lib/active_fedora/associations/builder/contains.rb
@@ -19,7 +19,11 @@ module ActiveFedora::Associations::Builder
       mixin.send(:define_method, name) do |*params|
         association(name).reader(*params).tap do |file|
           set_uri = uri.kind_of?(RDF::URI) ? uri.value.present? : uri.present?
-          file.uri = "#{uri}/#{name}" if set_uri
+          if set_uri
+            file_uri = "#{uri}/#{name}"
+            file.uri = file_uri
+            file.exists! if contains_assertions.include?(file_uri)
+          end
         end
       end
     end

--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -58,12 +58,19 @@ module ActiveFedora
       ldp_source.subject
     end
 
+    # If this file have a parent with ldp#contains, we know it is not new.
+    # By tracking exists we prevent an unnecessary HEAD request.
     def new_record?
-      ldp_source.new?
+      !@exists && ldp_source.new?
     end
 
     def uri= uri
       @ldp_source = Ldp::Resource::BinarySource.new(ldp_connection, uri, '', ActiveFedora.fedora.host + ActiveFedora.fedora.base_path)
+    end
+
+    # If we know the record to exist (parent has LDP:contains), we can avoid unnecessary HEAD requests
+    def exists!
+      @exists = true
     end
 
     # When restoring from previous versions, we need to reload certain attributes from Fedora

--- a/lib/active_fedora/loadable_from_json.rb
+++ b/lib/active_fedora/loadable_from_json.rb
@@ -62,6 +62,10 @@ module ActiveFedora
           @values.map {|v| FakeStatement.new(v) }
         end
 
+        def objects
+          @values
+        end
+
         class FakeStatement
           def initialize(value)
             @value = value
@@ -89,7 +93,7 @@ module ActiveFedora
       end
 
       def reflection(predicate)
-        @model.outgoing_reflections.find { |key, reflection| reflection.predicate == predicate }.first
+        Array(@model.outgoing_reflections.find { |key, reflection| reflection.predicate == predicate }).first
       end
     end
 

--- a/spec/integration/attached_files_spec.rb
+++ b/spec/integration/attached_files_spec.rb
@@ -1,6 +1,30 @@
 require 'spec_helper'
 
 describe ActiveFedora::AttachedFiles do
+  describe "#contains" do
+    before do
+      class FooHistory < ActiveFedora::Base
+         contains 'child'
+      end
+    end
+    after do
+      Object.send(:remove_const, :FooHistory)
+    end
+
+    context "when the object exists" do
+      let!(:o) { FooHistory.create }
+      before do
+        o.child.content = "HMMM"
+        o.save
+      end
+
+      it "should not need to do a head on the children" do
+        f = FooHistory.find(o.id)
+        expect(f.ldp_source.client).not_to receive(:head)
+        f.child.content
+      end
+    end
+  end
   describe "serializing datastreams" do
     before do
       class TestingMetadataSerializing < ActiveFedora::Base


### PR DESCRIPTION
If a NonRDFSource has a parent which is an RDFSource (AF::Base) and the
parent indicates that it contains the file (ldp:contains) then there is
no need to send a HEAD request to see if the file exists.