### PR TITLE
Allow a has_many association to specify an explicit foreign key via the :as option

### DIFF
--- a/lib/active_fedora/associations/builder/has_many.rb
+++ b/lib/active_fedora/associations/builder/has_many.rb
@@ -2,7 +2,7 @@ module ActiveFedora::Associations::Builder
   class HasMany < CollectionAssociation #:nodoc:
     self.macro = :has_many
 
-    self.valid_options += [:dependent, :inverse_of]
+    self.valid_options += [:as, :dependent, :inverse_of]
 
     def build
       reflection = super

--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -24,6 +24,37 @@ describe ActiveFedora::Base do
     end
 
   end
+  
+  describe "explicit foreign key" do
+    before do
+      class FooThing < ActiveFedora::Base
+        has_many :bars, :class_name=>'BarThing', :predicate=>ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf, :as=>:foothing
+      end
+
+      class BarThing < ActiveFedora::Base
+        belongs_to :foothing, :class_name=>'FooThing', :predicate=>ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf
+      end
+    end
+    
+    after do
+      Object.send(:remove_const, :FooThing)
+      Object.send(:remove_const, :BarThing)
+    end
+    
+    let(:foo) { FooThing.create }
+    let(:bar) { BarThing.create }
+    
+    it "should associate from bar to foo" do
+      bar.foothing = foo
+      bar.save
+      expect(foo.bars).to eq [bar]
+    end
+    
+    it "should associate from foo to bar" do
+      foo.bars << bar
+      expect(bar.foothing).to eq foo
+    end
+  end
 
   describe "complex example" do
     before do


### PR DESCRIPTION
Fixes the bug demonstrated in [this gist](https://gist.github.com/mbklein/88d07b3fe6ad97ee5f1d), which I never got around to filing an issue about because I fixed it instead.