### PR TITLE
Don't use Fcrepo digest predicate from rdf-vocab

### DIFF
--- a/lib/active_fedora/fixity_service.rb
+++ b/lib/active_fedora/fixity_service.rb
@@ -18,10 +18,18 @@ module ActiveFedora
     end
 
     def status
-      fixity_graph.query(predicate: ::RDF::Vocab::Fcrepo4.status).map(&:object).first.to_s
+      fixity_graph.query(predicate: status_predicate).map(&:object).first.to_s
     end
 
     private
+
+      # Fcrepo4.status was used by Fedora < 4.3, but it was removed
+      # from the 2015-07-24 version of the fedora 4 ontology
+      # http://fedora.info/definitions/v4/2015/07/24/repository and
+      # from rdf-vocab in version 0.8.5
+      def status_predicate
+        ::RDF::URI("http://fedora.info/definitions/v4/repository#status")
+      end
 
       def get_fixity_response_from_fedora
         uri = target + "/fcr:fixity"

--- a/spec/unit/file_spec.rb
+++ b/spec/unit/file_spec.rb
@@ -232,8 +232,10 @@ describe ActiveFedora::File do
     end
     context "with pre-4.3.0 predicate" do
       before do
+        predicate = ::RDF::URI("http://fedora.info/definitions/v4/repository#digest")
+        object = RDF::URI.new("urn:sha1:f1d2d2f924e986ac86fdf7b36c94bcdf32beec15")
         graph = ActiveTriples::Resource.new
-        graph << RDF::Statement.new(file.uri, RDF::Vocab::Fcrepo4.digest, RDF::URI.new("urn:sha1:f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"))
+        graph << RDF::Statement.new(file.uri, predicate, object)
         allow(file).to receive_message_chain(:metadata, :ldp_source, :graph).and_return(graph)
       end
       it "falls back on fedora:digest if premis:hasMessageDigest is not present" do


### PR DESCRIPTION
Fcrepo4.digest was used by Fedora < 4.2, but it was removed
from the 2015-07-24 version of the fedora 4 ontology
http://fedora.info/definitions/v4/2015/07/24/repository
and from rdf-vocab in version 0.8.5