### PR TITLE
RDF::IndexingService indexes objects & properties

### DIFF
--- a/lib/active_fedora/associations/builder/property.rb
+++ b/lib/active_fedora/associations/builder/property.rb
@@ -9,6 +9,16 @@ module ActiveFedora::Associations::Builder
       @name = :"#{name.to_s.singularize}_ids"
     end
 
+    def build
+      super.tap do |reflection|
+        model.index_config[name] = build_index_config(reflection)
+      end
+    end
+
+    def build_index_config(reflection)
+      ActiveFedora::Indexing::Map::IndexObject.new(reflection.predicate_for_solr) { |index| index.as :symbol }
+    end
+
   end
 end
 

--- a/lib/active_fedora/attributes.rb
+++ b/lib/active_fedora/attributes.rb
@@ -208,7 +208,7 @@ module ActiveFedora
       end
 
       def add_attribute_indexing_config(name, &block)
-        index_config[name] ||= ActiveFedora::Indexing::Map::IndexObject.new &block
+        index_config[name] ||= ActiveFedora::Indexing::Map::IndexObject.new(name, &block)
       end
 
       def warn_duplicate_predicates new_name, new_properties

--- a/lib/active_fedora/indexing/map.rb
+++ b/lib/active_fedora/indexing/map.rb
@@ -17,10 +17,12 @@ module ActiveFedora::Indexing
     # this enables a cleaner API for solr integration
     class IndexObject
       attr_accessor :data_type, :behaviors
+      attr_reader :key
 
-      def initialize(&block)
+      def initialize(name, &block)
         @behaviors = []
         @data_type = :string
+        @key = name
         yield self if block_given?
       end
 
@@ -33,14 +35,11 @@ module ActiveFedora::Indexing
       end
 
       def dup
-        self.class.new do |idx|
+        self.class.new(@key) do |idx|
           idx.behaviors = @behaviors.dup
         end
       end
 
-      def defaults
-        :noop
-      end
     end
   end
 end

--- a/lib/active_fedora/rdf.rb
+++ b/lib/active_fedora/rdf.rb
@@ -9,5 +9,7 @@ module ActiveFedora
     autoload :Identifiable
     autoload :Persistence
     autoload :ProjectHydra
+    autoload :FieldMap
+    autoload :FieldMapEntry
   end
 end

--- a/lib/active_fedora/rdf/field_map.rb
+++ b/lib/active_fedora/rdf/field_map.rb
@@ -1,0 +1,90 @@
+module ActiveFedora::RDF
+  # Transient class that maps solr field names, without their suffixes, to the values and behaviors that
+  # are used to transforming them for insertion into the solr document.
+  # It partially extends Ruby's Hash class, similar to the way ActiveFedora::Indexing::Map does,
+  # but only with selected methods as outlined in def_delegators.
+  class FieldMap
+    extend Forwardable
+    
+    def_delegators :@hash, :[], :[]=, :each, :keys
+    
+    def initialize(hash = {}, &block)
+      @hash = hash
+      yield self if block_given?
+    end
+
+    # Inserts each solr field map configuration into the FieldMap class
+    # @param [Symbol] name the name of the property on the object that we're indexing
+    # @param [Object] index_field_config an instance of ActiveFedora::Indexing::Map::IndexObject
+    # @param [Object] object the instance of ActiveFedora::Base which is being indexed into Solr
+    def insert(name, index_field_config, object)
+      self[index_field_config.key.to_s] ||= FieldMapEntry.new
+      PolymorphicBuilder.new(self[index_field_config.key.to_s], index_field_config, object, name).build
+    end
+
+    # Supports assigning the delegate class that calls .build to insert the fields into the solr document.
+    # @attr [Object] entry instance of ActiveFedora::RDF::FieldMapEntry which will contain the values of the solr field
+    # @attr [Object] index_field_config an instance of ActiveFedora::Indexing::Map::IndexObject
+    # @attr [Object] object the instance of ActiveFedora::Base which is being indexed into Solr
+    # @attr [Symbol] name the name of the property on the object that we're indexing
+    class PolymorphicBuilder
+
+      attr_accessor :entry, :index_field_config, :object, :name
+
+      def initialize(entry, index_field_config, object, name)
+        @entry              = entry
+        @index_field_config = index_field_config
+        @object             = object
+        @name               = name
+        self
+      end
+
+      def build
+        delegate_class.new(entry, index_field_config, object, name).build
+      end
+
+      private
+
+        def delegate_class
+          kind_of_af_base? ? ResourceBuilder : PropertyBuilder
+        end
+
+        def kind_of_af_base?
+          config = properties[name.to_s]
+          config && config[:class_name] && config[:class_name] < ActiveFedora::Base
+        end
+
+        def properties
+          object.class.properties
+        end
+
+    end
+
+    # Abstract class that implements the PolymorphicBuilder interface and is used for
+    # for building FieldMap entries. You can extend this object to create your own
+    # builder for creating the values in your solr fields.
+    class Builder < PolymorphicBuilder
+      def build
+        type = index_field_config.data_type
+        behaviors = index_field_config.behaviors
+        return unless type and behaviors
+        entry.merge!(type, behaviors, find_values)
+      end
+    end
+
+    # Builds a FieldMap entry for a resource such as an ActiveFedora::Base object and returns the uri as the value.
+    class ResourceBuilder < Builder
+      def find_values
+        object.send(name).map(&:uri)
+      end
+    end
+
+    # Builds a FieldMap entry for a rdf property and returns the values
+    class PropertyBuilder < Builder
+      def find_values
+        Array(object.send(name))
+      end
+    end
+
+  end
+end

--- a/lib/active_fedora/rdf/field_map_entry.rb
+++ b/lib/active_fedora/rdf/field_map_entry.rb
@@ -1,0 +1,28 @@
+module ActiveFedora::RDF
+  # Transient class that represents a field that we send to solr.
+  # It might be possible for two properties to share a single field map entry if they use the same solr key.
+  # @attribute [Symbol] type the data type hint for Solrizer
+  # @attribute [Array] behaviors the indexing hints such as :stored_searchable or :symbol
+  # @attribute [Array] values the actual values that get sent to solr
+  class FieldMapEntry
+
+    attr_accessor :type, :behaviors, :values
+
+    def initialize
+      @behaviors = []
+      @values = []
+    end
+
+    # Merges any existing values for solr fields with new, incoming values and ensures that resulting values are unique.
+    # @param [Symbol] type the data type for the field such as :string, :date, :integer
+    # @param [Array] behaviors Solrizer's behaviors for indexing such as :stored_searhable, :symbol
+    # @param [Array] values existing values for the solr field
+    def merge!(type, behaviors, values)
+      self.type ||= type
+      self.behaviors += behaviors
+      self.behaviors.uniq!
+      self.values += values
+    end
+
+  end
+end

--- a/lib/active_fedora/rdf/rdf_datastream.rb
+++ b/lib/active_fedora/rdf/rdf_datastream.rb
@@ -23,8 +23,7 @@ module ActiveFedora
 
       def add_attribute_indexing_config(name, &block)
         Deprecation.warn(RDFDatastream, "Adding indexing to datastreams is deprecated")
-        # TODO the hash can be initalized to return on of these
-        index_config[name] ||= ActiveFedora::Indexing::Map::IndexObject.new &block
+        index_config[name] ||= ActiveFedora::Indexing::Map::IndexObject.new(name, &block)
       end
 
       # Trim the last segment off the URI to get the parents uri

--- a/lib/active_fedora/reflection.rb
+++ b/lib/active_fedora/reflection.rb
@@ -193,10 +193,13 @@ module ActiveFedora
         options[:predicate]
       end
 
+      def predicate_for_solr
+        predicate.fragment || predicate.to_s.rpartition(/\//).last
+      end
+
       def solr_key
         @solr_key ||= begin
-          predicate_string = predicate.fragment || predicate.to_s.rpartition(/\//).last
-          ActiveFedora::SolrQueryBuilder.solr_name(predicate_string, :symbol)
+          ActiveFedora::SolrQueryBuilder.solr_name(predicate_for_solr, :symbol)
         end
       end
 

--- a/spec/integration/belongs_to_association_spec.rb
+++ b/spec/integration/belongs_to_association_spec.rb
@@ -172,7 +172,7 @@ describe ActiveFedora::Base do
           simple_collection.objects = [complex_object, simple_object]
           simple_collection.save!
         end
-        it "ignores objects who's classes aren't specified" do
+        it "ignores objects whose classes aren't specified" do
           expect(simple_collection.complex_objects.size).to eq 1
           expect(simple_collection.complex_objects[0]).to be_instance_of ZComplexObject
           expect(simple_collection.complex_objects[1]).to be_nil

--- a/spec/unit/indexing_service_spec.rb
+++ b/spec/unit/indexing_service_spec.rb
@@ -4,27 +4,6 @@ describe ActiveFedora::IndexingService do
   let(:indexer) { described_class.new(object) }
   let(:object) { ActiveFedora::Base.new }
 
-  describe "#solrize_relationships" do
-    subject { indexer.send(:solrize_relationships) }
-    let(:person_reflection) { double('person', foreign_key: 'person_id', kind_of?: true, solr_key: member_of) }
-    let(:location_reflection) { double('location', foreign_key: 'location_id', kind_of?: true, solr_key: part_of) }
-    let(:reflections) { { 'person' => person_reflection, 'location' => location_reflection } }
-
-    let(:member_of) { ActiveFedora::SolrQueryBuilder.solr_name("info:fedora/fedora-system:def/relations-external#isMemberOf", :symbol) }
-    let(:part_of) { ActiveFedora::SolrQueryBuilder.solr_name("info:fedora/fedora-system:def/relations-external#isPartOf", :symbol) }
-
-    before do
-      expect(object).to receive(:[]).with('person_id').and_return('info:fedora/demo:10')
-      expect(object).to receive(:[]).with('location_id').and_return('info:fedora/demo:11')
-      expect(object.class).to receive(:reflections).and_return(reflections)
-    end
-
-    it "should serialize the relationships into a Hash" do
-      expect(subject[member_of]).to eq "info:fedora/demo:10"
-      expect(subject[part_of]).to eq "info:fedora/demo:11"
-    end
-  end
-
   describe "#generate_solr_document" do
     context "when no block is passed" do
       subject { indexer.generate_solr_document }

--- a/spec/unit/rdf/indexing_service_spec.rb
+++ b/spec/unit/rdf/indexing_service_spec.rb
@@ -78,12 +78,12 @@ describe ActiveFedora::RDF::IndexingService do
     end
 
     it "should return the right values" do
-      expect(fields[:related_url][:values]).to eq ["http://example.org/blogtastic/"]
-      expect(fields[:based_near][:values]).to eq ["Tacoma, WA", "Renton, WA"]
+      expect(fields["related_url"].values).to eq ["http://example.org/blogtastic/"]
+      expect(fields["based_near"].values).to eq ["Tacoma, WA", "Renton, WA"]
     end
 
     it "should return the right type information" do
-      expect(fields[:created][:type]).to eq :date
+      expect(fields["created"].type).to eq :date
     end
   end
 

--- a/spec/unit/rdf_resource_datastream_spec.rb
+++ b/spec/unit/rdf_resource_datastream_spec.rb
@@ -42,10 +42,8 @@ describe ActiveFedora::RDFDatastream do
   subject { DummyAsset.new }
 
   describe "#to_solr" do
-    before do
-      subject.descMetadata.title = "bla"
-      subject.descMetadata.license = DummySubnode.new('http://example.org/blah')
-    end
+
+    before { subject.descMetadata.title = "bla" }
 
     it "should not be blank" do
       expect(subject.to_solr).not_to be_blank
@@ -55,9 +53,31 @@ describe ActiveFedora::RDFDatastream do
       expect(subject.to_solr["desc_metadata__title_teim"]).to eq ["bla"]
     end
 
-    it "should solrize uris" do
-      expect(subject.to_solr["desc_metadata__license_teim"]).to eq ['http://example.org/blah']
+    context "with ActiveFedora::Base resources" do
+
+      let(:dummy_asset) { DummyAsset.new }
+
+      before do
+        allow(dummy_asset).to receive(:uri).and_return("http://foo")
+        subject.descMetadata.creator = dummy_asset
+      end
+
+      it "should solrize objects" do
+        expect(subject.to_solr["desc_metadata__creator_teim"]).to eq ["http://foo"]
+      end
+
     end
+
+    context "with ActiveTriples resources" do
+
+      before { subject.descMetadata.license = DummySubnode.new('http://example.org/blah') }
+
+      it "should solrize uris" do
+        expect(subject.to_solr["desc_metadata__license_teim"]).to eq ['http://example.org/blah']
+      end
+
+   end
+
   end
 
   describe "delegation" do


### PR DESCRIPTION
Solrizing AF::Base objects and properties share common behaviors. This refactors both methods for indexing objects and properties into a common method: `solrize_rdf_assertions` which creates other classes that can be overridden if users wish to alter the ways in which their solr fields are created.

This also addresses #809 where objects can be indexed using their uris as the value.