### PR TITLE
Handles the case where the user passes an id to find via a hash

### DIFF
--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -49,6 +49,10 @@ module ActiveFedora
       end
 
       if options.present?
+        if options.keys.count == 1 && options[:id]
+          Deprecation.warn(ActiveFedora::Base, "Calling .find with an id via a hash has been deprecated and will not be allowed in active-fedora 10.0. Use .find('your-id') instead")
+          return find_with_ids([options[:id]], cast)
+        end
         options = args.first unless args.empty?
         Deprecation.warn(ActiveFedora::Base, "Calling .find with a hash has been deprecated and will not be allowed in active-fedora 10.0. Use .where instead")
         options = { conditions: options }

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -64,7 +64,14 @@ describe ActiveFedora::Base do
     describe "using an options hash" do
       it "is deprecated" do
         expect(Deprecation).to receive(:warn)
-        SpecModel::Basic.find(id: "_ID_")
+        SpecModel::Basic.find(id: "_ID_", foo: 'bar')
+      end
+    end
+
+    describe "using a single hash parameter of ID" do
+      it "behaves as find(id) but gives a deprecation warning" do
+        expect(Deprecation).to receive(:warn)
+        expect { SpecModel::Basic.find(id: "_ID_") }.to raise_error ActiveFedora::ObjectNotFoundError
       end
     end
   end


### PR DESCRIPTION
This handles the problem that Jenn and Lynette reported here: https://groups.google.com/forum/#!topic/hydra-tech/72KKRPbZlms

The basic issue is that a call to `Collection.find(id: 'col-1')` behaves different than a call to `Collection.find('col-1')` Notice that the former passes the `id` as a hash.

Passing the `id` as a hash is a deprecated behavior and AF gives a deprecation warning, however, the current behavior in AF also executes the search and returns a result different than the expected one.

For example:
```
x = Collection.find(id: 'col-1')
puts x.class 
=> ActiveFedora::Relation

vs

x = Collection.find('col-1')
puts x.class 
=> Collection
```

This PR gives a more specific warning when the user issues `.find(id: "1")` and executes the correct find behavior. 