### PR TITLE
Refactoring .find_target for HasAndBelongsToMany

### DIFF
--- a/lib/active_fedora/associations/builder/has_and_belongs_to_many.rb
+++ b/lib/active_fedora/associations/builder/has_and_belongs_to_many.rb
@@ -1,11 +1,13 @@
 module ActiveFedora::Associations::Builder
   class HasAndBelongsToMany < CollectionAssociation #:nodoc:
+    extend Deprecation
     self.macro = :has_and_belongs_to_many
 
     self.valid_options += [:inverse_of, :solr_page_size]
 
     def validate_options
       super
+      Deprecation.warn HasAndBelongsToMany, ":solr_page_size doesn't do anything anymore and will be removed in ActiveFedora 10" if options.key?(:solr_page_size)
       if !options[:predicate]
         raise "You must specify a predicate for #{name}"
       elsif !options[:predicate].kind_of?(RDF::URI)

--- a/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
+++ b/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
@@ -46,20 +46,6 @@ module ActiveFedora
         result && records
       end
 
-
-      def find_target
-        page_size = @reflection.options[:solr_page_size]
-        page_size ||= 200
-        ids = owner[reflection.foreign_key]
-        return [] if ids.blank?
-        solr_result = []
-        0.step(ids.size,page_size) do |startIdx|
-          query = ActiveFedora::SolrQueryBuilder.construct_query_for_ids(ids.slice(startIdx,page_size))
-          solr_result += ActiveFedora::SolrService.query(query, rows: page_size)
-        end
-        return ActiveFedora::QueryResultBuilder.reify_solr_results(solr_result)
-      end
-
       # In a HABTM, just look in the RDF, no need to run a count query from solr.
       def count(options = {})
         owner[reflection.foreign_key].size
@@ -94,6 +80,12 @@ module ActiveFedora
 
         def stale_state
           owner[reflection.foreign_key]
+        end
+
+        def find_target
+          ids = owner[reflection.foreign_key]
+          return [] if ids.blank?
+          ActiveFedora::Base.find(ids)
         end
 
     end


### PR DESCRIPTION
Removes the unnecessary calls to :solr_page_size and takes advantage of
ActiveFedora::Base.find accepting an array. The method is also made
private.