### PR TITLE
Return relation for .limit, fixes #352

### DIFF
--- a/lib/active_fedora/associations/collection_proxy.rb
+++ b/lib/active_fedora/associations/collection_proxy.rb
@@ -842,6 +842,12 @@ module ActiveFedora
         @association
       end
 
+      # @return [Relation] object for the records in this association
+      def scope
+        @association.scope
+      end
+      alias spawn scope
+
       def to_ary
         load_target.dup
       end

--- a/spec/integration/relation_spec.rb
+++ b/spec/integration/relation_spec.rb
@@ -3,9 +3,11 @@ require 'spec_helper'
 describe ActiveFedora::Base do
   before :all do
     class Library < ActiveFedora::Base
-      has_many :books, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf
+      has_many :books
     end
-    class Book < ActiveFedora::Base; end
+    class Book < ActiveFedora::Base
+      belongs_to :library, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf
+    end
   end
 
   after :all do
@@ -60,6 +62,12 @@ describe ActiveFedora::Base do
         expect{ subject.sort! }.to raise_error NoMethodError
       end
     end
+
+    context "when limit is applied" do
+      subject { Library.create books: [Book.create, Book.create] }
+      it "limits the number of books" do
+        expect(subject.books.limit(1).size).to eq 1
+      end
+    end
   end
 end
-

--- a/spec/unit/collection_proxy_spec.rb
+++ b/spec/unit/collection_proxy_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe ActiveFedora::Associations::CollectionProxy do
+
+  before do
+    class Book < ActiveFedora::Base
+    end
+    class Page < ActiveFedora::Base
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :Page)
+    Object.send(:remove_const, :Book)
+  end
+
+  describe "#spawn" do
+
+    let(:reflection)  { Book.create_reflection(:has_many, :pages, { predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isMemberOfCollection }, Book) }
+    let(:association) { ActiveFedora::Associations::HasManyAssociation.new(Book.new, reflection ) }
+    let(:proxy)       { described_class.new(association) }
+
+    subject { proxy.spawn }
+    it { is_expected.to be_instance_of ActiveFedora::Relation }
+
+  end
+
+end


### PR DESCRIPTION
Adds the .scope method to CollectionProxy so that you can chain
relations such as .limit to a CollectionProxy.