### PR TITLE
Adds explicit require of 'rdf/vocab' to AF::FedoraAttributes

### DIFF
--- a/lib/active_fedora/fedora_attributes.rb
+++ b/lib/active_fedora/fedora_attributes.rb
@@ -1,3 +1,5 @@
+require 'rdf/vocab'
+
 module ActiveFedora
   module FedoraAttributes
     extend ActiveSupport::Concern


### PR DESCRIPTION
We were getting an error in our project build:

NameError: uninitialized constant RDF::Vocab
/home/travis/.rvm/gems/ruby-2.1.5/bundler/gems/active_fedora-f85b4eab16f4/lib/active_fedora/fedora_attributes.rb:14:in `block in <module:FedoraAttributes>'