### PR TITLE
Update README to reflect dependency on Solr 4.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Description
 ActiveFedora is a Ruby gem for creating and
 managing objects in the Fedora Repository Architecture
 ([http://fedora-commons.org](http://fedora-commons.org)). ActiveFedora
-is loosely based on “ActiveRecord” in Rails. Version 9.0+ works with Fedora 4 and prior versions work on Fedora 3.
+is loosely based on “ActiveRecord” in Rails. Version 9.0+ works with Fedora 4 and prior versions work on Fedora 3. Version 9.2+ works with Solr 4.10.
 
 Getting Help
 ------------


### PR DESCRIPTION
https://github.com/projecthydra/active_fedora/commit/5b6da6d141bf8cf2dca2e0948972019865ead28b introduces the use of Solr's TermsQParser which was introduced in Solr 4.10.  Earlier versions of Solr are not compatible.