### PR TITLE
Move the indexing logic to the model. Fixes #736

### DIFF
--- a/lib/active_fedora/attributes/property_builder.rb
+++ b/lib/active_fedora/attributes/property_builder.rb
@@ -54,6 +54,7 @@ module ActiveFedora::Attributes
     end
 
     def build(&block)
+      #TODO remove this block stuff
       NodeConfig.new(name, options[:predicate], options.except(:predicate)) do |config|
         config.with_index(&block) if block_given?
       end

--- a/lib/active_fedora/indexing.rb
+++ b/lib/active_fedora/indexing.rb
@@ -1,6 +1,11 @@
 module ActiveFedora
   module Indexing
     extend ActiveSupport::Concern
+    extend ActiveSupport::Autoload
+
+    eager_autoload do
+      autoload :Map
+    end
 
     # Return a Hash representation of this object where keys in the hash are appropriate Solr field names.
     # @param [Hash] solr_doc (optional) Hash to insert the fields into
@@ -50,6 +55,11 @@ module ActiveFedora
       end
 
     module ClassMethods
+
+      # Return ActiveFedora::Indexing::Map
+      def index_config
+        @index_config ||= ActiveFedora::Indexing::Map.new
+      end
 
       def indexer
         IndexingService

--- a/lib/active_fedora/indexing/map.rb
+++ b/lib/active_fedora/indexing/map.rb
@@ -1,0 +1,36 @@
+require 'forwardable'
+module ActiveFedora::Indexing
+  # This is a description of how properties should map to indexing strategies
+  #  e.g. 'creator_name' => <IndexObject behaviors=[:stored_searchable, :facetable]>
+  class Map
+    extend Forwardable
+    def_delegators :@hash, :[], :[]=, :each, :keys
+
+    def initialize(hash = {})
+      @hash = hash
+    end
+
+    # this enables a cleaner API for solr integration
+    class IndexObject
+      attr_accessor :data_type, :behaviors
+
+      def initialize(&block)
+        @behaviors = []
+        @data_type = :string
+        yield self if block_given?
+      end
+
+      def as(*args)
+        @behaviors = args
+      end
+
+      def type(sym)
+        @data_type = sym
+      end
+
+      def defaults
+        :noop
+      end
+    end
+  end
+end

--- a/lib/active_fedora/rdf/datastream_indexing.rb
+++ b/lib/active_fedora/rdf/datastream_indexing.rb
@@ -26,6 +26,10 @@ module ActiveFedora::RDF
       def indexer
         ActiveFedora::RDF::IndexingService
       end
+
+      def index_config
+        @index_config ||= ActiveFedora::Indexing::Map.new
+      end
     end
 
     protected

--- a/lib/active_fedora/rdf/rdf_datastream.rb
+++ b/lib/active_fedora/rdf/rdf_datastream.rb
@@ -16,6 +16,17 @@ module ActiveFedora
         @subject_block ||= lambda { |ds| parent_uri(ds) }
       end
 
+      def property(name, *args, &block)
+        super
+        add_attribute_indexing_config(name, &block) if block_given?
+      end
+
+      def add_attribute_indexing_config(name, &block)
+        Deprecation.warn(RDFDatastream, "Adding indexing to datastreams is deprecated")
+        # TODO the hash can be initalized to return on of these
+        index_config[name] ||= ActiveFedora::Indexing::Map::IndexObject.new &block
+      end
+
       # Trim the last segment off the URI to get the parents uri
       def parent_uri(ds)
         m = /^(.*)\/[^\/]*$/.match(ds.uri)

--- a/spec/integration/attributes_spec.rb
+++ b/spec/integration/attributes_spec.rb
@@ -17,7 +17,9 @@ describe "delegating attributes" do
     end
     class RdfObject < ActiveFedora::Base
       contains 'foo', class_name: 'PropertiesDatastream'
-      has_attributes :depositor, datastream: :foo, multiple: false
+      has_attributes :depositor, datastream: :foo, multiple: false do |index|
+        index.as :stored_searchable
+      end
       has_attributes :wrangler, datastream: :foo, multiple: true
       property :resource_type, predicate: ::RDF::DC.type do |index|
         index.as :stored_searchable, :facetable
@@ -29,6 +31,14 @@ describe "delegating attributes" do
     Object.send(:remove_const, :TitledObject)
     Object.send(:remove_const, :RdfObject)
     Object.send(:remove_const, :PropertiesDatastream)
+  end
+
+  describe "#index_config" do
+    subject { RdfObject.index_config }
+    it "should have configuration " do
+      expect(subject[:resource_type].behaviors).to eq [:stored_searchable, :facetable]
+      expect(subject[:depositor].behaviors).to eq [:stored_searchable]
+    end
   end
 
   context "with a simple datastream" do

--- a/spec/integration/field_to_solr_name_spec.rb
+++ b/spec/integration/field_to_solr_name_spec.rb
@@ -5,12 +5,14 @@ describe "An object with RDF backed attributes" do
   before do
     class TestOne < ActiveFedora::Base
       class MyMetadata < ActiveFedora::NtriplesRDFDatastream
-        property :title, predicate: ::RDF::DC.title do |index|
-          index.as :stored_searchable
-        end
-        property :date_uploaded, predicate: ::RDF::DC.dateSubmitted do |index|
-          index.type :date
-          index.as :stored_searchable, :sortable
+        Deprecation.silence(ActiveFedora::RDFDatastream) do
+          property :title, predicate: ::RDF::DC.title do |index|
+            index.as :stored_searchable
+          end
+          property :date_uploaded, predicate: ::RDF::DC.dateSubmitted do |index|
+            index.type :date
+            index.as :stored_searchable, :sortable
+          end
         end
       end
       has_metadata 'descMetadata', type: MyMetadata

--- a/spec/integration/json_serialization_spec.rb
+++ b/spec/integration/json_serialization_spec.rb
@@ -43,8 +43,10 @@ describe "Objects should be serialized to JSON" do
       end
 
       class DummyResource < ActiveFedora::RDFDatastream
-        property :license, predicate: ::RDF::DC[:license], class_name: DummySubnode do |index|
-          index.as :searchable, :displayable
+        Deprecation.silence(ActiveFedora::RDFDatastream) do
+          property :license, predicate: ::RDF::DC[:license], class_name: DummySubnode do |index|
+            index.as :searchable, :displayable
+          end
         end
         def serialization_format
           :ntriples

--- a/spec/integration/ntriples_datastream_spec.rb
+++ b/spec/integration/ntriples_datastream_spec.rb
@@ -7,21 +7,23 @@ describe ActiveFedora::NtriplesRDFDatastream do
       property :size
     end
 
-    class MyDatastream < ActiveFedora::NtriplesRDFDatastream
-      property :title, predicate: ::RDF::DC.title do |index|
-        index.as :stored_searchable, :facetable
+    Deprecation.silence(ActiveFedora::RDFDatastream) do
+      class MyDatastream < ActiveFedora::NtriplesRDFDatastream
+        property :title, predicate: ::RDF::DC.title do |index|
+          index.as :stored_searchable, :facetable
+        end
+        property :date_uploaded, predicate: ::RDF::DC.dateSubmitted do |index|
+          index.type :date
+          index.as :stored_searchable, :sortable
+        end
+        property :filesize, predicate: FileVocabulary.size do |index|
+          index.type :integer
+          index.as :stored_sortable
+        end
+        property :part, predicate: ::RDF::DC.hasPart
+        property :based_near, predicate: ::RDF::FOAF.based_near
+        property :related_url, predicate: ::RDF::RDFS.seeAlso
       end
-      property :date_uploaded, predicate: ::RDF::DC.dateSubmitted do |index|
-        index.type :date
-        index.as :stored_searchable, :sortable
-      end
-      property :filesize, predicate: FileVocabulary.size do |index|
-        index.type :integer
-        index.as :stored_sortable
-      end
-      property :part, predicate: ::RDF::DC.hasPart
-      property :based_near, predicate: ::RDF::FOAF.based_near
-      property :related_url, predicate: ::RDF::RDFS.seeAlso
     end
 
     class RdfTest < ActiveFedora::Base

--- a/spec/unit/base_active_model_spec.rb
+++ b/spec/unit/base_active_model_spec.rb
@@ -25,7 +25,7 @@ describe ActiveFedora::Base do
       end
       has_metadata :type=>ActiveFedora::SimpleDatastream, :name=>"withText2" do |m|
         m.field "fubar", :text
-      end 
+      end
 
       has_metadata :type=>BarStream, :name=>"xmlish"
       has_attributes :fubar, datastream: 'withText', multiple: false

--- a/spec/unit/ntriples_datastream_spec.rb
+++ b/spec/unit/ntriples_datastream_spec.rb
@@ -134,26 +134,28 @@ describe ActiveFedora::NtriplesRDFDatastream do
 
   describe "solr integration" do
     before(:all) do
-      class MyDatastream < ActiveFedora::NtriplesRDFDatastream
-        property :created, predicate: ::RDF::DC.created do |index|
-          index.as :sortable, :displayable
-          index.type :date
+      Deprecation.silence(ActiveFedora::RDFDatastream) do
+        class MyDatastream < ActiveFedora::NtriplesRDFDatastream
+          property :created, predicate: ::RDF::DC.created do |index|
+            index.as :sortable, :displayable
+            index.type :date
+          end
+          property :title, predicate: ::RDF::DC.title do |index|
+            index.as :stored_searchable, :sortable
+            index.type :text
+          end
+          property :publisher, predicate: ::RDF::DC.publisher do |index|
+            index.as :facetable, :sortable, :stored_searchable
+          end
+          property :based_near, predicate: ::RDF::FOAF.based_near do |index|
+            index.as :facetable, :stored_searchable
+            index.type :text
+          end
+          property :related_url, predicate: ::RDF::RDFS.seeAlso do |index|
+            index.as :stored_searchable
+          end
+          property :rights, predicate: ::RDF::DC.rights
         end
-        property :title, predicate: ::RDF::DC.title do |index|
-          index.as :stored_searchable, :sortable
-          index.type :text
-        end
-        property :publisher, predicate: ::RDF::DC.publisher do |index|
-          index.as :facetable, :sortable, :stored_searchable
-        end
-        property :based_near, predicate: ::RDF::FOAF.based_near do |index|
-          index.as :facetable, :stored_searchable
-          index.type :text
-        end
-        property :related_url, predicate: ::RDF::RDFS.seeAlso do |index|
-          index.as :stored_searchable
-        end
-        property :rights, predicate: ::RDF::DC.rights
       end
     end
 

--- a/spec/unit/query_result_builder_spec.rb
+++ b/spec/unit/query_result_builder_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe QueryResultBuilder do
+describe ActiveFedora::QueryResultBuilder do
   describe "reify solr results" do
     before(:all) do
       class AudioRecord

--- a/spec/unit/rdf/indexing_service_spec.rb
+++ b/spec/unit/rdf/indexing_service_spec.rb
@@ -3,23 +3,25 @@ require 'spec_helper'
 describe ActiveFedora::RDF::IndexingService do
   before do
     class MyDatastream < ActiveFedora::NtriplesRDFDatastream
-      property :created, predicate: ::RDF::DC.created do |index|
-        index.as :sortable, :displayable
-        index.type :date
-      end
-      property :title, predicate: ::RDF::DC.title do |index|
-        index.as :stored_searchable, :sortable
-        index.type :text
-      end
-      property :publisher, predicate: ::RDF::DC.publisher do |index|
-        index.as :facetable, :sortable, :stored_searchable
-      end
-      property :based_near, predicate: ::RDF::FOAF.based_near do |index|
-        index.as :facetable, :stored_searchable
-        index.type :text
-      end
-      property :related_url, predicate: ::RDF::RDFS.seeAlso do |index|
-        index.as :stored_searchable
+      Deprecation.silence(ActiveFedora::RDFDatastream) do
+        property :created, predicate: ::RDF::DC.created do |index|
+          index.as :sortable, :displayable
+          index.type :date
+        end
+        property :title, predicate: ::RDF::DC.title do |index|
+          index.as :stored_searchable, :sortable
+          index.type :text
+        end
+        property :publisher, predicate: ::RDF::DC.publisher do |index|
+          index.as :facetable, :sortable, :stored_searchable
+        end
+        property :based_near, predicate: ::RDF::FOAF.based_near do |index|
+          index.as :facetable, :stored_searchable
+          index.type :text
+        end
+        property :related_url, predicate: ::RDF::RDFS.seeAlso do |index|
+          index.as :stored_searchable
+        end
       end
       property :rights, predicate: ::RDF::DC.rights
     end

--- a/spec/unit/rdf_resource_datastream_spec.rb
+++ b/spec/unit/rdf_resource_datastream_spec.rb
@@ -8,14 +8,16 @@ describe ActiveFedora::RDFDatastream do
     end
 
     class DummyResource < ActiveFedora::RDFDatastream
-      property :title, predicate: ::RDF::DC[:title], class_name: ::RDF::Literal do |index|
-        index.as :searchable, :displayable
-      end
-      property :license, predicate: ::RDF::DC[:license], class_name: DummySubnode do |index|
-        index.as :searchable, :displayable
-      end
-      property :creator, predicate: ::RDF::DC[:creator], class_name: 'DummyAsset' do |index|
-        index.as :searchable
+      Deprecation.silence(ActiveFedora::RDFDatastream) do
+        property :title, predicate: ::RDF::DC[:title], class_name: ::RDF::Literal do |index|
+          index.as :searchable, :displayable
+        end
+        property :license, predicate: ::RDF::DC[:license], class_name: DummySubnode do |index|
+          index.as :searchable, :displayable
+        end
+        property :creator, predicate: ::RDF::DC[:creator], class_name: 'DummyAsset' do |index|
+          index.as :searchable
+        end
       end
       def serialization_format
         :ntriples

--- a/spec/unit/solr_query_builder_spec.rb
+++ b/spec/unit/solr_query_builder_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SolrQueryBuilder do
+describe ActiveFedora::SolrQueryBuilder do
   describe "raw_query" do
     it "should generate a raw query clause" do
       expect(ActiveFedora::SolrQueryBuilder.raw_query('id', "my:_ID1_")).to eq '_query_:"{!raw f=id}my:_ID1_"'


### PR DESCRIPTION
You should now add indexing hints to has_attributes by passing a block
similar to how you do it with rdf properties. e.g.:

```ruby
class Book < ActiveFedora::Base
  has_metadata  'descMetadata', type: MODSDatastream
  has_attributes :title, :license, datastream: 'descMetadata' do |index|
    index.as :stored_searchable, :facetable
  end
end
```