### PR TITLE
allow AF models to specify the model URI in class decl

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -244,6 +244,9 @@ module ActiveFedora #:nodoc:
 
   self.configurator ||= ActiveFedora::FileConfigurator.new
 
+  def self.Base(uri=nil)
+    ActiveFedora::Base.subclass(uri)
+  end
 end
 
 

--- a/lib/active_fedora/base.rb
+++ b/lib/active_fedora/base.rb
@@ -29,6 +29,7 @@ module ActiveFedora
     extend ActiveSupport::DescendantsTracker
     extend LdpCache::ClassMethods
 
+    extend Model::ClassMethods
     include Core
     include Persistence
     include Indexing

--- a/lib/active_fedora/core.rb
+++ b/lib/active_fedora/core.rb
@@ -127,7 +127,7 @@ module ActiveFedora
       # Should reverse Model#from_class_uri
       # TODO this is a poorly named method
       def to_class_uri(attrs = {})
-        name
+        uri || name
       end
 
       ##

--- a/lib/active_fedora/model.rb
+++ b/lib/active_fedora/model.rb
@@ -5,29 +5,72 @@ module ActiveFedora
   # This module mixes various methods into the including class,
   # much in the way ActiveRecord does.  
   module Model 
+    module ClassMethods
+      # Takes a Fedora URI for a cModel, and returns a 
+      # corresponding Model if available
+      # This method should reverse ClassMethods#to_class_uri
+      # @return [Class, False] the class of the model or false, if it does not exist
+      def from_class_uri(model_value)
 
-    # Takes a Fedora URI for a cModel, and returns a 
-    # corresponding Model if available
-    # This method should reverse ClassMethods#to_class_uri
-    # @return [Class, False] the class of the model or false, if it does not exist
-    def self.from_class_uri(model_value)
-
-      unless class_exists?(model_value)
-        ActiveFedora::Base.logger.warn "'#{model_value}' is not a real class" if ActiveFedora::Base.logger
-        return nil
+        if class_exists?(model_value)
+          ActiveFedora.class_from_string(model_value)
+        else
+          rc = @@uris[model_value]
+          return rc if rc
+          ActiveFedora::Base.logger.warn "'#{model_value}' is not a real class" if ActiveFedora::Base.logger
+          return nil
+        end
       end
-      ActiveFedora.class_from_string(model_value)
-    end
 
-    private 
-    
-    def self.class_exists?(class_name)
-      return false if class_name.empty?
-      klass = class_name.constantize
-      return klass.is_a?(Class)
-    rescue NameError
-      return false
+      def subclass(uri=nil)
+        rc = Class.new(self)
+        rc.interim_uri = uri
+        rc
+      end
+      protected
+      def inherited(subclass)
+        super
+        subclass.uri= self.interim_uri
+        self.interim_uri = nil # only use once
+        @@uris[subclass.uri] = subclass if subclass.uri
+        unless subclass.name.nil? # ignore the interim classes
+          parts = subclass.name.split('::')
+          rcvr = parts[0...-1].join('::')
+          if rcvr.eql? ''
+            rcvr = Object
+          else
+            rcvr = rcvr.constantize
+          end
+          metaclass = class << rcvr; self; end
+          metaclass.send(:define_method, parts.last, Proc.new{|uri| subclass.subclass(uri) })
+        end
+      end
+      def interim_uri
+        @interim_uri
+      end
+      def interim_uri=(uri)
+        @interim_uri = uri
+        @interim_uri.freeze
+      end
+      def uri
+        @uri
+      end
+      def uri=(uri)
+        @uri = uri
+        @uri.freeze
+      end
+
+      private 
+      @@uris       = {}
+
+      def class_exists?(class_name)
+        return false if class_name.empty?
+        klass = class_name.constantize
+        return klass.is_a?(Class) || @@uris[klass]
+      rescue NameError
+        return false
+      end
     end
-    
+    extend ClassMethods
   end
 end

--- a/spec/unit/core_spec.rb
+++ b/spec/unit/core_spec.rb
@@ -18,6 +18,10 @@ describe ActiveFedora::Base do
         has_attributes :publisher, datastream: 'bar' # RDF backed property
       end
     end
+    module Nonkernel
+      class Object < ActiveFedora::Base("http://projecthydra.org/foo/Object")
+      end
+    end
   end
 
   let (:library) { Library.create }
@@ -27,6 +31,7 @@ describe ActiveFedora::Base do
     Object.send(:remove_const, :Book)
     Object.send(:remove_const, :Library)
     Object.send(:remove_const, :MyDatastream)
+    Object.send(:remove_const, :Nonkernel)
   end
 
   it "should assert a content model" do
@@ -139,5 +144,10 @@ describe ActiveFedora::Base do
       it { should eq '123456w' }
     end
   end
-
+  describe "to_class_uri" do
+    it do
+      expect(Nonkernel::Object.to_class_uri).to eq("http://projecthydra.org/foo/Object")
+      expect(Book.to_class_uri).to eq("Book")
+    end
+  end
 end

--- a/spec/unit/model_spec.rb
+++ b/spec/unit/model_spec.rb
@@ -6,6 +6,12 @@ describe ActiveFedora::Model do
     module SpecModel
       class Basic < ActiveFedora::Base
       end
+      class Object < ActiveFedora::Base("http://projecthydra.org/foo/Object")
+      end
+      class Bar < SpecModel::Object("http://projecthydra.org/bar/Object")
+      end
+      class Foo < SpecModel::Object
+      end
     end
   end
   
@@ -35,6 +41,28 @@ describe ActiveFedora::Model do
       before { expect(ActiveFedora::Base.logger).to receive(:warn) }
       let(:uri) { '' }
       it { should be_nil }
+    end
+    context "a kernel-level class name" do
+      let(:uri) { 'String' }
+      it { expect(subject).to be(String) }
+    end
+    context "a qualified class name" do
+      context "without inheritance" do
+        let(:uri) { 'SpecModel::Basic' }
+        it { expect(subject).to be(SpecModel::Basic) }
+      end
+      context "with inheritance" do
+        let(:uri) { 'SpecModel::Foo' }
+        it { expect(subject).to be(SpecModel::Foo) }
+      end
+    end
+    context "a uri" do
+      let(:uri) { 'http://projecthydra.org/bar/Object' }
+      it { expect(subject).to be(SpecModel::Bar) }
+    end
+    context "a uri for a class with kernel-level homonym" do
+      let(:uri) { 'http://projecthydra.org/foo/Object' }
+      it { expect(subject).to be(SpecModel::Object) }
     end
   end
 end


### PR DESCRIPTION
Following the pattern of RDF::Vocab, allows AF::Base extensions to explicitly register a model URI:
```ruby
class Foo < ActiveFedora::Base("http://hydra.org/Foo"); end
Foo.to_class_uri # -> "http://hydra.org/Foo"
ActiveFedora::Model.from_class_uri("http://hydra.org/Foo") # -> Foo
```