### PR TITLE
A SolrBackedResource should be enumerable

### DIFF
--- a/lib/active_fedora/loadable_from_json.rb
+++ b/lib/active_fedora/loadable_from_json.rb
@@ -54,8 +54,14 @@ module ActiveFedora
 
       # FakeQuery exists to adapt the hash to the RDF interface used by RDF associations in ActiveFedora
       class FakeQuery
+        include ::Enumerable
+
         def initialize(values)
           @values = values || []
+        end
+
+        def each(&block)
+          enum_statement.each(&block)
         end
 
         def enum_statement
@@ -87,6 +93,8 @@ module ActiveFedora
         ::RDF::URI.new(nil)
       end
 
+      # Called by Associations::RDF#replace to add data to this resource represenation
+      # @param [Array] vals an array of 3 elements (subject, predicate, object) to insert
       def insert(vals)
         _, pred, val = vals
         set_value(reflection(pred), [val])

--- a/spec/unit/loadable_from_json_spec.rb
+++ b/spec/unit/loadable_from_json_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe ActiveFedora::LoadableFromJson::SolrBackedResource do
+  before do
+    class Foo < ActiveFedora::Base
+      belongs_to :bar, predicate: ::RDF::DC.extent
+    end
+
+    class Bar < ActiveFedora::Base
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :Foo)
+    Object.send(:remove_const, :Bar)
+  end
+
+  let(:resource) { described_class.new(Foo) }
+
+  before do
+    resource.insert [nil, ::RDF::DC.extent, RDF::URI('http://example.org/123')]
+  end
+
+  describe "#query" do
+    subject { resource.query(predicate: ::RDF::DC.extent) }
+
+    it "is enumerable" do
+      expect(subject.map { |g| g.object }).to eq [RDF::URI('http://example.org/123')]
+    end
+  end
+end


### PR DESCRIPTION
Fixes: 
```
NoMethodError:
       undefined method `map' for
       #<ActiveFedora::LoadableFromJson::SolrBackedResource::FakeQuery:0x007fee7f00b570>
```
as seen in https://github.com/projecthydra/sufia/pull/1149