### PR TITLE
Reorganizing ActiveFedora:File code

### DIFF
--- a/lib/active_fedora/file/attributes.rb
+++ b/lib/active_fedora/file/attributes.rb
@@ -1,0 +1,63 @@
+module ActiveFedora::File::Attributes
+
+  attr_writer :mime_type
+
+  def mime_type
+    @mime_type ||= fetch_mime_type
+  end
+
+  def original_name
+    @original_name ||= fetch_original_name
+  end
+
+  def original_name= name
+    @original_name = name
+  end
+
+  def digest
+    response = metadata.ldp_source.graph.query(predicate: ActiveFedora::RDF::Fcrepo4.digest)
+    response.map(&:object)
+  end
+
+  def persisted_size
+    ldp_source.head.headers['Content-Length'].to_i unless new_record?
+  end
+
+  def dirty_size
+    content.size if changed? && content.respond_to?(:size)
+  end
+
+  def size
+    dirty_size || persisted_size
+  end
+
+  def has_content?
+    size && size > 0
+  end
+
+  def empty?
+    !has_content?
+  end
+
+  private
+
+    def links
+      @links ||= Ldp::Response.links(ldp_source.head)
+    end
+
+    def default_mime_type
+      'text/plain'
+    end
+
+    def fetch_mime_type
+      return default_mime_type if new_record?
+      ldp_source.head.headers['Content-Type']
+    end
+
+    def fetch_original_name
+      return if new_record?
+      m = ldp_source.head.headers['Content-Disposition'].match(/filename="(?<filename>[^"]*)";/)
+      URI.decode(m[:filename])
+    end
+
+end

--- a/lib/active_fedora/file/streaming.rb
+++ b/lib/active_fedora/file/streaming.rb
@@ -1,0 +1,46 @@
+module ActiveFedora::File::Streaming
+  # @param range [String] the Range HTTP header
+  # @return [Stream] an object that responds to each
+  def stream(range = nil)
+    uri = URI.parse(self.uri)
+    FileBody.new(uri, headers(range, authorization_key))
+  end
+
+  # @param range [String] from #stream
+  # @param key [String] from #authorization_key
+  # @return [Hash]
+  def headers(range, key, result = Hash.new)
+    result["Range"] = range if range
+    result["Authorization"] = key if key
+    result
+  end
+
+  class FileBody
+    attr_reader :uri, :headers
+    def initialize(uri, headers)
+      @uri = uri
+      @headers = headers
+    end
+
+    def each
+      Net::HTTP.start(uri.host, uri.port) do |http|
+        request = Net::HTTP::Get.new uri, headers
+        http.request request do |response|
+
+          raise "Couldn't get data from Fedora (#{uri}). Response: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+          response.read_body do |chunk|
+            yield chunk
+          end
+        end
+      end
+    end
+  end
+
+  private
+
+    # @return [String] current authorization token from Ldp::Client
+    def authorization_key
+      self.ldp_source.client.http.headers.fetch("Authorization", nil)
+    end
+
+end


### PR DESCRIPTION
This splits out some of the code in ActiveFedora::File into relevant modules for better organization and to
make the File class overall lighter and more easy to read.