### PR TITLE
Only set/save the inverse on a HABTM if the inverse is also HABTM

### DIFF
--- a/spec/integration/has_and_belongs_to_many_associations_spec.rb
+++ b/spec/integration/has_and_belongs_to_many_associations_spec.rb
@@ -364,6 +364,23 @@ describe ActiveFedora::Base do
           expect(component.item_ids).to eq [item.id]
         end
       end
+
+      context "when the has_and_belongs_to_many provides an inverse_of" do
+        let(:reflection) { Component.reflect_on_association(:items) }
+        before do
+          reflection.options[:inverse_of] = :components
+        end
+
+        describe "shifting" do
+          let(:component) { Component.create }
+          let(:item) { Item.new }
+
+          it "should set item_ids" do
+            component.items << item
+            expect(component.item_ids).to eq [item.id]
+          end
+        end
+      end
     end
 
     describe "From the has_many side" do


### PR DESCRIPTION
previously we were getting:

```
     ActiveFedora::UnknownAttributeError:
            Item does not have an attribute `item_id'
```

if the inverse was a has_many.