### PR TITLE
Prevents an object from being loaded to the incorrect class. 

### DIFF
--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -286,6 +286,39 @@ describe ActiveFedora::Base do
       end
     end
 
+    describe "when fetching an existing object" do
+      before do
+        class Dog < ActiveFedora::Base; end
+        class BigDog < Dog; end
+        class Cat < ActiveFedora::Base; end
+        @dog = Dog.create
+        @big_dog = BigDog.create
+      end
+      it "should detect class mismatch" do
+        expect {
+          Cat.find @dog.id
+        }.to raise_error(ActiveFedora::ActiveFedoraError)
+      end
+
+      it "should not accept parent class into a subclass" do
+        expect {
+          BigDog.find @dog.id
+        }.to raise_error(ActiveFedora::ActiveFedoraError)
+      end
+
+      it "should accept a subclass into a parent class" do
+        # We could prevent this altogether since loading a subclass into
+        # a parent class (a BigDog into a Dog) would result in lost of 
+        # data if the object is saved back and the subclass has more 
+        # properties than the parent class. However, it does seem reasonable 
+        # that people might want to use them interchangeably (after all  
+        # a BigDog is a Dog) and therefore we allow for it.
+        expect {
+          Dog.find @big_dog.id
+        }.not_to raise_error    
+      end
+    end
+
     describe "setting belongs_to" do
       before do
         @library = Library.new()


### PR DESCRIPTION
For example, when loading a batch object it should be loaded into a Batch class (and not a File for example.)

Loading an object to the incorrect class could result in loss of data when saving the object back. For example, loading a File into a Batch and then saving the Batch will blow away all the properties of the File that were not present in the Batch (which would be the majority.)

The current version of the code still allows an object to be loaded into a parent class. For example, a BigFile object could be loaded into a File object as long as BigFile *is a subclass* of File. This could still result in loss of data but I wasn't sure I wanted to be too restrictive so I am leaving this open for now. We might want to prevent this altogether in the future.