### PR TITLE
Removing dead define_destroy_hook method

### DIFF
--- a/lib/active_fedora/associations/builder/has_and_belongs_to_many.rb
+++ b/lib/active_fedora/associations/builder/has_and_belongs_to_many.rb
@@ -15,28 +15,5 @@ module ActiveFedora::Associations::Builder
       end
     end
 
-    def build
-      reflection = super
-      define_destroy_hook
-      reflection
-    end
-
-    private
-
-      def define_destroy_hook
-        # Don't use a before_destroy callback since users' before_destroy
-        # callbacks will be executed after the association is wiped out.
-        # TODO Update to destroy_associations
-        name = self.name
-        model.send(:include, Module.new {
-          class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def destroy          # def destroy
-              #{name}.clear      #   posts.clear
-              super              #   super
-            end                  # end
-          RUBY
-        })
-      end
-
   end
 end


### PR DESCRIPTION
Defines a destroy method that's only calling super, therefore it's unnecessary. @jcoyne right?