### PR TITLE
Fix issues with checking the _destroy flag in nested_attributes

### DIFF
--- a/spec/integration/nested_attribute_spec.rb
+++ b/spec/integration/nested_attribute_spec.rb
@@ -4,7 +4,7 @@ describe "NestedAttribute behavior" do
   before do
     class Bar < ActiveFedora::Base
       belongs_to :car, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.hasMember
-      has_metadata :type=>ActiveFedora::SimpleDatastream, :name=>"someData" do |m|
+      has_metadata type: ActiveFedora::SimpleDatastream, name: "someData" do |m|
         m.field "uno", :string
         m.field "dos", :string
       end
@@ -16,22 +16,22 @@ describe "NestedAttribute behavior" do
     # base Car class, used in test for association updates and :allow_destroy flag
     class Car < ActiveFedora::Base
       has_many :bars, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.hasMember
-      accepts_nested_attributes_for :bars, :allow_destroy=>true
+      accepts_nested_attributes_for :bars, allow_destroy: true
     end
 
-    # class used in test for :reject_if=>:all_blank
+    # class used in test for reject_if: :all_blank
     class CarAllBlank < Car
-      accepts_nested_attributes_for :bars, :reject_if=>:all_blank
+      accepts_nested_attributes_for :bars, reject_if: :all_blank
     end
 
-    # class used in test for :reject_if with proc object
+    # class used in test for reject_if: with proc object
     class CarProc < Car
-      accepts_nested_attributes_for :bars, :reject_if=>proc { |attributes| attributes['uno'].blank? }
+      accepts_nested_attributes_for :bars, reject_if: proc { |attributes| attributes['uno'].blank? }
     end
 
-    # class used in test for :reject_if with method name as symbol
+    # class used in test for reject_if: with method name as symbol
     class CarSymbol < Car
-      accepts_nested_attributes_for :bars, :reject_if=>:uno_blank
+      accepts_nested_attributes_for :bars, reject_if: :uno_blank
 
       def uno_blank(attributes)
         attributes['uno'].blank?
@@ -40,7 +40,7 @@ describe "NestedAttribute behavior" do
 
     # class used in test for :limit
     class CarWithLimit < Car
-      accepts_nested_attributes_for :bars, :limit => 1
+      accepts_nested_attributes_for :bars, limit: 1
     end
   end
   after do
@@ -52,80 +52,83 @@ describe "NestedAttribute behavior" do
     Object.send(:remove_const, :Car)
   end
 
+  let(:car_class) { Car }
+  let(:bar_class) { Bar }
+  let(:car_no_bars) { car_class.create }
+  let(:car_with_bars) { bar1; bar2; car_no_bars }
+  let(:car) { car_with_bars }
+  let(:bar1) { bar_class.create(car: car_no_bars) }
+  let(:bar2) { bar_class.create(car: car_no_bars) }
+
+
   it "should have _destroy" do
     expect(Bar.new._destroy).to be_nil
   end
 
   it "should update the child objects" do
-    @car, @bar1, @bar2 = create_car_with_bars
+    car.update bars_attributes: [{id: bar1.id, uno: "bar1 uno"}, {uno: "newbar uno"}, {id: bar2.id, _destroy: '1', uno: 'bar2 uno'}]
+    expect(Bar.find(bar1.id).uno).to eq 'bar1 uno'
+    expect(Bar.where(id: bar2.id).first).to be_nil
+    expect(Bar.where(uno: "newbar uno").first).to_not be_nil
 
-    @car.update bars_attributes: [{id: @bar1.id, uno: "bar1 uno"}, {uno: "newbar uno"}, {id: @bar2.id, _destroy: '1', uno: 'bar2 uno'}]
-    expect(Bar.find(@bar1.id).uno).to eq 'bar1 uno'
-    expect(Bar.where(:id => @bar2.id).first).to be_nil
-    expect(Bar.where(:uno => "newbar uno").first).to_not be_nil
-
-    bars = @car.bars(true)
-    expect(bars).to include(@bar1)
-    expect(bars).to_not include(@bar2)
+    bars = car.bars(true)
+    expect(bars).to include(bar1)
+    expect(bars).to_not include(bar2)
   end
 
-  it "should reject attributes when all blank" do
-    @car, @bar1, @bar2 = create_car_with_bars(CarAllBlank)
+  describe "reject_if: :all_blank" do
+    let(:car_class) { CarAllBlank }
+    it "should reject attributes when all blank" do
+      expect(car.bars.count).to eq 2
+      car.update bars_attributes: [{}, {id: bar1.id, uno: "bar1 uno"}]
+      expect(car.bars(true).count).to eq 2
 
-    expect(@car.bars.count).to eq 2
-    @car.update bars_attributes: [{}, {:id=>@bar1.id, :uno=>"bar1 uno"}]
-    expect(@car.bars(true).count).to eq 2
-
-    @bar1.reload
-    expect(@bar1.uno).to eq "bar1 uno"
+      bar1.reload
+      expect(bar1.uno).to eq "bar1 uno"
+    end
   end
 
-  it "should reject attributes based on proc" do
-    @car, @bar1, @bar2 = create_car_with_bars(CarProc)
-
-    @car.update bars_attributes: [{}, {:id=>@bar1.id, :uno=>"bar1 uno"}, {:id=>@bar2.id, :dos=>"bar2 dos"}]
-    @bar1.reload
-    @bar2.reload
-    expect(@bar1.uno).to eq "bar1 uno"
-    expect(@bar2.dos).to be_nil
+  describe "reject_if: with a proc" do
+    let(:car_class) { CarProc }
+    it "should reject attributes based on proc" do
+      car.update bars_attributes: [{}, {id: bar1.id, uno: "bar1 uno"}, {id: bar2.id, dos: "bar2 dos"}]
+      bar1.reload
+      bar2.reload
+      expect(bar1.uno).to eq "bar1 uno"
+      expect(bar2.dos).to be_nil
+    end
   end
 
-  it "should reject attributes base on method name" do
-    @car, @bar1, @bar2 = create_car_with_bars(CarSymbol)
-
-    @car.update bars_attributes: [{}, {:id=>@bar1.id, :uno=>"bar1 uno"}, {:id=>@bar2.id, :dos=>"bar2 dos"}]
-    @bar1.reload
-    @bar2.reload
-    expect(@bar1.uno).to eq "bar1 uno"
-    expect(@bar2.dos).to be_nil
+  describe "allow_destroy: false" do
+    let(:car_class) { CarProc }
+    it "should create a new record even if _destroy is set" do
+      expect(car.bars.count).to eq 2
+      car.update bars_attributes: [{uno: "new uno", _destroy: "1"}]
+      expect(car.bars(true).count).to eq 3
+    end
   end
 
-  it "should throw TooManyRecords" do
-    @car, @bar1, @bar2 = create_car_with_bars(CarWithLimit)
-
-    expect {
-      @car.attributes = {:bars_attributes=>[{}]}
-    }.to_not raise_exception
-
-    expect {
-      @car.attributes = {:bars_attributes=>[{}, {}]}
-    }.to raise_exception(ActiveFedora::NestedAttributes::TooManyRecords)
+  describe "reject_if: with a symbol" do
+    let(:car_class) { CarSymbol }
+    it "should reject attributes base on method name" do
+      car.update bars_attributes: [{}, {id: bar1.id, uno: "bar1 uno"}, {id: bar2.id, dos: "bar2 dos"}]
+      bar1.reload
+      bar2.reload
+      expect(bar1.uno).to eq "bar1 uno"
+      expect(bar2.dos).to be_nil
+    end
   end
 
-  private
+  describe "limit" do
+    let(:car_class) { CarWithLimit }
+    it "should throw TooManyRecords" do
+      expect {
+        car.attributes = {bars_attributes: [{}]}
+      }.to_not raise_exception
 
-  # Helper method used to create 1 Car and 2 Bars (with option to provide classes for both models)
-  #
-  # @param car_class [class] class for new `car` object, default Car
-  # @param bar_class [class] class for new `bar` object, default Bar
-  #
-  # @return [car,bar,bar] returns 1 Car and 2 Bars
-  def create_car_with_bars(car_class = Car, bar_class = Bar)
-    car = car_class.new; car.save!
-
-    bar1 = bar_class.new(car: car); bar1.save!
-    bar2 = bar_class.new(car: car); bar2.save!
-    [car, bar1, bar2]
+      expect {
+        car.attributes = {bars_attributes: [{}, {}]}
+      }.to raise_exception(ActiveFedora::NestedAttributes::TooManyRecords)
+    end
   end
-
 end


### PR DESCRIPTION
Fixes two related issues with _destroy flag in nested_attributes.

call_reject_if used to immediately return false if has_destroy_flag? returned true, even if the _destroy flag wouldn't actually destroy the record. Thus you could circumvent the reject_if check in some cases. This would happen for new records (id is blank) or if allow_destroy is not set in the options. Now reject_if call is skipped only if _destroy flag is set and allow_destroy is set in options.

This still leaves the issue of having a blank id (i.e. a new record), _destroy flag being set and allow_destroy set in the options. This used to create the new record and not do anything with the _destroy flag. What's more the reject_if checks were skipped. I changed the behaviour when both id is left blank and _destroy flag is set. Instead of creating a new record it will simply skip the whole thing doing nothing with it. I think this is also the more logical behaviour, it's as if a new record was created and then immediately destroyed.