### PR TITLE
Use delegate_to instead of datastream in the options for property

### DIFF
--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -38,7 +38,7 @@ describe ActiveFedora::Base do
         before do
           class BarHistory4 < ActiveFedora::Base
             has_metadata type: BarStream2, name: "xmlish"
-            property :cow, datastream: 'xmlish'
+            property :cow, delegate_to: 'xmlish'
           end
         end
         after do


### PR DESCRIPTION
Trying to reduce/elimnate the useage of "datastream" especially in the
public API.