### PR TITLE
RDF association ids setter should handle nil

### DIFF
--- a/lib/active_fedora/associations/rdf.rb
+++ b/lib/active_fedora/associations/rdf.rb
@@ -3,11 +3,12 @@ module ActiveFedora
     class RDF < SingularAssociation #:nodoc:
 
       def replace(values)
+        ids = Array(values).reject(&:blank?)
         raise "can't modify frozen #{owner.class}" if owner.frozen?
         destroy
-        values.each do |value|
-          uri = ActiveFedora::Base.id_to_uri(value)
-          owner.resource.insert [owner.rdf_subject, reflection.predicate, ::RDF::URI.new(uri)]
+        ids.each do |id|
+          uri = ::RDF::URI(ActiveFedora::Base.id_to_uri(id))
+          owner.resource.insert [owner.rdf_subject, reflection.predicate, uri]
         end
         owner.send(:attribute_will_change!, reflection.name)
       end

--- a/spec/integration/associations/rdf_spec.rb
+++ b/spec/integration/associations/rdf_spec.rb
@@ -20,6 +20,19 @@ describe "rdf associations" do
       expect(library.association(:foo_ids)).not_to receive(:filter_by_class)
       library.foos.to_a
     end
+
+    describe "the id setter" do
+      it "can handle nil" do
+        library.foo_ids = nil
+        expect(library.foo_ids).to eq []
+      end
+
+      it "can handle array with nils" do
+        library.foo_ids = [nil, nil]
+        expect(library.foo_ids).to eq []
+      end
+    end
+
   end
 
   context "when two relationships have the same predicate" do


### PR DESCRIPTION
previously setting nil or [nil] caused a stacktrace:
  `undefined method 'each' for nil:NilClass`