### PR TITLE
Moving a method to protected

### DIFF
--- a/lib/active_fedora/indexing_service.rb
+++ b/lib/active_fedora/indexing_service.rb
@@ -14,10 +14,6 @@ module ActiveFedora
       @profile_solr_name ||= ActiveFedora::SolrQueryBuilder.solr_name("object_profile", :displayable)
     end
 
-    def profile_service
-      ProfileIndexingService
-    end
-
     def rdf_service
       RDF::IndexingService
     end
@@ -42,6 +38,10 @@ module ActiveFedora
     end
 
     protected
+
+    def profile_service
+      ProfileIndexingService
+    end
 
     def c_time
       c_time = object.create_date.present? ? object.create_date : DateTime.now


### PR DESCRIPTION
This method was not called from outside of the object. This reduces
the outward facing API of the object.