### PR TITLE
Don't skip reject_if when _destroy is passed

### DIFF
--- a/spec/integration/nested_attribute_spec.rb
+++ b/spec/integration/nested_attribute_spec.rb
@@ -18,37 +18,9 @@ describe "NestedAttribute behavior" do
       has_many :bars, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.hasMember
       accepts_nested_attributes_for :bars, allow_destroy: true
     end
-
-    # class used in test for reject_if: :all_blank
-    class CarAllBlank < Car
-      accepts_nested_attributes_for :bars, reject_if: :all_blank
-    end
-
-    # class used in test for reject_if: with proc object
-    class CarProc < Car
-      accepts_nested_attributes_for :bars, reject_if: proc { |attributes| attributes['uno'].blank? }
-    end
-
-    # class used in test for reject_if: with method name as symbol
-    class CarSymbol < Car
-      accepts_nested_attributes_for :bars, reject_if: :uno_blank
-
-      def uno_blank(attributes)
-        attributes['uno'].blank?
-      end
-    end
-
-    # class used in test for :limit
-    class CarWithLimit < Car
-      accepts_nested_attributes_for :bars, limit: 1
-    end
   end
   after do
     Object.send(:remove_const, :Bar)
-    Object.send(:remove_const, :CarAllBlank)
-    Object.send(:remove_const, :CarProc)
-    Object.send(:remove_const, :CarSymbol)
-    Object.send(:remove_const, :CarWithLimit)
     Object.send(:remove_const, :Car)
   end
 
@@ -76,8 +48,15 @@ describe "NestedAttribute behavior" do
     expect(bars).to_not include(bar2)
   end
 
-  describe "reject_if: :all_blank" do
+  context "when reject_if: :all_blank" do
+    before do
+      class CarAllBlank < Car
+        accepts_nested_attributes_for :bars, reject_if: :all_blank
+      end
+    end
+
     let(:car_class) { CarAllBlank }
+    after { Object.send(:remove_const, :CarAllBlank) }
     it "should reject attributes when all blank" do
       expect(car.bars.count).to eq 2
       car.update bars_attributes: [{}, {id: bar1.id, uno: "bar1 uno"}]
@@ -88,29 +67,70 @@ describe "NestedAttribute behavior" do
     end
   end
 
-  describe "reject_if: with a proc" do
-    let(:car_class) { CarProc }
-    it "should reject attributes based on proc" do
-      car.update bars_attributes: [{}, {id: bar1.id, uno: "bar1 uno"}, {id: bar2.id, dos: "bar2 dos"}]
-      bar1.reload
-      bar2.reload
-      expect(bar1.uno).to eq "bar1 uno"
-      expect(bar2.dos).to be_nil
+  context "when reject_if attribute is supplied with a proc" do
+    before do
+      class CarProc < Car
+        accepts_nested_attributes_for :bars, reject_if: ->(attributes) { attributes['uno'].blank? }
+      end
     end
-  end
 
-  describe "allow_destroy: false" do
+    after { Object.send(:remove_const, :CarProc) }
     let(:car_class) { CarProc }
-    it "should create a new record even if _destroy is set" do
-      expect(car.bars.count).to eq 2
-      car.update bars_attributes: [{uno: "new uno", _destroy: "1"}]
-      expect(car.bars(true).count).to eq 3
+
+    context "and the reject_if proc evaluates to false" do
+      before do
+        car.update bars_attributes: [{}, { id: bar1.id, uno: "bar1 uno" }]
+      end
+      it "updates attributes" do
+        expect(bar1.reload.uno).to eq "bar1 uno"
+      end
+    end
+
+    context "and the reject_if proc evaluates to true" do
+      before do
+        car.update bars_attributes: [{}, { id: bar1.id, dos: "bar1 uno" }]
+      end
+      it "rejects attributes" do
+        expect(bar1.reload.dos).to be_nil
+      end
+    end
+
+    context "and `allow_destroy: false`" do
+      context "and the reject_if proc evaluates to true" do
+        before do
+          car.update bars_attributes: [{}, { id: bar1.id, dos: "bar1 uno", _destroy: "1" }]
+        end
+        it "rejects attributes (_destroy doesn't affect the outcome)" do
+          expect(bar1.reload.dos).to be_nil
+        end
+      end
+
+      context "a record with the destroy flag and without an id" do
+        it "creates a new record" do
+          expect {
+            car.update bars_attributes: [{ uno: "bar1 uno", _destroy: "1" }]
+          }.not_to change { car.bars(true).count }
+        end
+      end
     end
   end
 
   describe "reject_if: with a symbol" do
+    before do
+      # class used in test for reject_if: with method name as symbol
+      class CarSymbol < Car
+        accepts_nested_attributes_for :bars, reject_if: :uno_blank
+
+        def uno_blank(attributes)
+          attributes['uno'].blank?
+        end
+      end
+    end
+
+    after { Object.send(:remove_const, :CarSymbol) }
     let(:car_class) { CarSymbol }
-    it "should reject attributes base on method name" do
+
+    it "rejects attributes based on method name" do
       car.update bars_attributes: [{}, {id: bar1.id, uno: "bar1 uno"}, {id: bar2.id, dos: "bar2 dos"}]
       bar1.reload
       bar2.reload
@@ -119,7 +139,31 @@ describe "NestedAttribute behavior" do
     end
   end
 
+  describe "allow_destroy: true" do
+    before do
+      class CarDestroy < Car
+        accepts_nested_attributes_for :bars, allow_destroy: true
+      end
+    end
+
+    let(:car_class) { CarDestroy }
+    after { Object.send(:remove_const, :CarDestroy) }
+
+    it "doesn't create a new record if _destroy is set" do
+      expect {
+        car.update bars_attributes: [{ uno: "new uno", _destroy: "1" }]
+      }.not_to change { car.bars(true).count }
+    end
+  end
+
   describe "limit" do
+    before do
+      class CarWithLimit < Car
+        accepts_nested_attributes_for :bars, limit: 1
+      end
+    end
+    after { Object.send(:remove_const, :CarWithLimit) }
+
     let(:car_class) { CarWithLimit }
     it "should throw TooManyRecords" do
       expect {

--- a/spec/integration/nested_attribute_spec.rb
+++ b/spec/integration/nested_attribute_spec.rb
@@ -4,13 +4,8 @@ describe "NestedAttribute behavior" do
   before do
     class Bar < ActiveFedora::Base
       belongs_to :car, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.hasMember
-      has_metadata type: ActiveFedora::SimpleDatastream, name: "someData" do |m|
-        m.field "uno", :string
-        m.field "dos", :string
-      end
-      Deprecation.silence(ActiveFedora::Attributes) do
-        has_attributes :uno, :dos, datastream: 'someData', multiple: false
-      end
+      property :uno, predicate: ::RDF::URI('http://example.com/uno'), multiple: false
+      property :dos, predicate: ::RDF::URI('http://example.com/dos'), multiple: false
     end
 
     # base Car class, used in test for association updates and :allow_destroy flag
@@ -25,12 +20,9 @@ describe "NestedAttribute behavior" do
   end
 
   let(:car_class) { Car }
-  let(:bar_class) { Bar }
-  let(:car_no_bars) { car_class.create }
-  let(:car_with_bars) { bar1; bar2; car_no_bars }
-  let(:car) { car_with_bars }
-  let(:bar1) { bar_class.create(car: car_no_bars) }
-  let(:bar2) { bar_class.create(car: car_no_bars) }
+  let(:car) { car_class.create }
+  let(:bar1) { Bar.create(car: car) }
+  let(:bar2) { Bar.create(car: car) }
 
 
   it "should have _destroy" do
@@ -39,9 +31,7 @@ describe "NestedAttribute behavior" do
 
   it "should update the child objects" do
     car.update bars_attributes: [{id: bar1.id, uno: "bar1 uno"}, {uno: "newbar uno"}, {id: bar2.id, _destroy: '1', uno: 'bar2 uno'}]
-    expect(Bar.find(bar1.id).uno).to eq 'bar1 uno'
-    expect(Bar.where(id: bar2.id).first).to be_nil
-    expect(Bar.where(uno: "newbar uno").first).to_not be_nil
+    expect(Bar.all.map(&:uno)).to match_array ['bar1 uno', 'newbar uno']
 
     bars = car.bars(true)
     expect(bars).to include(bar1)
@@ -57,6 +47,10 @@ describe "NestedAttribute behavior" do
 
     let(:car_class) { CarAllBlank }
     after { Object.send(:remove_const, :CarAllBlank) }
+    let(:car) { car_class.create }
+    let!(:bar1) { Bar.create(car: car) }
+    let!(:bar2) { Bar.create(car: car) }
+
     it "should reject attributes when all blank" do
       expect(car.bars.count).to eq 2
       car.update bars_attributes: [{}, {id: bar1.id, uno: "bar1 uno"}]


### PR DESCRIPTION
Nested attributes was previously skiping the check of the reject_if proc
if the _destroy flag was passed. This was occuring when allow_destroy
was false, so the record was getting updated. Thanks to @ojlyytinen for
finding this bug and the orignal work on PR #879 from which this PR is
inspired.