### PR TITLE
Failing test for nested attributes issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'byebug' unless ENV['TRAVIS']
 group :test do
   gem 'simplecov', require: false
   gem 'coveralls', require: false
+  gem 'actionpack'
 end
 
 gem 'jruby-openssl', platform: :jruby

--- a/spec/unit/model_spec.rb
+++ b/spec/unit/model_spec.rb
@@ -1,10 +1,23 @@
 require 'spec_helper'
+require 'action_controller'
 
 describe ActiveFedora::Model do
   
   before(:all) do
     module SpecModel
       class Basic < ActiveFedora::Base
+      end
+
+      class Title < ActiveFedora::Base
+        belongs_to :work, predicate: ::RDF::Vocab::Bibframe.relatedTo, class_name: 'SpecModel::Work'
+        property :value, predicate: ::RDF::Vocab::Bibframe.titleValue, multiple: false
+        property :variant, predicate: ::RDF::Vocab::Bibframe.titleType, multiple: false
+        property :subtitle, predicate: ::RDF::Vocab::Bibframe.subtitle, multiple: false
+      end
+
+      class Work < ActiveFedora::Base
+        has_many :titles, class_name: 'SpecModel::Title'
+        accepts_nested_attributes_for :titles
       end
     end
   end
@@ -35,6 +48,34 @@ describe ActiveFedora::Model do
       before { expect(ActiveFedora::Base.logger).to receive(:warn) }
       let(:uri) { '' }
       it { should be_nil }
+    end
+  end
+
+  describe 'Nested titles' do
+
+    it 'should only contain one title when saved with ActionController::Parameters' do
+      SpecModel::Title.create(value: 'One fine title')
+      SpecModel::Title.create(value: 'Another fine title')
+      params = ActionController::Parameters.new(
+          {
+              "utf8"=>"✓", "authenticity_token"=>"4shDs/q9nxha/xSFgvHMOrfv8gPC81muvpsQ+uWvgkek2+9Y2gPmi/YSIYI9sxOZIXKOh3I2WBRBOHkoyQc1/A==",
+              "work"=>{"titles_attributes"=>{"0"=>{"value"=>"A mediocre title" }}},
+              "commit"=>"Gem værk", "controller"=>"works", "action"=>"create"
+          }
+      )
+      permitted = params[:work].permit(titles_attributes: [[ :language ]])
+      w = SpecModel::Work.new(permitted)
+      expect(w.save).to be true
+      expect(w.titles.size).to eql 1
+    end
+
+    it 'should only contain one title when saved with a hash of parameters' do
+      SpecModel::Title.create(value: 'One fine title')
+      SpecModel::Title.create(value: 'Another fine title')
+      params = {"titles_attributes"=>{"0"=>{"value"=>"A mediocre title" }}}
+      w = SpecModel::Work.new(params)
+      expect(w.save).to be true
+      expect(w.titles.size).to eql 1
     end
   end
 end


### PR DESCRIPTION
Hi,

Here is a couple of tests that demonstrate the nested models problem described in the mail. When creating this PR I discovered that the test fails regardless of whether they're ActionController::Parameters or not, so I guess that part is unimportant. Note also that when debugging this problem locally, I found that the Work object first began to have extra titles after [the creation of the LDP source](https://github.com/projecthydra/active_fedora/blob/master/lib/active_fedora/persistence.rb#L151) in the Persistence module. I wasn't able to figure out why though.