### PR TITLE
Patches casting behavior

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -23,7 +23,7 @@ module ActiveFedora #:nodoc:
   class RecordNotSaved < RuntimeError; end # :nodoc:
   class IllegalOperation < RuntimeError; end # :nodoc:
   class Rollback < RuntimeError; end # :nodoc:
-
+  class ModelNotAsserted < RuntimeError; end # :nodoc:
 
   eager_autoload do
     autoload :AssociationRelation

--- a/lib/active_fedora/content_model.rb
+++ b/lib/active_fedora/content_model.rb
@@ -14,15 +14,14 @@ module ActiveFedora
     end
     
     def self.best_model_for(obj)
-      best_model_match = obj.class unless obj.instance_of? ActiveFedora::Base
+      best_model_match = nil
 
       known_models_for(obj).each do |model_value|
-        # If this is of type ActiveFedora::Base, then set to the first found :has_model.
-        best_model_match ||= model_value
-
-        # If there is an inheritance structure, use the most specific case.
-        if best_model_match > model_value
-          best_model_match = model_value
+        if model_value <= obj.class
+          # If there is an inheritance structure, use the most specific case.
+          if best_model_match.nil? || best_model_match > model_value
+            best_model_match = model_value
+          end
         end
       end
 

--- a/lib/active_fedora/core.rb
+++ b/lib/active_fedora/core.rb
@@ -119,21 +119,15 @@ module ActiveFedora
       klass.allocate.init_with_object(inner_object)
     end
 
-    # Examines the :has_model assertions in the RELS-EXT.
-    #
-    # If the object is of type ActiveFedora::Base, then use the first :has_model
-    # in the RELS-EXT for this object. Due to how the RDF writer works, this is
-    # currently just the first alphabetical model.
-    #
-    # If the object was instantiated with any other class, then use that class
-    # as the base of the type the user wants rather than casting to the first
-    # :has_model found on the object.
-    #
-    # In either case, if an extended model of that initial base model of the two
-    # cases above exists in the :has_model, then instantiate as that extended
-    # model type instead.
+    # Adapts the inner object to the best known model
+    # Raise ActiveFedora::ModelNotAsserted if unable to adapt object
+    # (i.e, best model is nil)
     def adapt_to_cmodel
       best_model_match = ActiveFedora::ContentModel.best_model_for(self)
+
+      if best_model_match.nil?
+        raise ActiveFedora::ModelNotAsserted, "Unable to adapt #{self.inspect} to a model asserted for the resource."
+      end
 
       self.instance_of?(best_model_match) ? self : self.adapt_to(best_model_match)
     end

--- a/lib/active_fedora/rdf/identifiable.rb
+++ b/lib/active_fedora/rdf/identifiable.rb
@@ -47,7 +47,7 @@ module ActiveFedora::RDF::Identifiable
     # @param [RDF::URI] uri URI that is being looked up.
     def from_uri(uri,_)
       begin
-        self.find(pid_from_subject(uri))
+        ActiveFedora::Base.find(pid_from_subject(uri))
       rescue ActiveFedora::ObjectNotFoundError
         self.ds_specs[resource_datastream.to_s][:type].resource_class.new(uri)
       end

--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -168,10 +168,12 @@ module ActiveFedora
     protected
 
     def load_from_fedora(pid, cast)
-      cast = true if klass == ActiveFedora::Base && cast.nil?
       inner = DigitalObject.find(klass, pid)
-      af_base = klass.allocate.init_with_object(inner)
-      cast ? af_base.adapt_to_cmodel : af_base
+      obj = klass.allocate.init_with_object(inner)
+      if cast != false
+        obj = obj.adapt_to_cmodel
+      end
+      obj
     end
 
     def find_with_ids(ids, cast)

--- a/spec/integration/datastreams_spec.rb
+++ b/spec/integration/datastreams_spec.rb
@@ -60,7 +60,7 @@ describe ActiveFedora::Datastreams do
     end
     
     it "should use ds_specs and preserve existing datastreams on migrated objects" do
-      test_obj = HasMetadata.find(@base.pid)
+      test_obj = HasMetadata.find(@base.pid, cast: false)
       expect(test_obj.datastreams["testDS"].dsLabel).to eql "Test DS"
       expect(test_obj.datastreams["testDS"].new?).to be_false
       expect(test_obj.with_versions.dsLabel).to eql "Versioned DS"
@@ -114,17 +114,17 @@ describe ActiveFedora::Datastreams do
     end
     
     it "should use ds_specs on migrated objects" do
-      test_obj = HasFile.find(@base.pid)
+      test_obj = HasFile.find(@base.pid, cast: false)
       expect(test_obj.file_ds.versionable).to be_false
       expect(test_obj.file_ds.new?).to be_true
       test_obj.file_ds.content = "blah blah blah"
       test_obj.save
       expect(test_obj.file_ds.versionable).to be_false
       # look it up again to check datastream profile
-      test_obj = HasFile.find(@base.pid)
+      test_obj = HasFile.find(@base.pid, cast: false)
       expect(test_obj.file_ds.versionable).to be_false
       expect(test_obj.file_ds.dsLabel).to eql "File Datastream"
-      test_obj = HasFile.find(@base2.pid)
+      test_obj = HasFile.find(@base2.pid, cast: false)
       expect(test_obj.file_ds.versionable).to be_true
       expect(test_obj.file_ds.dsLabel).to eql "Pre-existing DS"
     end

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -428,9 +428,9 @@ describe ActiveFedora::Base do
     describe ".adapt_to_cmodel with implemented (non-ActiveFedora::Base) cmodel" do
       subject { FooHistory.new }
 
-      it "should not cast to a random first cmodel if it has a specific cmodel already" do
+      it "should raise an exception if the object class is not equal to or a subclass of any known model" do
         ActiveFedora::ContentModel.should_receive(:known_models_for).with(subject).and_return([FooAdaptation])
-        subject.adapt_to_cmodel.should be_kind_of FooHistory
+        expect { subject.adapt_to_cmodel }.to raise_error(ActiveFedora::ModelNotAsserted)
       end
       it "should cast to an inherited model over a random one" do
         ActiveFedora::ContentModel.should_receive(:known_models_for).with(subject).and_return([FooAdaptation, FooInherited])

--- a/spec/unit/content_model_spec.rb
+++ b/spec/unit/content_model_spec.rb
@@ -19,10 +19,10 @@ describe ActiveFedora::ContentModel do
   end
   
   describe '.best_model_for' do
-    it 'should be the input model if no relationships' do
+    it 'should be nil if no relationships' do
       mock_object = BaseModel.new
       mock_object.should_receive(:relationships).with(:has_model).and_return([])
-      expect(ActiveFedora::ContentModel.best_model_for(mock_object)).to eq BaseModel
+      expect(ActiveFedora::ContentModel.best_model_for(mock_object)).to be_nil
     end
 
     it 'should be based on inheritance hierarchy' do

--- a/spec/unit/om_datastream_spec.rb
+++ b/spec/unit/om_datastream_spec.rb
@@ -407,15 +407,15 @@ describe ActiveFedora::OmDatastream do
       @obj = MyObj.new
       @obj.descMetadata.title = 'Foobar'
       @obj.save
+      @obj.reload
     end
     after do
       @obj.destroy
       Object.send(:remove_const, :MyObj)
     end
-    subject { @obj.reload.descMetadata } 
     it "should not load the descMetadata datastream when calling content_changed?" do
       @obj.inner_object.repository.should_not_receive(:datastream_dissemination).with(hash_including(:dsid=>'descMetadata'))
-      subject.should_not be_content_changed
+      @obj.descMetadata.should_not be_content_changed
     end
   end
 end

--- a/spec/unit/rdf_datastream_spec.rb
+++ b/spec/unit/rdf_datastream_spec.rb
@@ -18,13 +18,14 @@ describe ActiveFedora::RDFDatastream do
       @obj = MyObj.new
       @obj.descMetadata.title = 'Foobar'
       @obj.save
+      @obj.reload
     end
     after do
       @obj.destroy
       Object.send(:remove_const, :MyDatastream)
       Object.send(:remove_const, :MyObj)
     end
-    subject { @obj.reload.descMetadata }
+    subject { @obj.descMetadata }
     it "should not load the descMetadata datastream when calling content_changed?" do
       @obj.inner_object.repository.should_not_receive(:datastream_dissemination).with(hash_including(:dsid=>'descMetadata'))
       subject.should_not be_content_changed

--- a/spec/unit/rdf_resource_datastream_spec.rb
+++ b/spec/unit/rdf_resource_datastream_spec.rb
@@ -7,8 +7,6 @@ describe ActiveFedora::RDFDatastream do
       property :relation, :predicate => RDF::DC[:relation]
     end
 
-    class DummyAsset < ActiveFedora::Base; end;
-
     class DummyResource < ActiveFedora::RDFDatastream
       property :title, :predicate => RDF::DC[:title], :class_name => RDF::Literal do |index|
         index.as :searchable, :displayable
@@ -16,7 +14,7 @@ describe ActiveFedora::RDFDatastream do
       property :license, :predicate => RDF::DC[:license], :class_name => DummySubnode do |index|
         index.as :searchable, :displayable
       end
-      property :creator, :predicate => RDF::DC[:creator], :class_name => DummyAsset do |index|
+      property :creator, :predicate => RDF::DC[:creator], :class_name => "DummyAsset" do |index|
         index.as :searchable
       end
       def serialization_format


### PR DESCRIPTION
See https://github.com/projecthydra/active_fedora/wiki/Patching-ActiveFedora-7.x-&-8.x-Casting-Behavior
for detailed information on the problem.

The solution offered in this patch preserves the most-specific-class algorithm
of `ActiveFedora::ContentModel.best_model_for` and raises a new execption,
`ActiveFedora::ModelNotAsserted` in `ActiveFedora::Core#adapt_to_cmodel`.

Note that a repository object can still be loaded into a model class not asserted,
for example, by using `.find` with `cast: false`.

Closes #746 (although not really a backport)