### PR TITLE
Enable support for hash URIs.

### DIFF
--- a/lib/active_fedora/sparql_insert.rb
+++ b/lib/active_fedora/sparql_insert.rb
@@ -20,7 +20,7 @@ module ActiveFedora
       query +=
         changes.map do |_, result|
           result.map do |statement|
-            ::RDF::Query::Pattern.new(subject: subject, predicate: statement.predicate, object: statement.object).to_s
+            ::RDF::Query::Pattern.new(subject: pattern_subject(statement.subject), predicate: statement.predicate, object: statement.object).to_s
           end.join("\n")
         end.join("\n")
 
@@ -30,16 +30,51 @@ module ActiveFedora
 
     private
 
+    def pattern_subject(potential_subject)
+      if MaybeHashUri.new(potential_subject).hash?
+        potential_subject
+      else
+        subject
+      end
+    end
+
     def deletes(subject)
       patterns(subject).map do |pattern|
         "DELETE { #{pattern} }\n  WHERE { #{pattern} } ;\n"
       end
     end
 
+    # Returns query patterns for finding all existing changed properties as well
+    # as well as their embedded hash-uri graphs.
+    # 
+    # @return [Array<::RDF::Query::Pattern>]
     def patterns(subject)
-      changes.map do |key, _|
-        ::RDF::Query::Pattern.new(subject, key, :change).to_s
+      changes.flat_map do |key, result|
+        [
+          ::RDF::Query::Pattern.new(subject, key, :change).to_s,
+          hash_patterns(result)
+        ].flatten
       end
+    end
+
+    def hash_patterns(graph)
+      graph = graph.select do |statement|
+        MaybeHashUri.new(statement.subject).hash?
+      end
+      graph.map do |statement|
+        ::RDF::Query::Pattern.new(statement.subject, statement.predicate, :change).to_s
+      end
+    end
+  end
+
+  class MaybeHashUri
+    attr_reader :uri
+    def initialize(uri)
+      @uri = uri
+    end
+
+    def hash?
+      uri.to_s.include?("#")
     end
   end
 end

--- a/spec/integration/nested_hash_resources_spec.rb
+++ b/spec/integration/nested_hash_resources_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe "nested hash resources" do
+  before do
+    class NestedResource < ActiveTriples::Resource
+      property :title, predicate: ::RDF::DC.title
+      ## Necessary to get AT to create hash URIs.
+      def initialize(uri, parent)
+        if uri.try(:node?)
+          uri = RDF::URI("#nested_#{uri.to_s.gsub('_:','')}")
+        elsif uri.start_with?("#")
+          uri = RDF::URI(uri)
+        end
+        super
+      end
+
+      def final_parent
+        parent
+      end
+    end
+    class ExampleOwner < ActiveFedora::Base
+      property :relation, predicate: ::RDF::DC.relation, class_name: NestedResource
+      accepts_nested_attributes_for :relation
+    end
+  end
+  after do
+    Object.send(:remove_const, :NestedResource)
+    Object.send(:remove_const, :ExampleOwner)
+  end
+  it "should be able to nest resources" do
+    obj = ExampleOwner.new
+    obj.attributes = {
+      :relation_attributes => [
+        {
+          :title => "Test"
+        }
+      ]
+    }
+    obj.save!
+
+    expect(obj.reload.relation.first.title).to eq ["Test"]
+  end
+end

--- a/spec/unit/change_set_spec.rb
+++ b/spec/unit/change_set_spec.rb
@@ -46,6 +46,15 @@ describe ActiveFedora::ChangeSet do
         base.title = nil
         expect(subject[RDF::DC.title].to_a).to eq []
       end
+      it "should include hash URIs" do
+        # This is useful as an alternative to blank nodes.
+        hash_uri = RDF::URI(base.uri.to_s + "#test")
+        base.resource << RDF::Statement.new(hash_uri, RDF::DC.title, "good")
+        base.title = [RDF::URI(hash_uri)]
+        expect(subject[RDF::DC.title].to_a).not_to eq []
+        # Include the title reference and the title for the hash URI
+        expect(subject[RDF::DC.title].to_a.length).to eq 2
+      end
     end
 
     it { is_expected.to_not be_empty }


### PR DESCRIPTION
This allows for nested resources without using blank nodes.