### PR TITLE
Requires 'deprecation' for ActiveFedora::File

### DIFF
--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -1,3 +1,5 @@
+require 'deprecation'
+
 module ActiveFedora
 
   #This class represents a Fedora datastream


### PR DESCRIPTION
When trying to run specs for a gem that has `active-fedora` as a dependency, i was getting the following error:

```
.../gems/active-fedora-9.0.7/lib/active_fedora/file.rb:7:in `<class:File>': uninitialized constant ActiveFedora::File::Deprecation (NameError)
```
This change fixed it for me.