### PR TITLE
Refactoring ActiveFedora::File to use ActiveFedora::Persistence

### DIFF
--- a/lib/active_fedora/fedora_attributes.rb
+++ b/lib/active_fedora/fedora_attributes.rb
@@ -29,31 +29,6 @@ module ActiveFedora
       resource.set_value(*args)
     end
 
-    def id
-      if uri.kind_of?(::RDF::URI) && uri.value.blank?
-        nil
-      elsif uri.present?
-        self.class.uri_to_id(URI.parse(uri))
-      end
-    end
-
-    def id=(id)
-      raise "ID has already been set to #{self.id}" if self.id
-      @ldp_source = build_ldp_resource(id.to_s)
-    end
-
-
-    # TODO: Remove after we no longer support #pid.
-    def pid
-      Deprecation.warn FedoraAttributes, "#{self.class}#pid is deprecated and will be removed in active-fedora 10.0. Use #{self.class}#id instead."
-      id
-    end
-
-    def uri
-      # TODO could we return a RDF::URI instead?
-      uri = @ldp_source.try(:subject_uri)
-      uri.value == '' ? uri : uri.to_s
-    end
 
     ##
     # The resource is the RdfResource object that stores the graph for

--- a/lib/active_fedora/identifiable.rb
+++ b/lib/active_fedora/identifiable.rb
@@ -32,6 +32,32 @@ module ActiveFedora
       end
     end
 
+    def id
+      if uri.kind_of?(::RDF::URI) && uri.value.blank?
+        nil
+      elsif uri.present?
+        self.class.uri_to_id(URI.parse(uri))
+      end
+    end
+
+    def id=(id)
+      raise "ID has already been set to #{self.id}" if self.id
+      @ldp_source = build_ldp_resource(id.to_s)
+    end
+
+
+    # TODO: Remove after we no longer support #pid.
+    def pid
+      Deprecation.warn FedoraAttributes, "#{self.class}#pid is deprecated and will be removed in active-fedora 10.0. Use #{self.class}#id instead."
+      id
+    end
+
+    def uri
+      # TODO could we return a RDF::URI instead?
+      uri = @ldp_source.try(:subject_uri)
+      uri.value == '' ? uri : uri.to_s
+    end
+
 
     module ClassMethods
       ##

--- a/lib/active_fedora/with_metadata.rb
+++ b/lib/active_fedora/with_metadata.rb
@@ -9,7 +9,7 @@ module ActiveFedora
       @metadata_node ||= self.class.metadata_schema.new(self)
     end
 
-    def save(*)
+    def create_or_update(*)
       if super && !new_record?
         metadata_node.metadata_uri = described_by # TODO only necessary if the URI was < > before
         metadata_node.save # TODO if changed?


### PR DESCRIPTION
We also changed spacing and removed the internal persistence module since it did not make as much sense when we were including persistence.