### PR TITLE
Removing dead code in QueryMethods

### DIFF
--- a/lib/active_fedora/relation/query_methods.rb
+++ b/lib/active_fedora/relation/query_methods.rb
@@ -1,15 +1,6 @@
 module ActiveFedora
   module QueryMethods # :nodoc:
 
-    def extending_values
-      @values[:extending] || []
-    end
-
-    def extending_values=(values)
-      raise ImmutableRelation if @loaded
-      @values[:extending] = values
-    end
-
     def where_values
       @values[:where] ||= []
     end


### PR DESCRIPTION
Removing these methods because they aren't being used anymore... at least as far as we can tell.