### PR TITLE
Fix issue where xml datastreams reverting after save, closes #913

### DIFF
--- a/lib/active_fedora/datastreams/nokogiri_datastreams.rb
+++ b/lib/active_fedora/datastreams/nokogiri_datastreams.rb
@@ -63,7 +63,7 @@ module ActiveFedora
       end
 
       def remote_content
-        @datastream_content ||= Nokogiri::XML(super).to_xml(&:no_declaration).strip
+        @ds_content ||= Nokogiri::XML(super).to_xml(&:no_declaration).strip
       end
 
       def content=(new_content)

--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -106,6 +106,7 @@ module ActiveFedora
       @mime_type = nil
       @content = nil
       @metadata = nil
+      @ds_content = nil
       changed_attributes.clear
     end
 

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -78,6 +78,32 @@ describe ActiveFedora::Base do
           it { is_expected.to eq 'one' }
         end
       end
+
+      context "when updating and saving a property" do
+        before do
+          class BarHistory4 < ActiveFedora::Base
+            has_metadata type: BarStream2, name: "xmlish"
+            property :cow, delegate_to: 'xmlish', multiple: false
+          end
+        end
+        after do
+          Object.send(:remove_const, :BarHistory4)
+        end
+
+        let(:obj) { BarHistory4.new }
+
+        before do
+          obj.cow = 'two'
+          obj.save
+          obj.attached_files[:xmlish].content
+          obj.cow = 'three'
+          obj.save
+        end
+        describe "the attached datastream" do
+          subject { obj.attached_files[:xmlish].content }
+          it { is_expected.to include '<cow>three</cow>' }
+        end
+      end
     end
 
     describe "first level delegation" do


### PR DESCRIPTION
Create failing test for issue with datastreams resetting to old version after save related to https://github.com/projecthydra/active_fedora/issues/913

lib/active_fedora/file.rb#refresh resets @ds_content
lib/active_fedora/datastreams/nokogiri_datastream.rb#remote_content change @datastream_content to @ds_content

Closes #913

Fixes an issue where xml datastreams were reverting to the old version after and edit and save.