### PR TITLE
Restore versionable? behavior

### DIFF
--- a/lib/active_fedora/versionable.rb
+++ b/lib/active_fedora/versionable.rb
@@ -10,7 +10,7 @@ module ActiveFedora
     module ClassMethods
       def has_many_versions
         Deprecation.warn Versionable, "has_many_versions is deprecated and will be removed in ActiveFedora 11."
-        # self.versionable = true
+        self.versionable = true
       end
     end
 


### PR DESCRIPTION
Although deprecated, has_many_versions still ought to behave as it did and set self.versionable to true. This method is still used in the fedora-migrate gem as a means of identifying Fedora 3 datastreams that should have all their versions migrated.