### PR TITLE
Add apply_schema support to AF.

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'om', '~> 3.1'
   s.add_dependency 'nom-xml', '>= 0.5.1'
   s.add_dependency "activesupport", '>= 4.1.0'
-  s.add_dependency "active-triples", '~> 0.7.0'
+  s.add_dependency "active-triples", '~> 0.7.1'
   s.add_dependency "rdf-rdfxml", '~> 1.1.0'
   s.add_dependency "linkeddata"
   s.add_dependency "deprecation"

--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -68,6 +68,7 @@ module ActiveFedora #:nodoc:
     autoload :FilesHash
     autoload :FixityService
     autoload :Identifiable
+    autoload :Indexers
     autoload :Indexing
     autoload :IndexingService
     autoload :InheritableAccessors
@@ -105,9 +106,11 @@ module ActiveFedora #:nodoc:
       autoload :FinderMethods
     end
 
+    autoload :Schema
     autoload :Scoping
     autoload :Serialization
     autoload :SimpleDatastream
+    autoload :SchemaIndexingStrategy
     autoload :SolrInstanceLoader
     autoload :SolrQueryBuilder
     autoload :SolrService

--- a/lib/active_fedora/base.rb
+++ b/lib/active_fedora/base.rb
@@ -50,6 +50,7 @@ module ActiveFedora
     include Attributes
     include Versionable
     include LoadableFromJson
+    include Schema
   end
 
   ActiveSupport.run_load_hooks(:active_fedora, Base)

--- a/lib/active_fedora/indexers.rb
+++ b/lib/active_fedora/indexers.rb
@@ -1,0 +1,10 @@
+module ActiveFedora
+  module Indexers
+    extend ActiveSupport::Autoload
+
+    eager_autoload do
+      autoload :NullIndexer
+      autoload :GlobalIndexer
+    end
+  end
+end

--- a/lib/active_fedora/indexers/global_indexer.rb
+++ b/lib/active_fedora/indexers/global_indexer.rb
@@ -1,0 +1,30 @@
+module ActiveFedora::Indexers
+  ##
+  # Applies indexing hints to any given property, independent of what that
+  # property
+  class GlobalIndexer
+    # @param [Array<Symbol>] index_types The indexing hints to use.
+    def initialize(index_types=nil)
+      @index_types = Array.wrap(index_types)
+    end
+
+
+    # The global indexer acts as both an indexer factory and an indexer, since
+    # the property doesn't matter.
+    def new(property)
+      self
+    end
+
+    # @param [ActiveFedora::Indexing::Map::IndexObject, #as] index_obj The indexing
+    #   object to call #as on.
+    def index(index_obj)
+      unless index_types.empty?
+        index_obj.as(*index_types)
+      end
+    end
+
+    private
+
+    attr_reader :index_types
+  end
+end

--- a/lib/active_fedora/indexers/null_indexer.rb
+++ b/lib/active_fedora/indexers/null_indexer.rb
@@ -1,0 +1,12 @@
+module ActiveFedora::Indexers
+  ##
+  # An indexer which does nothing with the given index object.
+  class NullIndexer
+    include Singleton
+    def new(_)
+      self
+    end
+    def index(_)
+    end
+  end
+end

--- a/lib/active_fedora/schema.rb
+++ b/lib/active_fedora/schema.rb
@@ -1,0 +1,16 @@
+module ActiveFedora
+  ##
+  # Implement the .apply_schema method from ActiveTriples to allow for
+  # externally defined schemas to be put on an AF::Base object.
+  module Schema
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def apply_schema(schema, strategy=ActiveFedora::SchemaIndexingStrategy.new)
+        schema.properties.each do |property|
+          strategy.apply(self, property)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_fedora/schema.rb
+++ b/lib/active_fedora/schema.rb
@@ -6,6 +6,16 @@ module ActiveFedora
     extend ActiveSupport::Concern
 
     module ClassMethods
+      # Applies a schema to an ActiveFedora::Base.
+      # @note The default application strategy adds no indexing hints. You may
+      #   want to implement a different strategy if you want to set values on the
+      #   property reflection.
+      # @param schema [ActiveTriples::Schema] The schema to apply.
+      # @param strategy [#apply] The strategy to use for applying the schema.
+      # @example Apply a schema and index everything as symbol.
+      #   apply_schema MySchema, ActiveFedora::SchemaIndexingStrategy.new(
+      #     ActiveFedora::GlobalIndexer.new(:symbol)
+      #   )
       def apply_schema(schema, strategy=ActiveFedora::SchemaIndexingStrategy.new)
         schema.properties.each do |property|
           strategy.apply(self, property)

--- a/lib/active_fedora/schema_indexing_strategy.rb
+++ b/lib/active_fedora/schema_indexing_strategy.rb
@@ -1,0 +1,25 @@
+module ActiveFedora
+  ##
+  # An extension strategy to also apply solr indexes for each property.
+  # @note If how a field is indexed changes based on property, this would be a
+  #   good place to define that.
+  class SchemaIndexingStrategy
+    # @param [#index] indexer The indexer to use
+    def initialize(indexer=Indexers::NullIndexer.instance)
+      @indexer = indexer
+    end
+
+    # @param [ActiveFedora::Base] object The object to apply the property to.
+    # @param [ActiveTriples::Property, #name, #to_h] property The property to define.
+    def apply(object, property)
+      object.property property.name, property.to_h do |index|
+        indexer.new(property).index(index)
+      end
+    end
+
+    private
+
+    attr_reader :indexer
+  end
+end
+

--- a/spec/integration/base_spec.rb
+++ b/spec/integration/base_spec.rb
@@ -135,6 +135,25 @@ describe ActiveFedora::Base do
     end
   end
   
+  describe "#apply_schema" do
+    before do
+      class ExampleSchema < ActiveTriples::Schema
+        property :title, predicate: RDF::DC.title
+      end
+      class ExampleBase < ActiveFedora::Base
+        apply_schema ExampleSchema, ActiveFedora::SchemaIndexingStrategy.new(ActiveFedora::Indexers::GlobalIndexer.new(:symbol))
+      end
+    end
+    after do
+      Object.send(:remove_const, :ExampleSchema)
+      Object.send(:remove_const, :ExampleBase)
+    end
+    let(:obj) { ExampleBase.new }
+    it "should configure properties and solrize them" do
+      obj.title = ["Test"]
+      expect(obj.to_solr[ActiveFedora::SolrQueryBuilder.solr_name("title", :symbol)]).to eq ["Test"]
+    end
+  end
 
   describe "#exists?" do
     let(:obj) { ActiveFedora::Base.create } 

--- a/spec/integration/datastream_rdf_nested_attributes_spec.rb
+++ b/spec/integration/datastream_rdf_nested_attributes_spec.rb
@@ -99,7 +99,7 @@ describe "Nesting attribute behavior of RDFDatastream" do
       end
 
       describe "on lists" do
-        subject { ComplexRDFDatastream::PersonalName.new(RDF::Graph.new) }
+        subject { ComplexRDFDatastream::PersonalName.new(nil) }
         it "should accept a hash" do
           subject.elementList_attributes =  [{ topicElement_attributes: {'0' => { elementValue:"Quantum Behavior" }, '1' => { elementValue:"Wave Function" }}}]
           expect(subject.elementList.first[0].elementValue).to eq ["Quantum Behavior"]

--- a/spec/unit/indexers/global_indexer_spec.rb
+++ b/spec/unit/indexers/global_indexer_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Indexers::GlobalIndexer do
+  subject { described_class.new(index_types) }
+  let(:index_types) {}
+
+  describe "#new" do
+    # The global indexer acts as both an indexer factory and an indexer, since
+    # the property doesn't matter.
+    it "should return itself" do
+      expect(subject.new("bla")).to eq subject
+    end
+  end
+  describe "#index" do
+    let(:index_obj) { instance_double(ActiveFedora::Indexing::Map::IndexObject, as: nil) }
+    context "with one index type" do
+      let(:index_types) { :symbol }
+      it "should pass that to index_obj" do
+        subject.index(index_obj)
+
+        expect(index_obj).to have_received(:as).with(:symbol)
+      end
+    end
+    context "with multiple index types" do
+      let(:index_types) { [:symbol, :stored_searchable] }
+      it "should pass that to index_obj" do
+        subject.index(index_obj)
+
+        expect(index_obj).to have_received(:as).with(:symbol, :stored_searchable)
+      end
+    end
+    context "with no index types" do
+      subject { described_class.new }
+      it "should not pass anything to index_obj" do
+        subject.index(index_obj)
+
+        expect(index_obj).not_to have_received(:as)
+      end
+    end
+  end
+end

--- a/spec/unit/rdf_resource_datastream_spec.rb
+++ b/spec/unit/rdf_resource_datastream_spec.rb
@@ -148,7 +148,6 @@ describe ActiveFedora::RDFDatastream do
       end
       context "persisted to repository" do
         before do
-          DummySubnode.configure :repository => :default
           allow_any_instance_of(DummySubnode).to receive(:repository).and_return(RDF::Repository.new)
           dummy = DummySubnode.new(RDF::URI('http://example.org/dummy/blah'))
           dummy.title = 'subbla'

--- a/spec/unit/schema_indexing_strategy_spec.rb
+++ b/spec/unit/schema_indexing_strategy_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::SchemaIndexingStrategy do
+  subject { described_class.new(property_indexer_factory) }
+
+  describe "#apply" do
+    let(:property) do
+      p = object_double(ActiveTriples::Property.new(:name => nil))
+      allow(p).to receive(:to_h).and_return(options)
+      allow(p).to receive(:name).and_return(name)
+      p
+    end
+    let(:name) { "Name" }
+    let(:options) do
+      {
+        :class_name => "Test"
+      }
+    end
+    let(:object) do
+      o = object_double(ActiveFedora::Base)
+      allow(o).to receive(:property).and_yield(index_configuration)
+      o
+    end
+    let(:index_configuration) do
+      d = double("index configuration")
+      allow(d).to receive(:as)
+      d
+    end
+    let(:property_indexer) do
+      p = double("property_indexer")
+      allow(p).to receive(:index).with(anything) do |index|
+        index.as(*Array.wrap(index_types))
+      end
+      p
+    end
+    let(:property_indexer_factory) do
+      p = double("property indexer factory")
+      allow(p).to receive(:new).with(anything).and_return(property_indexer)
+      p
+    end
+    let(:index_types) {}
+    context "with no index types" do
+      subject { described_class.new }
+      it "should not try to index it" do
+        subject.apply(object, property)
+
+        expect(object).to have_received(:property).with(property.name, property.to_h)
+        expect(index_configuration).not_to have_received(:as)
+      end
+    end
+    context "with one index type" do
+      let(:index_types) { :symbol }
+      it "should apply that one" do
+        subject.apply(object, property)
+
+        expect(index_configuration).to have_received(:as).with(:symbol)
+      end
+    end
+    context "with multiple index types" do
+      let(:index_types) { [:symbol, :stored_searchable] }
+      it "should apply all of them" do
+        subject.apply(object, property)
+
+        expect(index_configuration).to have_received(:as).with(:symbol, :stored_searchable)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pending merge and release of ActiveTriples with Schema support.

This is related to https://github.com/ActiveTriples/ActiveTriples/pull/132 and I'm only doing it before that code is merged because I feel like there's discussion to have around this, especially in regard to the SolrApplicationStrategy.

I'm proposing that if you apply a schema you probably want it indexed, and by default the system should do that for you.