### PR TITLE
Add method workaround to support ruby 1.9.

### DIFF
--- a/lib/active_fedora/attribute_methods.rb
+++ b/lib/active_fedora/attribute_methods.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/object'
 require 'active_support/core_ext/class/attribute'
+require 'active_support/core_ext/module/method_transplanting'
 
 module ActiveFedora
   module AttributeMethods

--- a/lib/active_fedora/attribute_methods/read.rb
+++ b/lib/active_fedora/attribute_methods/read.rb
@@ -48,12 +48,36 @@ module ActiveFedora
 
 
       module ClassMethods
-        def define_method_attribute(name)
-          method = ReaderMethodCache[name.to_s]
-          generated_attribute_methods.module_eval {
-            define_method name, method
-          }
+        # Copied from ActiveRecord.  This workaround should not be required
+        # after ruby 1.9 support is ended.
+        if Module.methods_transplantable?
+          def define_method_attribute(name)
+            method = ReaderMethodCache[name.to_s]
+            generated_attribute_methods.module_eval {
+              define_method name, method
+            }
+          end
+        else
+          def define_method_attribute(name)
+            safe_name = name.unpack('h*').first
+            temp_method = "__temp__#{safe_name}"
+
+            ActiveFedora::AttributeMethods::AttrNames.set_name_cache safe_name, name
+
+            generated_attribute_methods.module_eval <<-STR, __FILE__, __LINE__ + 1
+              def #{temp_method}
+                name = ::ActiveFedora::AttributeMethods::AttrNames::ATTR_#{safe_name}
+                read_attribute(name) { |n| missing_attribute(n, caller) }
+              end
+            STR
+
+            generated_attribute_methods.module_eval do
+              alias_method name, temp_method
+              undef_method temp_method
+            end
+          end
         end
+
 
       end
     end


### PR DESCRIPTION
Code copied and slightly modified from ActiveRecord.
Resolves issue #739.  Which was affecting jruby-1.7.19.
This should become obsolete as soon as support for ruby 1.9 ends.