### PR TITLE
Don't try to parse empty dates

### DIFF
--- a/lib/active_fedora/loadable_from_json.rb
+++ b/lib/active_fedora/loadable_from_json.rb
@@ -179,6 +179,7 @@ module ActiveFedora
       # @return [Object] the adapted value
       def adapt_single_attribute_value(value, attribute_name)
         if value && date_attribute?(attribute_name)
+          return nil unless value.present?
           DateTime.parse(value)
         else
           value

--- a/spec/integration/date_time_properties_spec.rb
+++ b/spec/integration/date_time_properties_spec.rb
@@ -7,8 +7,12 @@ describe ActiveFedora::Base do
       property :date, predicate: ::RDF::DC.date do |index|
         index.type :date
       end
+      property :integer, predicate: ::RDF::URI.new('http://www.example.com/integer'), multiple: false do |index|
+        index.type :integer
+      end
       property :single_date, multiple: false, class_name: 'DateTime', predicate: ::RDF::URI.new('http://www.example.com/single_date')
       property :missing_date, multiple: false, class_name: 'DateTime', predicate: ::RDF::URI.new('http://www.example.com/missing_date')
+      property :empty_date, multiple: false, class_name: 'DateTime', predicate: ::RDF::URI.new('http://www.example.com/empty_date')
     end
   end
 
@@ -18,7 +22,7 @@ describe ActiveFedora::Base do
 
   let(:date) { DateTime.parse("2015-10-22T10:20:03.653+01:00") }
   let(:date2) { DateTime.parse("2015-10-22T15:34:20.323-11:00") }
-  subject { Foo.create(date: [date], single_date: date2).reload }
+  subject { Foo.create(date: [date], single_date: date2, empty_date: '', integer: 1).reload }
 
   describe "saving and loading in Fedora" do
     it "loads the correct time" do


### PR DESCRIPTION
I'm getting `invalid date` when I have a date property that's empty: `''`

Not sure if this is a valid use case or not, but I'm getting it in the context of a Sufia app. Maybe I need to rectify this at the form/presenter level instead? Otherwise, here's the PR...