### PR TITLE
CollectionAssociation should generate a solr query lazily

### DIFF
--- a/lib/active_fedora/associations/has_many_association.rb
+++ b/lib/active_fedora/associations/has_many_association.rb
@@ -17,7 +17,7 @@ module ActiveFedora
         count = if loaded?
           @target.size
         else
-          @reflection.klass.count(:conditions => @counter_query)
+          @reflection.klass.count(conditions: construct_query)
         end
 
         # If there's nothing in the database and @target has no new records

--- a/spec/integration/has_many_associations_spec.rb
+++ b/spec/integration/has_many_associations_spec.rb
@@ -25,6 +25,17 @@ describe "Collection members" do
         expect(library.books.any?).to be false
       end
     end
+
+    context "loading the association prior to a save that affects the association" do
+      let(:library) { Library.new }
+      before do
+        Book.create
+        library.books
+        library.save
+      end
+      subject { library.books.size }
+      it { is_expected.to eq 0 }
+    end
   end
 
   describe "looking up has_many" do


### PR DESCRIPTION
When a CollectionAssociation is loaded before the owing object is saved
the solr query is produced without the id of the owner, so all the
objects of the correct type are returned.
Ref #781