### PR TITLE
Refactor File#== to avoid an unnecessary API call

### DIFF
--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -51,8 +51,10 @@ module ActiveFedora
     end
 
     def ==(comparison_object)
-      return true if comparison_object.equal?(self)
-      comparison_object.instance_of?(self.class) && comparison_object.uri == uri && !comparison_object.new_record?
+      super ||
+        comparison_object.instance_of?(self.class) &&
+        id.present? &&
+        comparison_object.uri == uri
     end
 
     def ldp_source


### PR DESCRIPTION
The new_record? call used to cause an API call to fedora, which we are
now able to avoid.