### PR TITLE
The jcr/mix versionable predicate is no longer used

### DIFF
--- a/spec/integration/versionable_spec.rb
+++ b/spec/integration/versionable_spec.rb
@@ -75,9 +75,7 @@ describe ActiveFedora::Versionable do
         subject.create_version
       end
 
-      it "sets model_type to versionable" do
-        expect(subject.reload.model_type).to include ::RDF::URI.new('http://www.jcp.org/jcr/mix/1.0versionable')
-      end
+      it { is_expected.to have_versions }
 
       it "has one version" do
         expect(subject.versions).to be_kind_of ActiveFedora::VersionsGraph


### PR DESCRIPTION
Includes some refactoring, but the change in the spec test makes AF compatible with Fedora 4.5.