### PR TITLE
query for nil creates correct query

### DIFF
--- a/lib/active_fedora/relation/calculations.rb
+++ b/lib/active_fedora/relation/calculations.rb
@@ -8,12 +8,12 @@ module ActiveFedora
       opts = {}
       opts[:rows] = limit_value if limit_value
       opts[:sort] = order_values if order_values
-      
+
       calculate :count, where_values, opts
     end
 
     def calculate(calculation, conditions, opts={})
-      SolrService.query(create_query(conditions), :raw=>true, :rows=>0)['response']['numFound']
+      SolrService.query(create_query(conditions), raw: true, rows: 0).fetch('response'.freeze)['numFound'.freeze]
     end
   end
 end

--- a/lib/active_fedora/relation/query_methods.rb
+++ b/lib/active_fedora/relation/query_methods.rb
@@ -17,7 +17,7 @@ module ActiveFedora
     def where_values=(values)
       raise ImmutableRelation if @loaded
       @values[:where] = values
-    end   
+    end
 
     def order_values
       @values[:order] || []
@@ -62,11 +62,13 @@ module ActiveFedora
       self
     end
 
+    # @param [Hash,String] values
+    # @return [Array<String>] list of solr hashes
     def build_where(values)
       return [] if values.blank?
       case values
       when Hash
-        [create_query_from_hash(values)]
+        create_query_from_hash(values)
       when String
         ["(#{values})"]
       else
@@ -76,7 +78,7 @@ module ActiveFedora
 
     # Order the returned records by the field and direction provided
     #
-    # @option [Array<String>] args a list of fields and directions to sort by 
+    # @option [Array<String>] args a list of fields and directions to sort by
     #
     # @example
     #  Person.where(occupation_s: 'Plumber').order('name_t desc', 'color_t asc')

--- a/lib/active_fedora/solr_service.rb
+++ b/lib/active_fedora/solr_service.rb
@@ -103,8 +103,8 @@ module ActiveFedora
 
       def query(query, args={})
         raw = args.delete(:raw)
-        args = args.merge(:q=>query, :qt=>'standard')
-        result = SolrService.instance.conn.get('select', :params=>args)
+        args = args.merge(q: query, qt: 'standard')
+        result = SolrService.instance.conn.get('select', params: args)
         return result if raw
         result['response']['docs']
       end

--- a/spec/integration/scoped_query_spec.rb
+++ b/spec/integration/scoped_query_spec.rb
@@ -30,7 +30,6 @@ describe "scoped queries" do
     Object.send(:remove_const, :ModelIntegrationSpec)
   end
 
-
   describe "When there is one object in the store" do
     let!(:test_instance) { ModelIntegrationSpec::Basic.create!()}
 
@@ -67,7 +66,7 @@ describe "scoped queries" do
         test_instance3.delete
       end
 
-      it "should query" do
+      it "queries" do
         field = ActiveFedora::SolrQueryBuilder.solr_name('foo', type: :string)
         expect(ModelIntegrationSpec::Basic.where(field => 'Beta')).to eq [test_instance1]
         expect(ModelIntegrationSpec::Basic.where('foo' => 'Beta')).to eq [test_instance1]
@@ -90,8 +89,13 @@ describe "scoped queries" do
         expect(ModelIntegrationSpec::Basic.where("foo:bar OR bar:baz").where_values).to eq ["(foo:bar OR bar:baz)"]
       end
 
-      it "should chain where queries" do
-        expect(ModelIntegrationSpec::Basic.where(ActiveFedora::SolrQueryBuilder.solr_name('bar', type: :string) => 'Peanuts').where("#{ActiveFedora::SolrQueryBuilder.solr_name('foo', type: :string)}:bar").where_values).to eq ["#{ActiveFedora::SolrQueryBuilder.solr_name('bar', type: :string)}:Peanuts", "(#{ActiveFedora::SolrQueryBuilder.solr_name('foo', type: :string)}:bar)"]
+      it "chains where queries" do
+        first_condition = { ActiveFedora::SolrQueryBuilder.solr_name('bar', type: :string) => 'Peanuts' }
+        second_condition = "foo_tesim:bar"
+        where_values = ModelIntegrationSpec::Basic.where(first_condition)
+                                                    .where(second_condition).where_values
+        expect(where_values).to eq ["bar_tesim:Peanuts",
+                                    "(foo_tesim:bar)"]
       end
 
       it "should chain count" do

--- a/spec/unit/finder_methods_spec.rb
+++ b/spec/unit/finder_methods_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe ActiveFedora::FinderMethods do
+  let(:object_class) do
+    Class.new do
+      def self.delegated_attributes
+        {}
+      end
+    end
+  end
+
+  let(:finder_class) do
+    this = self
+    Class.new do
+      include ActiveFedora::FinderMethods
+      @@klass = this.object_class
+      def initialize
+        @klass = @@klass
+      end
+    end
+  end
+
+  let(:finder) { finder_class.new }
+
+  describe "#condition_to_clauses" do
+    subject { finder.send(:condition_to_clauses, key, value) }
+    let(:key) { 'library_id' }
+
+    context "when value is nil" do
+      let(:value) { nil }
+      it { is_expected.to eq "-library_id:[* TO *]" }
+    end
+
+    context "when value is empty string" do
+      let(:value) { '' }
+      it { is_expected.to eq "-library_id:[* TO *]" }
+    end
+
+    context "when value is an id" do
+      let(:value) { 'one/two/three' }
+      it { is_expected.to eq "_query_:\"{!raw f=library_id}one/two/three\"" }
+    end
+
+    context "when value is an array" do
+      let(:value) { ['one', 'four'] }
+      it { is_expected.to eq "_query_:\"{!raw f=library_id}one\" AND " \
+                             "_query_:\"{!raw f=library_id}four\"" }
+    end
+  end
+end

--- a/spec/unit/solr_config_options_spec.rb
+++ b/spec/unit/solr_config_options_spec.rb
@@ -27,11 +27,15 @@ describe ActiveFedora do
       expect(@test_object.to_solr[:id]).to be_nil
     end
 
-    it "should be used by ActiveFedora::Base#find_with_conditions" do
+    it "is used by ActiveFedora::Base#find_with_conditions" do
       mock_response = double("SolrResponse")
-      expect(ActiveFedora::SolrService).to receive(:query).with("_query_:\"{!raw f=#{ActiveFedora::SolrQueryBuilder.solr_name("has_model", :symbol)}}SolrSpecModel::Basic\" AND " + SOLR_DOCUMENT_ID + ':changeme\\:30', {:sort => ["#{ActiveFedora::SolrQueryBuilder.solr_name("system_create", :stored_sortable, type: :date)} asc"]}).and_return(mock_response)
+      expect(ActiveFedora::SolrService).to receive(:query)
+        .with("_query_:\"{!raw f=has_model_ssim}SolrSpecModel::Basic\" AND " \
+              "_query_:\"{!raw f=MY_SAMPLE_ID}changeme:30\"",
+              sort: ["#{ActiveFedora::SolrQueryBuilder.solr_name("system_create", :stored_sortable, type: :date)} asc"])
+        .and_return(mock_response)
 
-      expect(SolrSpecModel::Basic.find_with_conditions(:id=>"changeme:30")).to equal(mock_response)
+      expect(SolrSpecModel::Basic.find_with_conditions(id: "changeme:30")).to equal(mock_response)
     end
   end
 


### PR DESCRIPTION
Previously querying for a field to be nil (e.g. library_id: nil) would
just ignore that restriction and return all records. Now it actually
queryies for records that don't have library_id set (e.g. `-library_id:[*
TO *]`) Fixes #910