### PR TITLE
Update ActiveTriples

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gemspec path: File.expand_path('..', __FILE__)
 
 gem 'byebug' unless ENV['TRAVIS']
+gem 'pry-byebug' unless ENV['CI']
 
 group :test do
   gem 'simplecov', require: false

--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |s|
   s.add_dependency 'om', '~> 3.1'
   s.add_dependency 'nom-xml', '>= 0.5.1'
   s.add_dependency "activesupport", '>= 4.1.0'
-  s.add_dependency "active-triples", '~> 0.6.0'
+  s.add_dependency "active-triples", '~> 0.7.0'
   s.add_dependency "rdf-rdfxml", '~> 1.1.0'
   s.add_dependency "linkeddata"
   s.add_dependency "deprecation"
-  s.add_dependency "ldp", '~> 0.3.0'
+  s.add_dependency "ldp", '~> 0.3.1'
   s.add_dependency "rdf-ldp"
 
   s.add_development_dependency "rdoc"

--- a/lib/active_fedora/rdf/indexing_service.rb
+++ b/lib/active_fedora/rdf/indexing_service.rb
@@ -54,7 +54,7 @@ module ActiveFedora::RDF
           when ::RDF::URI
             val.to_s
           when ActiveTriples::Resource
-            val.solrize
+            val.node? ? val.rdf_label : val.rdf_subject.to_s
           else
             val
         end

--- a/spec/integration/complex_rdf_datastream_spec.rb
+++ b/spec/integration/complex_rdf_datastream_spec.rb
@@ -36,7 +36,7 @@ describe "Nested Rdf Objects" do
     end
 
     it "should be able to nest a complex object" do
-      comp = SpecDatastream::Component.new(ds.graph)
+      comp = SpecDatastream::Component.new(nil, ds.graph)
       comp.label = ["Alternator"]
       ds.parts = comp
       expect(ds.parts.first.label).to eq ["Alternator"]
@@ -53,16 +53,16 @@ describe "Nested Rdf Objects" do
       ds.parts.build(label: 'Alternator')
       ds.parts.build(label: 'Distributor')
       expect(ds.parts.size).to eq 2
-      comp = SpecDatastream::Component.new(ds.graph)
+      comp = SpecDatastream::Component.new(nil, ds.graph)
       comp.label = "Injector port"
       ds.parts = [comp]
       expect(ds.parts.size).to eq 1
     end
 
     it "should be able to nest many complex objects" do
-      comp1 = SpecDatastream::Component.new ds.graph
+      comp1 = SpecDatastream::Component.new nil, ds.graph
       comp1.label = ["Alternator"]
-      comp2 = SpecDatastream::Component.new ds.graph
+      comp2 = SpecDatastream::Component.new nil, ds.graph
       comp2.label = ["Crankshaft"]
       ds.parts = [comp1, comp2]
       expect(ds.parts.first.label).to eq ["Alternator"]
@@ -70,9 +70,9 @@ describe "Nested Rdf Objects" do
     end
 
     it "should be able to clear complex objects" do
-      comp1 = SpecDatastream::Component.new ds.graph
+      comp1 = SpecDatastream::Component.new nil, ds.graph
       comp1.label = ["Alternator"]
-      comp2 = SpecDatastream::Component.new ds.graph
+      comp2 = SpecDatastream::Component.new nil, ds.graph
       comp2.label = ["Crankshaft"]
       ds.parts = [comp1, comp2]
       ds.parts = []
@@ -147,7 +147,7 @@ END
 
 
       it "should store the type of complex objects when type is specified" do
-        comp = SpecDatastream::MediatorUser.new ds.graph
+        comp = SpecDatastream::MediatorUser.new nil, ds.graph
         comp.title = ["Doctor"]
         ds.mediator = comp
         expect(ds.mediator.first.type.first).to be_instance_of ::RDF::URI
@@ -211,11 +211,11 @@ END
 
 
       it "should store the type of complex objects when type is specified" do
-        series = SpecDatastream::Series.new file.graph
+        series = SpecDatastream::Series.new nil, file.graph
         series.title = ["renovating bathrooms"]
         file.series = series
 
-        program = SpecDatastream::Program.new file.graph
+        program = SpecDatastream::Program.new nil, file.graph
         program.title = ["This old House"]
         file.program = program
 

--- a/spec/integration/rdf_nested_attributes_spec.rb
+++ b/spec/integration/rdf_nested_attributes_spec.rb
@@ -7,7 +7,7 @@ describe "Nesting attribute behavior of RDF resources" do
     end
 
     class ComplexResource < ActiveFedora::Base
-      property :topic, predicate: DummyMADS.Topic, class_name: "Topic"
+      property :topic, predicate: DummyMADS.Topic, class_name: "ComplexResource::Topic"
 
       class Topic < ActiveTriples::Resource
         property :subject, predicate: ::RDF::DC.subject

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ require 'rspec'
 require 'rspec/its'
 require 'equivalent-xml/rspec_matchers'
 require 'logger'
-require 'byebug' unless ENV['TRAVIS']
+require 'pry' unless ENV['TRAVIS']
 
 ActiveFedora::Base.logger = Logger.new(STDERR)
 ActiveFedora::Base.logger.level = Logger::WARN


### PR DESCRIPTION
This has a dependency on releases in both ActiveTriples and LDP.

This is required to get multiple type support from AT.