### PR TITLE
ids_reader should not return duplicates.

### DIFF
--- a/lib/active_fedora/associations/indirectly_contains_association.rb
+++ b/lib/active_fedora/associations/indirectly_contains_association.rb
@@ -30,7 +30,7 @@ module ActiveFedora
           target.map(&:id)
         else
           owner.resource.query(predicate: predicate)
-            .map { |s| ActiveFedora::Base.uri_to_id(s.object) } + target.map(&:id)
+            .map { |s| ActiveFedora::Base.uri_to_id(s.object) } | target.map(&:id)
         end
       end
 

--- a/spec/integration/indirect_container_spec.rb
+++ b/spec/integration/indirect_container_spec.rb
@@ -182,6 +182,13 @@ describe "Indirect containers" do
             end
           end
 
+          context "after save" do
+            it "returns correctly" do
+              o.save
+              expect(o.related_object_ids).to eq [file.id]
+            end
+          end
+
           context "with some members in memory" do
             let(:file2) { RelatedObject.create }
             before do


### PR DESCRIPTION
Fixes an issue with duplicate IDs being indexed the first time an object
is saved.