### PR TITLE
Make sure datastreams get configured on load as well as new/create

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "jettywrapper", ">= 2.0.0"
   s.add_development_dependency "rspec", "~> 3.0"
+  s.add_development_dependency "rspec-its"
   s.add_development_dependency "equivalent-xml"
   s.add_development_dependency "simplecov", '~> 0.7.1'
 

--- a/lib/active_fedora/associations/contains_association.rb
+++ b/lib/active_fedora/associations/contains_association.rb
@@ -7,7 +7,9 @@ module ActiveFedora
       end
 
       def find_target
-        reflection.build_association(target_uri)
+        reflection.build_association(target_uri).tap do |record|
+          configure_datastream(record) if reflection.options[:block]
+        end 
       end
 
       def target_uri

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ end
 
 require 'active-fedora'
 require 'rspec'
+require 'rspec/its'
 require 'equivalent-xml/rspec_matchers'
 require 'logger'
 require 'byebug' unless ENV['TRAVIS']


### PR DESCRIPTION
This PR fixes an edge-case bug described in [@cjcolvar's gist](https://gist.github.com/cjcolvar/86f8c87f7be86c08fa62), in which loading a resource with a SimpleDatastream will fail if the resource's class hasn't been configured with a call to `#new` or `#create` yet.

The corresponding test has to set up the fixture via `Ldp::Orm` in order to prevent the test class from being configured during setup. Hence the ugly test. If there's a way to make it prettier, I'd welcome some feedback.