### PR TITLE
Load create_date and modified_date from Solr.

### DIFF
--- a/lib/active_fedora/indexing_service.rb
+++ b/lib/active_fedora/indexing_service.rb
@@ -19,6 +19,14 @@ module ActiveFedora
       @profile_solr_name ||= ActiveFedora::SolrQueryBuilder.solr_name("object_profile", :displayable)
     end
 
+    def self.create_time_solr_name
+      @create_time_solr_name ||= ActiveFedora::SolrQueryBuilder.solr_name('system_create', :stored_sortable, type: :date)
+    end
+
+    def self.modified_time_solr_name
+      @modified_time_solr_name ||= ActiveFedora::SolrQueryBuilder.solr_name('system_modified', :stored_sortable, type: :date)
+    end
+
     def rdf_service
       RDF::IndexingService
     end

--- a/lib/active_fedora/loadable_from_json.rb
+++ b/lib/active_fedora/loadable_from_json.rb
@@ -109,6 +109,8 @@ module ActiveFedora
     end
 
     # @param json [String] json to be parsed into attributes
+    # @yield [self] Yields self after attributes from json have been assigned
+    #               but before callbacks and before the object is frozen.
     def init_with_json(json)
       attrs = JSON.parse(json)
       id = attrs.delete('id')
@@ -122,6 +124,8 @@ module ActiveFedora
       @resource = SolrBackedResource.new(self.class)
       self.attributes = adapt_attributes(attrs)
       # TODO: Should we clear the change tracking, or make this object Read-only?
+
+      yield self if block_given?
 
       run_callbacks :find
       run_callbacks :initialize

--- a/lib/active_fedora/querying.rb
+++ b/lib/active_fedora/querying.rb
@@ -9,7 +9,7 @@ module ActiveFedora
     end
 
     def default_sort_params
-      [ActiveFedora::SolrQueryBuilder.solr_name(:system_create, :stored_sortable, type: :date) + ' asc']
+      [indexer.create_time_solr_name + ' asc']
     end
   end
 end

--- a/lib/active_fedora/solr_instance_loader.rb
+++ b/lib/active_fedora/solr_instance_loader.rb
@@ -27,7 +27,12 @@ module ActiveFedora
     private
 
       def allocate_object
-        active_fedora_class.allocate.init_with_json(profile_json)
+        active_fedora_class.allocate.init_with_json(profile_json) do |allocated_object|
+          create_key = allocated_object.indexing_service.class.create_time_solr_name
+          modified_key = allocated_object.indexing_service.class.modified_time_solr_name
+          allocated_object.resource.set_value(:create_date, DateTime.parse(solr_doc[create_key])) if solr_doc[create_key]
+          allocated_object.resource.set_value(:modified_date, DateTime.parse(solr_doc[modified_key])) if solr_doc[modified_key]
+        end
       end
 
       def solr_doc

--- a/spec/integration/solr_instance_loader_spec.rb
+++ b/spec/integration/solr_instance_loader_spec.rb
@@ -142,4 +142,19 @@ describe ActiveFedora::SolrInstanceLoader do
       end
     end
   end
+
+  describe "loading system properties" do
+    let(:obj_solr) { Foo.load_instance_from_solr(obj.id) }
+    it "loads create_date from solr" do
+      expect(obj.create_date).to be_present
+      expect(obj_solr).to be_present
+      expect(obj_solr.create_date).to be_a DateTime
+    end
+
+    it "loads modified_date from solr" do
+      expect(obj.modified_date).to be_present
+      expect(obj_solr).to be_present
+      expect(obj_solr.modified_date).to be_a DateTime
+    end
+  end
 end


### PR DESCRIPTION
Fixes #905. Trying to access create_date or modified_date in objects loaded from Solr used to raise an error. They are now loaded properly from the Solr properties system_create and system_modified.