### PR TITLE
Backport solr escape patch

### DIFF
--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -233,10 +233,10 @@ module ActiveFedora
         if value.empty?
           "-#{key}:['' TO *]"
         elsif value.is_a? Array
-          value.map { |val| "#{key}:#{RSolr.escape(val)}" }
+          value.map { |val| "#{key}:#{solr_escape(val)}" }
         else
           key = SOLR_DOCUMENT_ID if (key === :id || key === :pid)
-          "#{key}:#{RSolr.escape(value)}"
+          "#{key}:#{solr_escape(value)}"
         end
       end
     end
@@ -248,5 +248,8 @@ module ActiveFedora
       end
     end
 
+    def solr_escape terms
+      RSolr.solr_escape(terms).gsub(/\s+/,"\\ ")
+    end
   end
 end

--- a/spec/integration/solr_service_spec.rb
+++ b/spec/integration/solr_service_spec.rb
@@ -36,7 +36,7 @@ describe ActiveFedora::SolrService do
       Object.send(:remove_const, :FooObject)
     end
     it "should return an array of objects that are of the class stored in active_fedora_model_s" do
-      query = "id\:#{RSolr.escape(@test_object.pid)} OR id\:#{RSolr.escape(@foo_object.pid)}"
+      query = "id\:#{RSolr.solr_escape(@test_object.pid)} OR id\:#{RSolr.solr_escape(@foo_object.pid)}"
       solr_result = ActiveFedora::SolrService.query(query)
       result = ActiveFedora::SolrService.reify_solr_results(solr_result)
       result.length.should == 2
@@ -46,7 +46,7 @@ describe ActiveFedora::SolrService do
     end
     
     it 'should load objects from solr data if a :load_from_solr option is passed in' do
-      query = "id\:#{RSolr.escape(@test_object.pid)} OR id\:#{RSolr.escape(@foo_object.pid)}"
+      query = "id\:#{RSolr.solr_escape(@test_object.pid)} OR id\:#{RSolr.solr_escape(@foo_object.pid)}"
       solr_result = ActiveFedora::SolrService.query(query)
       result = ActiveFedora::SolrService.reify_solr_results(solr_result,{:load_from_solr=>true})
       result.length.should == 2
@@ -67,7 +67,7 @@ describe ActiveFedora::SolrService do
     end
     
     it 'should #reify a lightweight object as a new instance' do
-      query = "id\:#{RSolr.escape(@foo_object.pid)}"
+      query = "id\:#{RSolr.solr_escape(@foo_object.pid)}"
       solr_result = ActiveFedora::SolrService.query(query)
       result = ActiveFedora::SolrService.reify_solr_results(solr_result,{:load_from_solr=>true})
       solr_foo = result.first
@@ -79,7 +79,7 @@ describe ActiveFedora::SolrService do
     end
     
     it 'should #reify! a lightweight object within the same instance' do
-      query = "id\:#{RSolr.escape(@foo_object.pid)}"
+      query = "id\:#{RSolr.solr_escape(@foo_object.pid)}"
       solr_result = ActiveFedora::SolrService.query(query)
       result = ActiveFedora::SolrService.reify_solr_results(solr_result,{:load_from_solr=>true})
       solr_foo = result.first
@@ -90,7 +90,7 @@ describe ActiveFedora::SolrService do
     end
     
     it 'should raise an exception when attempting to reify a first-class object' do
-      query = "id\:#{RSolr.escape(@foo_object.pid)}"
+      query = "id\:#{RSolr.solr_escape(@foo_object.pid)}"
       solr_result = ActiveFedora::SolrService.query(query)
       result = ActiveFedora::SolrService.reify_solr_results(solr_result,{:load_from_solr=>true})
       solr_foo = result.first
@@ -101,7 +101,7 @@ describe ActiveFedora::SolrService do
     end
   
     it 'should call load_instance_from_solr if :load_from_solr option passed in' do
-      query = "id\:#{RSolr.escape(@test_object.pid)} OR id\:#{RSolr.escape(@foo_object.pid)}"
+      query = "id\:#{RSolr.solr_escape(@test_object.pid)} OR id\:#{RSolr.solr_escape(@foo_object.pid)}"
       solr_result = ActiveFedora::SolrService.query(query)
       ActiveFedora::Base.should_receive(:load_instance_from_solr).once
       FooObject.should_receive(:load_instance_from_solr).once


### PR DESCRIPTION
In preparation for a Hydra 8 release, this backport will allow the hydra gem to be on the latest rsolr without spewing a ton of deprecation warnings.  I tried to make this as similar to this commit (https://github.com/projecthydra/active_fedora/commit/75b4afb248ee61d9edb56911b2ef51f30f1ce17f) on the master branch while still keeping it contained and small.