### PR TITLE
Save time zone information for DateTimes. Solr returns DateTimes rather than Strings.

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -14,20 +14,21 @@ ENABLE_SOLR_UPDATES = true unless defined?(ENABLE_SOLR_UPDATES)
 
 # Monkey patching RDF::Literal::DateTime to support fractional seconds.
 # See https://github.com/projecthydra/active_fedora/issues/497
+# Also monkey patches in a fix for timezones to be stored properly.
 module RDF
   class Literal
     class DateTime < Literal
       ALTERNATIVE_FORMAT   = '%Y-%m-%dT%H:%M:%S'.freeze
       DOT                  = '.'.freeze
-      Z                    = 'Z'.freeze
       EMPTY                = ''.freeze
+      TIMEZONE_FORMAT      = '%z'.freeze
 
       def to_s
         @string ||= begin
           # Show nanoseconds but remove trailing zeros
           nano = @object.strftime('%N').sub(/0+\Z/, EMPTY)
           nano = DOT + nano unless nano.blank?
-          @object.strftime(ALTERNATIVE_FORMAT) + nano + Z
+          @object.strftime(ALTERNATIVE_FORMAT) + nano + @object.strftime(TIMEZONE_FORMAT)
         end
       end
     end

--- a/lib/active_fedora/loadable_from_json.rb
+++ b/lib/active_fedora/loadable_from_json.rb
@@ -131,8 +131,7 @@ module ActiveFedora
 
     private
 
-      # Adapt attributes read from Solr to possible minor changes in data model
-      # since the attributes were saved.
+      # Adapt attributes read from Solr to fit the data model.
       # @param attrs [Hash] attributes read from Solr
       # @return [Hash] the adapted attributes
       def adapt_attributes(attrs)
@@ -141,24 +140,44 @@ module ActiveFedora
         end
       end
 
-      # Adapts a single attribute value from the given attributes hash to match
-      # minor changes in the data model.
+      # Adapts a single attribute from the given attributes hash to fit the data
+      # model.
       # @param attrs [Hash] attributes read from Solr
       # @param attribute_name [String] the name of the attribute to adapt
       # @return [Object] the adapted value
       def adapt_attribute_value(attrs, attribute_name)
         reflection = self.class.reflect_on_property(attribute_name)
-        if !reflection
-          return attrs[attribute_name] # if this isn't a property, copy value verbatim
-        else
-          multiple = reflection.multiple?
-          if !attrs.key?(attribute_name)
-            # value is missing in attrs, add [] or nil
-            return multiple ? [] : nil
-          else
-            # convert an existing scalar to an array if needed
-            return multiple ? Array(attrs[attribute_name]) : attrs[attribute_name]
+        # if this isn't a property, copy value verbatim
+        return attrs[attribute_name] unless reflection
+        multiple = reflection.multiple?
+        # if value is missing in attrs, return [] or nil as appropriate
+        return multiple ? [] : nil unless attrs.key?(attribute_name)
+
+        if multiple
+          Array(attrs[attribute_name]).map do |value|
+            adapt_single_attribute_value(value, attribute_name)
           end
+        else
+          adapt_single_attribute_value(attrs[attribute_name], attribute_name)
+        end
+      end
+
+      def date_attribute?(attribute_name)
+        reflection = self.class.reflect_on_property(attribute_name)
+        return false unless reflection
+        reflection.type == :date || reflection.class_name == DateTime
+      end
+
+      # Adapts a single attribute value to fit the data model. If the attribute
+      # is multi-valued, each value is passed separately to this method.
+      # @param value [Object] attribute value read from Solr
+      # @param attribute_name [String] the name of the attribute to adapt
+      # @return [Object] the adapted value
+      def adapt_single_attribute_value(value, attribute_name)
+        if date_attribute?(attribute_name)
+          DateTime.parse(value)
+        else
+          value
         end
       end
   end

--- a/spec/integration/date_time_properties_spec.rb
+++ b/spec/integration/date_time_properties_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe ActiveFedora::Base do
+  before do
+    class Foo < ActiveFedora::Base
+      # Date attributes are recognized by having index.type :Date or class_name: 'DateTime'
+      property :date, predicate: ::RDF::DC.date do |index|
+        index.type :date
+      end
+      property :single_date, multiple: false, class_name: 'DateTime', predicate: ::RDF::URI.new('http://www.example.com/single_date')
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :Foo)
+  end
+
+  let(:date) { DateTime.parse("2015-10-22T10:20:03.653+01:00") }
+  let(:date2) { DateTime.parse("2015-10-22T15:34:20.323-11:00") }
+  subject { Foo.create(date: [date], single_date: date2).reload }
+
+  describe "saving and loading in Fedora" do
+    it "loads the correct time" do
+      expect(subject.date.first).to eql date
+      expect(subject.single_date).to eql date2
+    end
+  end
+
+  describe "saving and loading in Solr" do
+    let(:subject_solr) { subject.class.load_instance_from_solr(subject.id) }
+    it "uses DateTime objects" do
+      expect(subject_solr.date.first).to be_a DateTime
+      expect(subject_solr.single_date).to be_a DateTime
+    end
+    it "loads the correct time" do
+      expect(subject_solr.date.first).to eql date
+      expect(subject_solr.single_date).to eql date2
+    end
+  end
+end


### PR DESCRIPTION
As it stands, time zone information is not stored in Fedora, instead it's just always set to Z. All time information is effectively shifted by your local time offset if you take time zones into account. This results in unexpected behaviour where timestamps for example end up in the future if your local time zone offset is positive.

```ruby
class Foo < ActiveFedora::Base
  property :date, predicate: ::RDF::DC.date do |index|
    index.type :date
  end
end

foo = Foo.create(date: [DateTime.now])
sleep 1
foo.date.first > DateTime.now # => true assuming your time offset is positive
```

There seems to be a bug in RDF::Literal::DateTime#to_s which prints out time zone as Z if you initialise the object with a DateTime rather than a String, so this should be fixed there. But a similar bug is present also in the monkey patch applied in [lib/active_fedora.rb](https://github.com/projecthydra/active_fedora/blob/master/lib/active_fedora.rb#L15-L35) which is fixed in this PR.

The PR also makes Solr-loaded documents return DateTime objects rather than Strings when indexing type has been set to date. What used to happen is that the same field which returned a DateTime object when loaded from Fedora would return a String when loaded from Solr.
