### PR TITLE
Pass hash of options to index.as

### DIFF
--- a/lib/active_fedora/indexing/map.rb
+++ b/lib/active_fedora/indexing/map.rb
@@ -16,7 +16,7 @@ module ActiveFedora::Indexing
 
     # this enables a cleaner API for solr integration
     class IndexObject
-      attr_accessor :data_type, :behaviors
+      attr_accessor :data_type, :behaviors, :term
       attr_reader :key
 
       def initialize(name, &_block)
@@ -27,6 +27,7 @@ module ActiveFedora::Indexing
       end
 
       def as(*args)
+        @term = args.last.is_a?(Hash) ? args.pop : {}
         @behaviors = args
       end
 

--- a/lib/active_fedora/rdf/field_map.rb
+++ b/lib/active_fedora/rdf/field_map.rb
@@ -70,10 +70,12 @@ module ActiveFedora::RDF
       end
     end
 
-    # Builds a FieldMap entry for a resource such as an ActiveFedora::Base object and returns the uri as the value.
+    # Builds a FieldMap entry for a resource such as an ActiveFedora::Base object and returns the uri as the value
+    # unless :using has been set as an option to the index.as block on the property in question. In that case, the
+    # symbol assigned to :using will used as the value.
     class ResourceBuilder < Builder
       def find_values
-        object.send(name).map(&:uri)
+        object.send(name).map(&index_field_config.term.fetch(:using, :uri))
       end
     end
 

--- a/spec/integration/rdf_nested_attributes_spec.rb
+++ b/spec/integration/rdf_nested_attributes_spec.rb
@@ -4,10 +4,25 @@ describe "Nesting attribute behavior of RDF resources" do
   before do
     class DummyMADS < RDF::Vocabulary("http://www.loc.gov/mads/rdf/v1#")
       property :Topic
+      property :Name
+      property :Source
+    end
+
+    class CustomName < ActiveFedora::Base
+      property :pref_label, predicate: ::RDF::SKOS.prefLabel, multiple: false
+    end
+
+    class CustomSource < ActiveFedora::Base
     end
 
     class ComplexResource < ActiveFedora::Base
       property :topic, predicate: DummyMADS.Topic, class_name: "ComplexResource::Topic"
+      property :name, predicate: DummyMADS.Name, class_name: "CustomName" do |index|
+        index.as :stored_searchable, using: :pref_label
+      end
+      property :source, predicate: DummyMADS.Source, class_name: "CustomSource" do |index|
+        index.as :stored_searchable
+      end
 
       class Topic < ActiveTriples::Resource
         property :subject, predicate: ::RDF::Vocab::DC.subject
@@ -18,37 +33,53 @@ describe "Nesting attribute behavior of RDF resources" do
   after do
     Object.send(:remove_const, :ComplexResource)
     Object.send(:remove_const, :DummyMADS)
+    Object.send(:remove_const, :CustomName)
+    Object.send(:remove_const, :CustomSource)
   end
 
-  subject { ComplexResource.new }
+  context "with an AT resource as a property" do
+    subject { ComplexResource.new }
 
-  let(:params) { [{ subject: 'Foo' }, { subject: 'Bar' }] }
-
-  before do
-    ComplexResource.accepts_nested_attributes_for(*args)
-    subject.topic_attributes = params
-  end
-
-  context "when no options are set" do
-    let(:args) { [:topic] }
-
-    it "sets the attributes" do
-      expect(subject.topic.size).to eq 2
-      expect(subject.topic.map(&:subject)).to eq [['Foo'], ['Bar']]
-    end
-
-    it "marks the attributes as changed" do
-      expect(subject.changed_attributes).to eq('topic' => [])
-    end
-  end
-
-  context "when reject_if is set" do
-    let(:args) { [:topic, reject_if: reject_proc] }
-    let(:reject_proc) { lambda { |attributes| attributes[:subject] == 'Bar' } }
     let(:params) { [{ subject: 'Foo' }, { subject: 'Bar' }] }
 
-    it "does not add terms for which the proc is true" do
-      expect(subject.topic.map(&:subject)).to eq [['Foo']]
+    before do
+      ComplexResource.accepts_nested_attributes_for(*args)
+      subject.topic_attributes = params
+    end
+
+    context "when no options are set" do
+      let(:args) { [:topic] }
+
+      it "sets the attributes" do
+        expect(subject.topic.size).to eq 2
+        expect(subject.topic.map(&:subject)).to eq [['Foo'], ['Bar']]
+      end
+
+      it "marks the attributes as changed" do
+        expect(subject.changed_attributes).to eq('topic' => [])
+      end
+    end
+
+    context "when reject_if is set" do
+      let(:args) { [:topic, reject_if: reject_proc] }
+      let(:reject_proc) { lambda { |attributes| attributes[:subject] == 'Bar' } }
+      let(:params) { [{ subject: 'Foo' }, { subject: 'Bar' }] }
+
+      it "does not add terms for which the proc is true" do
+        expect(subject.topic.map(&:subject)).to eq [['Foo']]
+      end
+    end
+  end
+
+  context "with an AF::Base object as a property" do
+    describe "#to_solr" do
+      let(:name) { CustomName.create(pref_label: "Joe Schmo") }
+      let(:source) { CustomSource.create }
+      let(:solr_doc) { ComplexResource.new(name: [name], source: [source]).to_solr }
+      it "indexes the value of the properties accordingly" do
+        expect(solr_doc).to include("name_tesim" => ["Joe Schmo"])
+        expect(solr_doc).to include("source_tesim" => [source.uri])
+      end
     end
   end
 end


### PR DESCRIPTION
Allows you to configure how we index properties that are ActiveFedora::Base objects. Instead of using only the uri as the value of the solr field, you can specify any arbitrary property you want.

@jcoyne @tpendragon I'm curious as to what your thoughts are on this approach.