### PR TITLE
Request Inbound Relations

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -72,6 +72,7 @@ module ActiveFedora #:nodoc:
     autoload :Indexing
     autoload :IndexingService
     autoload :InheritableAccessors
+    autoload :InboundRelationConnection
     autoload :LdpCache
     autoload :LdpResource
     autoload :LdpResourceService

--- a/lib/active_fedora/fedora.rb
+++ b/lib/active_fedora/fedora.rb
@@ -22,7 +22,7 @@ module ActiveFedora
     end
 
     def connection
-      @connection ||= CachingConnection.new(authorized_connection)
+      @connection ||= InboundRelationConnection.new(CachingConnection.new(authorized_connection))
     end
 
     def clean_connection

--- a/lib/active_fedora/fedora_attributes.rb
+++ b/lib/active_fedora/fedora_attributes.rb
@@ -62,7 +62,10 @@ module ActiveFedora
     #
     # set_value, get_value, and property accessors are delegated to this object.
     def resource
-      @resource ||= self.class.resource_class.new(@ldp_source.graph.rdf_subject, @ldp_source.graph)
+      # Appending the graph at the end is necessary because adding it as the
+      # parent leaves behind triples not related to the ldp_source's rdf
+      # subject.
+      @resource ||= self.class.resource_class.new(@ldp_source.graph.rdf_subject, @ldp_source.graph) << @ldp_source.graph
     end
 
     # You can set the URI to use for the rdf_label on ClassMethods.rdf_label, then on

--- a/lib/active_fedora/inbound_relation_connection.rb
+++ b/lib/active_fedora/inbound_relation_connection.rb
@@ -1,0 +1,21 @@
+module ActiveFedora
+  class InboundRelationConnection < SimpleDelegator
+    def get(*args)
+      result = __getobj__.get(*args) do |req|
+        prefer_headers = Ldp::PreferHeaders.new(req.headers["Prefer"])
+        prefer_headers.include = prefer_headers.include | include_uris
+        req.headers["Prefer"] = prefer_headers.to_s
+        yield req if block_given?
+      end
+      result
+    end
+
+    private
+
+    def include_uris
+      [
+        RDF::Fcrepo4.InboundReferences
+      ]
+    end
+  end
+end

--- a/lib/active_fedora/rdf/fcrepo4.rb
+++ b/lib/active_fedora/rdf/fcrepo4.rb
@@ -8,5 +8,6 @@ module ActiveFedora::RDF
     property :lastModified
     property :status
     property :ServerManaged
+    property :InboundReferences
   end
 end

--- a/spec/integration/indirect_container_spec.rb
+++ b/spec/integration/indirect_container_spec.rb
@@ -75,6 +75,11 @@ describe "Direct containers" do
             it "has two related_objects" do
               expect(reloaded.related_objects).to eq [file, file2]
             end
+            it "has inbound triples" do
+              statement = file.reload.resource.query(predicate: ::RDF::URI.new('http://www.openarchives.org/ore/terms/proxyFor')).to_a.first
+
+              expect(statement.object).to eq file.resource.rdf_subject
+            end
           end
         end
       end


### PR DESCRIPTION
This requests inbound relations for all Fedora calls to reduce future requests
necessary to efficiently act on those relations.

Closes #793 

One note - this will only work with Fedora.