### PR TITLE
Allowing access to the gone? method from outside the object

### DIFF
--- a/lib/active_fedora/persistence.rb
+++ b/lib/active_fedora/persistence.rb
@@ -114,14 +114,18 @@ module ActiveFedora
         gone?(uri) ? delete_tombstone(uri) : false
       end
 
-      private
+      # Allows the user to find out if an id has been used in the system and then been deleted
+      # @param uri id in fedora that may or may not have been deleted
+      def gone?(uri)
+        ActiveFedora::Base.find(uri)
+        false
+      rescue Ldp::Gone
+        true
+      rescue ActiveFedora::ObjectNotFoundError
+        false
+      end
 
-        def gone?(uri)
-          ActiveFedora::Base.find(uri)
-          false
-        rescue Ldp::Gone
-          true
-        end
+      private
 
         def delete_tombstone(uri)
           tombstone = ActiveFedora::Base.id_to_uri(uri) + "/fcr:tombstone"

--- a/spec/integration/gone_spec.rb
+++ b/spec/integration/gone_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe ActiveFedora::Base do
+  before(:all) do
+    class ResurrectionModel < ActiveFedora::Base
+      after_destroy :eradicate
+    end
+  end
+
+  after(:all) do
+    Object.send(:remove_const, :ResurrectionModel)
+  end
+
+  context "when an object is has already been deleted" do
+    let(:ghost) do
+      obj = described_class.create
+      obj.destroy
+      obj.id
+    end
+    it "is gone" do
+      expect(described_class.gone?(ghost)).to be true
+    end
+  end
+
+  context "when the id has never been used" do
+    let(:id) { "abc123" }
+    it "is not gone" do
+      expect(described_class.gone?(id)).to be false
+    end
+  end
+
+  context "when the id is in use" do
+    let(:active) do
+      obj = described_class.create
+      obj.id
+    end
+    it "is not gone" do
+      expect(described_class.gone?(active)).to be false
+    end
+  end
+end


### PR DESCRIPTION
We are running into instances where our minter is minting ids that have been deleted.  I would like access to the gone method here https://github.com/psu-stewardship/active_fedora-noid/blob/master/lib/active_fedora/noid/synchronized_minter.rb#L16

This way we will not create invalid ids and end up with an LDP::Gone exception when we try to save.