### PR TITLE
Avoid unnecessary loads

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,6 +70,7 @@ Metrics/ModuleLength:
     - 'lib/active_fedora/persistence.rb'
     - 'lib/active_fedora/attributes.rb'
     - 'lib/active_fedora/autosave_association.rb'
+    - 'lib/active_fedora/attached_files.rb'
 
 Metrics/ClassLength:
   Exclude:

--- a/lib/active_fedora/association_hash.rb
+++ b/lib/active_fedora/association_hash.rb
@@ -3,6 +3,8 @@ module ActiveFedora
   # Used as an access method for associations on a model, given some
   # reflections.
   class AssociationHash
+    attr_reader :base
+
     def initialize(model, reflections)
       @base = model
       @reflections = reflections
@@ -19,7 +21,7 @@ module ActiveFedora
     def association(name)
       # Check to see if the key exists before casting to a symbol, because symbols
       # are not garbage collected in earlier versions of Ruby
-      @base.association(name.to_sym) if key?(name)
+      base.association(name.to_sym) if key?(name)
     end
 
     attr_reader :reflections
@@ -68,10 +70,13 @@ module ActiveFedora
       end
     end
 
+    # returns the loaded files for with the passed block returns true
     def select
       keys.each_with_object({}) do |k, h|
-        val = self[k]
-        h[k] = val if yield k, val
+        if association(k).loaded?
+          val = self[k]
+          h[k] = val if yield k, val
+        end
       end
     end
 
@@ -91,6 +96,7 @@ module ActiveFedora
 
     def initialize(first, second)
       @first = first
+      @base = first.base
       @second = second
     end
 

--- a/lib/active_fedora/attached_files.rb
+++ b/lib/active_fedora/attached_files.rb
@@ -12,7 +12,14 @@ module ActiveFedora
     deprecation_deprecate :ds_specs
 
     def serialize_attached_files
-      attached_files.each_value(&:serialize!)
+      declared_attached_files.each_value(&:serialize!)
+    end
+
+    # Returns only the attached_files that are declared with 'contains'
+    def declared_attached_files
+      attached_files.reflections.keys.each_with_object({}) do |k, h|
+        h[k] = attached_files[k]
+      end
     end
 
     #

--- a/lib/active_fedora/indexing_service.rb
+++ b/lib/active_fedora/indexing_service.rb
@@ -34,7 +34,7 @@ module ActiveFedora
       solr_doc.merge!(QueryResultBuilder::HAS_MODEL_SOLR_FIELD => object.has_model)
       solr_doc.merge!(SOLR_DOCUMENT_ID.to_sym => object.id)
       solr_doc.merge!(self.class.profile_solr_name => profile_service.new(object).export)
-      object.attached_files.each do |name, file|
+      object.declared_attached_files.each do |name, file|
         solr_doc.merge! file.to_solr(solr_doc, name: name.to_s)
       end
       solr_doc = solrize_rdf_assertions(solr_doc)

--- a/spec/integration/persistence_spec.rb
+++ b/spec/integration/persistence_spec.rb
@@ -20,4 +20,21 @@ describe "persisting objects" do
       expect { MockAFBaseRelationship.create! }.to raise_error ActiveFedora::RecordInvalid, "Validation failed: Name can't be blank"
     end
   end
+
+  describe "#save" do
+    context "With undefined contains associations" do
+      let(:f1) { ActiveFedora::Base.create }
+      let!(:f2) { ActiveFedora::Base.create(id: "#{f1.id}/part2") }
+
+      before do
+        f1.reload # so it learns about f2
+      end
+
+      it "doesn't load the children" do
+        allow(f1).to receive(:update_index) # solrizing can load the attached files.
+        expect(ActiveFedora::File).not_to receive(:new)
+        f1.save
+      end
+    end
+  end
 end

--- a/spec/unit/attached_files_spec.rb
+++ b/spec/unit/attached_files_spec.rb
@@ -168,6 +168,33 @@ describe ActiveFedora::AttachedFiles do
     end
   end
 
+  describe "#declared_attached_files" do
+    subject { obj.declared_attached_files }
+
+    context "when there are undeclared attached files" do
+      let(:obj) { ActiveFedora::Base.create }
+      let(:file) { ActiveFedora::File.new }
+      before do
+        obj.attach_file(file, 'Abc')
+      end
+      it { is_expected.to be_empty }
+    end
+
+    context "when there are declared attached files" do
+      before do
+        class FooHistory < ActiveFedora::Base
+          contains 'thumbnail'
+        end
+      end
+
+      after do
+        Object.send(:remove_const, :FooHistory)
+      end
+      let(:obj) { FooHistory.new }
+      it { is_expected.to have_key :thumbnail }
+    end
+  end
+
   describe "#serialize_attached_files" do
     it "touches each file" do
       m1 = double
@@ -175,7 +202,7 @@ describe ActiveFedora::AttachedFiles do
 
       expect(m1).to receive(:serialize!)
       expect(m2).to receive(:serialize!)
-      allow(subject).to receive(:attached_files).and_return(m1: m1, m2: m2)
+      allow(subject).to receive(:declared_attached_files).and_return(m1: m1, m2: m2)
       subject.serialize_attached_files
     end
   end

--- a/spec/unit/indexing_spec.rb
+++ b/spec/unit/indexing_spec.rb
@@ -69,7 +69,7 @@ describe ActiveFedora::Indexing do
         expect(mock1).to receive(:to_solr).and_return("one" => "title one")
         expect(mock2).to receive(:to_solr).and_return("two" => "title two")
 
-        allow(test_object).to receive(:attached_files).and_return(ds1: mock1, ds2: mock2)
+        allow(test_object).to receive(:declared_attached_files).and_return(ds1: mock1, ds2: mock2)
         expect(subject).to include('one' => 'title one', 'two' => 'title two')
       end
     end


### PR DESCRIPTION
Previously AF was loading contained objects just to see if they had
changed or to save them.  This was unnecessary and costly.

Fixes #927 and Fixes #928