### PR TITLE
Add optional prefix to resource URI

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -88,6 +88,7 @@ module ActiveFedora #:nodoc:
     autoload :NomDatastream
     autoload :NullRelation
     autoload :OmDatastream
+    autoload :Pathing
     autoload :Persistence
     autoload :ProfileIndexingService
     autoload :Property

--- a/lib/active_fedora/base.rb
+++ b/lib/active_fedora/base.rb
@@ -51,6 +51,7 @@ module ActiveFedora
     include Versionable
     include LoadableFromJson
     include Schema
+    include Pathing
   end
 
   ActiveSupport.run_load_hooks(:active_fedora, Base)

--- a/lib/active_fedora/pathing.rb
+++ b/lib/active_fedora/pathing.rb
@@ -1,0 +1,24 @@
+module ActiveFedora
+  module Pathing
+    extend ActiveSupport::Concern
+
+    included do
+      def uri_prefix
+        nil
+      end
+
+      def has_uri_prefix?
+        !uri_prefix.nil?
+      end
+
+      def root_resource_path
+        if has_uri_prefix?
+          ActiveFedora.fedora.base_path + "/" + self.uri_prefix
+        else
+          ActiveFedora.fedora.base_path
+        end
+      end
+    end
+
+  end
+end

--- a/lib/active_fedora/persistence.rb
+++ b/lib/active_fedora/persistence.rb
@@ -184,8 +184,20 @@ module ActiveFedora
       @ldp_source = if !id && new_id = assign_id
         LdpResource.new(ActiveFedora.fedora.connection, self.class.id_to_uri(new_id), @resource)
       else
-        LdpResource.new(ActiveFedora.fedora.connection, @ldp_source.subject, @resource, ActiveFedora.fedora.host + ActiveFedora.fedora.base_path)
+        LdpResource.new(ActiveFedora.fedora.connection, @ldp_source.subject, @resource, ActiveFedora.fedora.host + base_path_for_resource)
       end
+    end
+
+    def base_path_for_resource
+      init_root_path if self.has_uri_prefix?
+      self.root_resource_path
+    end
+
+    def init_root_path
+      path = self.root_resource_path.gsub(/^\//,"")
+      ActiveFedora.fedora.connection.head(path)
+    rescue Ldp::NotFound
+      ActiveFedora.fedora.connection.put(path, "")
     end
 
     def assign_uri_to_attached_files

--- a/spec/unit/pathing_spec.rb
+++ b/spec/unit/pathing_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe ActiveFedora::Base do
+  describe ".uri_prefix" do
+    let(:path) { "foo" }
+    before do
+      class FooHistory < ActiveFedora::Base
+        def uri_prefix
+          "foo"
+        end
+        property :title, predicate: ::RDF::DC.title
+      end
+    end
+    after do
+      Object.send(:remove_const, :FooHistory)
+    end
+    subject { FooHistory.new(title: ["Root foo"]) }
+    it { is_expected.to have_uri_prefix }
+    it "should use the root path in the uri" do
+      expect(subject.uri_prefix).to eql path
+    end
+    context "when the object is saved" do
+      before { subject.save }
+      it "should persist the path in the uri" do
+        expect(subject.uri).to include(path)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This is based on some needs I've seen recently. I've seen PCDM examples prefix classes with names in the url, ex.
```
/works/work1
/works/work2
```
`works` is just a basic container. You can specify a containing URI for your classes:
``` ruby
GenericWork < ActiveFedora::Base
  uri_prefix "works"
end
```
Creating a new GenericWork will create a uri similar to:
`/fedora/rest/dev/works/ab/cd/ef/abcdef` depending on your id minting scheme.