### PR TITLE
Add collection#select using block syntax.

### DIFF
--- a/lib/active_fedora/associations/collection_association.rb
+++ b/lib/active_fedora/associations/collection_association.rb
@@ -284,6 +284,10 @@ module ActiveFedora
         owner.new_record? && !foreign_key_present?
       end
 
+      def select(select=nil, &block)
+        to_a.select(&block)
+      end
+
       protected
 
         def construct_query

--- a/spec/integration/collection_association_spec.rb
+++ b/spec/integration/collection_association_spec.rb
@@ -79,11 +79,13 @@ describe ActiveFedora::Base do
     end
   end
 
-  # TODO: Bug described in issue #609
   describe "#select" do
-    it "should choose a subset of objects in the relationship" do
-      pending "method has private visibility"
+    # TODO: Bug described in issue #609
+    xit "should choose a subset of objects in the relationship" do
       expect(library.books.select([:id])).to include(book1.id)
+    end
+    it "should work as a block" do
+      expect(library.books.select{|x| x.id == book1.id}).to eq [book1]
     end
   end
 


### PR DESCRIPTION
There's an alternative method that's described as working, but we'd have to
change the solr query used to find the objects (add an :fl parameter) to make this work, and I'm not
sure that's possible with how many different ways of finding there is.