### PR TITLE
Make #translate_id_to_uri/uri_to_id reliable.

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -52,6 +52,10 @@ module ActiveFedora #:nodoc:
     autoload :CleanConnection
     autoload :Config
     autoload :Core
+    autoload_under 'core' do
+      autoload :FedoraIdTranslator
+      autoload :FedoraUriTranslator
+    end
     autoload :Datastream
     autoload :Datastreams
     autoload :DelegatedAttribute

--- a/lib/active_fedora/core.rb
+++ b/lib/active_fedora/core.rb
@@ -14,14 +14,25 @@ module ActiveFedora
       # :singleton-method
       #
       # Accepts a proc that takes an id and transforms it to a URI
-      mattr_accessor :translate_id_to_uri, instance_writer: false
+      mattr_reader :translate_id_to_uri do
+        FedoraIdTranslator
+      end
+
+      def self.translate_id_to_uri=(translator)
+        @@translate_id_to_uri = translator || FedoraIdTranslator
+      end
 
       ##
       # :singleton-method
       #
       # Accepts a proc that takes a uri and transforms it to an id
-      mattr_accessor :translate_uri_to_id, instance_writer: false
+      mattr_reader :translate_uri_to_id do
+        FedoraUriTranslator
+      end
 
+      def self.translate_uri_to_id=(translator)
+        @@translate_uri_to_id = translator || FedoraUriTranslator
+      end
     end
 
     def ldp_source
@@ -134,27 +145,14 @@ module ActiveFedora
       # Transforms an id into a uri
       # if translate_id_to_uri is set it uses that proc, otherwise just the default
       def id_to_uri(id)
-        if translate_id_to_uri
-          translate_id_to_uri.call(id)
-        else
-          id = "/#{id}" unless id.start_with? SLASH
-          unless ActiveFedora.fedora.base_path == SLASH || id.start_with?("#{ActiveFedora.fedora.base_path}/")
-            id = ActiveFedora.fedora.base_path + id
-          end
-          ActiveFedora.fedora.host + id
-        end
+        translate_id_to_uri.call(id)
       end
 
       ##
       # Transforms a uri into an id
       # if translate_uri_to_id is set it uses that proc, otherwise just the default
       def uri_to_id(uri)
-        if translate_uri_to_id
-          translate_uri_to_id.call(uri)
-        else
-          id = uri.to_s.sub(ActiveFedora.fedora.host + ActiveFedora.fedora.base_path, '')
-          id.start_with?('/') ? id[1..-1] : id
-        end
+        translate_uri_to_id.call(uri)
       end
 
       ##

--- a/lib/active_fedora/core/fedora_id_translator.rb
+++ b/lib/active_fedora/core/fedora_id_translator.rb
@@ -1,0 +1,12 @@
+module ActiveFedora::Core
+  class FedoraIdTranslator
+    SLASH = '/'.freeze
+    def self.call(id)
+      id = "/#{id}" unless id.start_with? SLASH
+      unless ActiveFedora.fedora.base_path == SLASH || id.start_with?("#{ActiveFedora.fedora.base_path}/")
+        id = ActiveFedora.fedora.base_path + id
+      end
+      ActiveFedora.fedora.host + id
+    end
+  end
+end

--- a/lib/active_fedora/core/fedora_uri_translator.rb
+++ b/lib/active_fedora/core/fedora_uri_translator.rb
@@ -1,0 +1,9 @@
+module ActiveFedora::Core
+  class FedoraUriTranslator
+    SLASH = '/'.freeze
+    def self.call(uri)
+      id = uri.to_s.sub(ActiveFedora.fedora.host + ActiveFedora.fedora.base_path, '')
+      id.start_with?(SLASH) ? id[1..-1] : id
+    end
+  end
+end

--- a/spec/unit/core/fedora_id_translator_spec.rb
+++ b/spec/unit/core/fedora_id_translator_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Core::FedoraIdTranslator do
+  describe ".call" do
+    let(:result) { described_class.call(id) }
+    context "when given an id" do
+      let(:good_uri) { ActiveFedora.fedora.host+ActiveFedora.fedora.base_path+"/banana" }
+      let(:id) { "banana" }
+      it "should return a fedora URI" do
+        expect(result).to eq good_uri
+      end
+      context "when given an id with a leading slash" do
+        let(:id) { "/banana" }
+        it "should return a good fedora URI" do
+          expect(result).to eq good_uri
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/core/fedora_uri_translator_spec.rb
+++ b/spec/unit/core/fedora_uri_translator_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Core::FedoraUriTranslator do
+  describe ".call" do
+    let(:result) { described_class.call(uri) }
+    context "when given a Fedora URI" do
+      let(:uri) { ActiveFedora.fedora.host + ActiveFedora.fedora.base_path+"/6" }
+      it "should return the id" do
+        expect(result).to eq '6'
+      end
+    end
+    context "when given a URI missing a slash" do
+      let(:uri) { ActiveFedora.fedora.host + ActiveFedora.fedora.base_path+"602-a" }
+      it "should return the id" do
+        expect(result).to eq "602-a"
+      end
+    end
+  end
+end

--- a/spec/unit/core_spec.rb
+++ b/spec/unit/core_spec.rb
@@ -90,12 +90,54 @@ describe ActiveFedora::Base do
     end
   end
 
+  describe "#translate_id_to_uri" do
+    subject { ActiveFedora::Base.translate_id_to_uri }
+    context "when it's not set" do
+      it "should be a FedoraIdTranslator" do
+        expect(subject).to eq ActiveFedora::Core::FedoraIdTranslator
+      end
+    end
+    context "when it's set to nil" do
+      before do
+        ActiveFedora::Base.translate_id_to_uri = nil
+      end
+      it "should be a FedoraIdTranslator" do
+        expect(subject).to eq ActiveFedora::Core::FedoraIdTranslator
+      end
+    end
+  end
+
+  describe "#translate_uri_to_id" do
+    subject { ActiveFedora::Base.translate_uri_to_id }
+    context "when it's not set" do
+      it "should be a FedoraUriTranslator" do
+        expect(subject).to eq ActiveFedora::Core::FedoraUriTranslator
+      end
+    end
+    context "when it's set to nil" do
+      before do
+        ActiveFedora::Base.translate_uri_to_id = nil
+      end
+      it "should be a FedoraIdTranslator" do
+        expect(subject).to eq ActiveFedora::Core::FedoraUriTranslator
+      end
+    end
+  end
+
   describe "id_to_uri" do
     let(:id) { '123456w' }
     subject { ActiveFedora::Base.id_to_uri(id) }
 
     context "with no custom proc is set" do
       it { should eq "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/123456w" }
+      it "should just call #translate_id_to_uri" do
+        allow(ActiveFedora::Base).to receive(:translate_id_to_uri).and_call_original
+        allow(ActiveFedora::Core::FedoraIdTranslator).to receive(:call).and_call_original
+
+        subject
+
+        expect(ActiveFedora::Core::FedoraIdTranslator).to have_received(:call).with(id)
+      end
     end
 
     context "when custom proc is set" do
@@ -128,6 +170,14 @@ describe ActiveFedora::Base do
 
     context "with no custom proc is set" do
       it { should eq 'foo/123456w' }
+      it "should just call #translate_uri_to_id" do
+        allow(ActiveFedora::Base).to receive(:translate_uri_to_id).and_call_original
+        allow(ActiveFedora::Core::FedoraUriTranslator).to receive(:call).and_call_original
+
+        subject
+
+        expect(ActiveFedora::Core::FedoraUriTranslator).to have_received(:call).with(uri)
+      end
     end
 
     context "when custom proc is set" do


### PR DESCRIPTION
They were sometimes nil before, which means other things can't rely on that
translator being there.