### PR TITLE
Stop using InboundRelationConnection

### DIFF
--- a/lib/active_fedora/associations/contained_finder.rb
+++ b/lib/active_fedora/associations/contained_finder.rb
@@ -1,17 +1,20 @@
 module ActiveFedora::Associations
-  ## 
+  ##
   # Finds the objects which associate with a given record and are contained
   # within the given container. Uses #repository to find the objects.
   class ContainedFinder
-    attr_reader :container, :repository
+    attr_reader :container, :repository, :proxy_class
     delegate :contained_ids, to: :container
     # @param [#contained_ids] container a container that records are stored
     #   under.
     # @param [#translate_uri_to_id, #find] repository a repository to build
     #   objects from.
-    def initialize(container:, repository:)
+    # @param [ActiveFedora::Base] proxy_class class that represents an
+    #   ore:Proxy
+    def initialize(container:, repository:, proxy_class:)
       @container = container
       @repository = repository
+      @proxy_class = proxy_class
     end
 
     # @param [ActiveFedora::Base] record a record which you want to find the
@@ -33,8 +36,14 @@ module ActiveFedora::Associations
       relation_subjects(record)
     end
 
+    # This could be done with Prefer InboundReferences, but that is
+    # a slow fedora call
     def relation_subjects(record)
-      record.resource.query(object: record.rdf_subject).subjects.to_a
+      query = ActiveFedora::SolrQueryBuilder.construct_query_for_rel(
+        [[:has_model, proxy_class.to_class_uri], [:proxyFor, record.id]]
+      )
+      results = ActiveFedora::SolrService.query(query, fl: 'id')
+      results.map { |res| ::RDF::URI(ActiveFedora::Base.id_to_uri(res['id'])) }
     end
   end
 

--- a/lib/active_fedora/associations/indirectly_contains_association.rb
+++ b/lib/active_fedora/associations/indirectly_contains_association.rb
@@ -64,7 +64,7 @@ module ActiveFedora
         end
 
         def record_proxy_finder
-          ContainedFinder.new(container: container, repository: composite_proxy_repository)
+          ContainedFinder.new(container: container, repository: composite_proxy_repository, proxy_class: proxy_class)
         end
 
         def composite_proxy_repository

--- a/lib/active_fedora/fedora.rb
+++ b/lib/active_fedora/fedora.rb
@@ -22,7 +22,11 @@ module ActiveFedora
     end
 
     def connection
-      @connection ||= InboundRelationConnection.new(CachingConnection.new(authorized_connection))
+      # The InboundRelationConnection does provide more data, useful for
+      # things like ldp:IndirectContainers, but it's imposes a significant
+      # performance penalty on every request
+      #   @connection ||= InboundRelationConnection.new(CachingConnection.new(authorized_connection))
+      @connection ||= CachingConnection.new(authorized_connection)
     end
 
     def clean_connection

--- a/lib/active_fedora/inbound_relation_connection.rb
+++ b/lib/active_fedora/inbound_relation_connection.rb
@@ -1,4 +1,6 @@
 module ActiveFedora
+  # Use this connection judiciously, on fedora 4.3, these requests
+  # may be 3-5x slower, and make a graph that takes longer to parse.
   class InboundRelationConnection < SimpleDelegator
     def get(*args)
       result = __getobj__.get(*args) do |req|

--- a/spec/integration/indirect_container_spec.rb
+++ b/spec/integration/indirect_container_spec.rb
@@ -151,16 +151,13 @@ describe "Indirect containers" do
               file2.title = "Derp"
               o.save!
             end
+
             it "has two related_objects" do
               expect(reloaded.related_objects).to eq [file, file2]
             end
-            it "has inbound triples" do
-              statement = file.reload.resource.query(predicate: ::RDF::URI.new('http://www.openarchives.org/ore/terms/proxyFor')).to_a.first
-
-              expect(statement.object).to eq file.resource.rdf_subject
-            end
           end
         end
+
         describe "remove" do
           it "should be able to remove" do
             o.related_objects = []


### PR DESCRIPTION
The InboundRelation prefer header was causing a 3-5x performance
penalty. We can get the same info from Solr anyway.
Reverts #796
Fixes #875