### PR TITLE
Jettywrapper doesn't require hydra_jetty_version

### DIFF
--- a/lib/tasks/active_fedora_dev.rake
+++ b/lib/tasks/active_fedora_dev.rake
@@ -1,7 +1,7 @@
 APP_ROOT = File.expand_path("#{File.dirname(__FILE__)}/../../")
 
 require 'jettywrapper'
-Jettywrapper.hydra_jetty_version = "master"
+
 namespace :active_fedora do
   # Use yard to build docs
   begin


### PR DESCRIPTION
As of Jettywrapper 2.0.3, the hydra_jetty_version is no longer required unless you want to download a version of hydra-jetty other than master.