### PR TITLE
Add support for customizable Solr request handlers.

### DIFF
--- a/lib/active_fedora/file_configurator.rb
+++ b/lib/active_fedora/file_configurator.rb
@@ -143,7 +143,8 @@ module ActiveFedora
 
       config = solr_yml.symbolize_keys
       raise "The #{ActiveFedora.environment.to_sym} environment settings were not found in the solr.yml config.  If you already have a solr.yml file defined, make sure it defines settings for the #{ActiveFedora.environment.to_sym} environment" unless config[ActiveFedora.environment.to_sym]
-      @solr_config = { url: solr_url(config[ActiveFedora.environment.to_sym].symbolize_keys) }
+      config = config[ActiveFedora.environment.to_sym].symbolize_keys
+      @solr_config = { url: solr_url(config) }.merge(config.slice(:update_path, :select_path))
     end
 
     # Given the solr_config that's been loaded for this environment,

--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -151,11 +151,12 @@ module ActiveFedora
       opts[:sort] = @klass.default_sort_params unless opts[:sort].present?
 
       batch_size = opts.delete(:batch_size) || 1000
+      select_path = ActiveFedora::SolrService.select_path
 
       counter = 0
       loop do
         counter += 1
-        response = ActiveFedora::SolrService.instance.conn.paginate counter, batch_size, "select", params: opts
+        response = ActiveFedora::SolrService.instance.conn.paginate counter, batch_size, select_path, params: opts
         docs = response["response"]["docs"]
         yield docs
         break unless docs.has_next?

--- a/lib/active_fedora/solr_service.rb
+++ b/lib/active_fedora/solr_service.rb
@@ -23,11 +23,15 @@ module ActiveFedora
         Thread.current[:solr_service] = nil
       end
 
+      def select_path
+        ActiveFedora.solr_config.fetch(:select_path, 'select')
+      end
+
       def instance
         # Register Solr
 
         unless Thread.current[:solr_service]
-          register(ActiveFedora.solr_config[:url])
+          register(ActiveFedora.solr_config[:url], ActiveFedora.solr_config)
         end
 
         raise SolrNotInitialized unless Thread.current[:solr_service]
@@ -104,7 +108,7 @@ module ActiveFedora
       def query(query, args = {})
         raw = args.delete(:raw)
         args = args.merge(q: query, qt: 'standard')
-        result = SolrService.instance.conn.get('select', params: args)
+        result = SolrService.instance.conn.get(select_path, params: args)
         return result if raw
         result['response']['docs']
       end

--- a/spec/unit/file_configurator_spec.rb
+++ b/spec/unit/file_configurator_spec.rb
@@ -230,6 +230,15 @@ describe ActiveFedora::FileConfigurator do
         expect(subject.load_solr_config).to eq(url: "http://mysolr:8081")
         expect(subject.solr_config).to eq(url: "http://mysolr:8081")
       end
+
+      it "includes update_path and select_path in solr_config" do
+        allow(subject).to receive(:load_solrizer_config)
+        expect(subject).to receive(:config_path).with(:solr).and_return("/path/to/solr.yml")
+        expect(subject).to receive(:load_fedora_config)
+        expect(IO).to receive(:read).with("/path/to/solr.yml").and_return("test:\n  url: http://mysolr:8080\n  update_path: update_test\n  select_path: select_test\n")
+        expect(subject.solr_config[:update_path]).to eq('update_test')
+        expect(subject.solr_config[:select_path]).to eq('select_test')
+      end
     end
 
     describe "load_configs" do


### PR DESCRIPTION
Lets you configure which Solr request handlers are used for selects and updates by specifying select_path and update_path in solr.yml. This requires a patch in RSolr as well, a pull request for that is at rsolr/rsolr#116. Probably best to wait merging this until that's merged just in case something in there needs to be changed.

I've made this backwards compatible so that Active-Fedora doesn't depend on the new version of RSolr. With an older version of RSolr the custom request handlers simply will not work.