### PR TITLE
Update ldp gem to 0.4.0.

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rdf-rdfxml", '~> 1.1.0'
   s.add_dependency "linkeddata"
   s.add_dependency "deprecation"
-  s.add_dependency "ldp", '~> 0.3.1'
+  s.add_dependency "ldp", '~> 0.4.0'
 
   s.add_development_dependency "rdoc"
   s.add_development_dependency "yard"


### PR DESCRIPTION
This enables catching 409 conflicts as Ldp::Conflict rather than
Ldp::HttpError.  This is necessary because Fcrepo 4.3 changed the error
code from 400 to 409 when you tried to modify a system property