### PR TITLE
Run test FCRepo on a separate instance from development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bin
 .ruby-gemset
 gemfiles/*.gemfile.lock
 /fcrepo4-data
+/fcrepo4-test-data

--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "yard"
   s.add_development_dependency "rake"
   s.add_development_dependency "solr_wrapper", "~> 0.4"
-  s.add_development_dependency 'fcrepo_wrapper', '~> 0.1'
+  s.add_development_dependency 'fcrepo_wrapper', '~> 0.2'
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "rspec-its"
   s.add_development_dependency "equivalent-xml"

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -6,7 +6,7 @@ development:
 test:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://localhost:8984/rest
+  url: http://localhost:8986/rest
   base_path: /test
 production:
   user: fedoraAdmin

--- a/config/jetty.yml
+++ b/config/jetty.yml
@@ -1,6 +1,0 @@
-default:
-  startup_wait: 90
-  jetty_port: 8983
-  java_opts:
-    - "-Xmx512m"
-    - "-XX:MaxPermSize=128m"

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -5,9 +5,9 @@ development:
     url: http://localhost:8983/solr/development
 test:
   default:
-    url: http://localhost:8983/solr/hydra-test
+    url: http://localhost:8985/solr/hydra-test
   full_text:
-    url: http://localhost:8983/solr/test
+    url: http://localhost:8985/solr/test
 production:
   default:
     url: http://localhost:8080/solr/production

--- a/lib/active_fedora/version.rb
+++ b/lib/active_fedora/version.rb
@@ -1,3 +1,3 @@
 module ActiveFedora
-  VERSION = "9.8.0".freeze
+  VERSION = "9.8.1".freeze
 end

--- a/lib/generators/active_fedora/config/fedora/templates/fedora.yml
+++ b/lib/generators/active_fedora/config/fedora/templates/fedora.yml
@@ -6,7 +6,7 @@ development:
 test:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://localhost:8984/rest
+  url: http://localhost:8986/rest
   base_path: /test
 production:
   user: fedoraAdmin

--- a/lib/generators/active_fedora/config/solr/templates/solr.yml
+++ b/lib/generators/active_fedora/config/solr/templates/solr.yml
@@ -2,6 +2,6 @@
 development:
   url: http://localhost:8983/solr/hydra-dev
 test:
-  url: <%= "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8983}/solr/hydra-test" %>
+  url: <%= "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8985}/solr/hydra-test" %>
 production:
   url: http://your.production.server:8080/bl_solr/core0

--- a/lib/tasks/active_fedora_dev.rake
+++ b/lib/tasks/active_fedora_dev.rake
@@ -51,11 +51,9 @@ namespace :active_fedora do
   desc "CI build"
   task :ci do
     ENV['environment'] = "test"
-    # Rake::Task["active_fedora:configure_jetty"].invoke
-    # jetty_params = Jettywrapper.load_config
-    solr_params = { port: 8983, verbose: true, managed: true }
-    fcrepo_params = { port: 8984, verbose: true, managed: true }
-    error = nil
+    solr_params = { port: 8985, verbose: true, managed: true }
+    fcrepo_params = { port: 8986, verbose: true, managed: true,
+                      no_jms: true, fcrepo_home_dir: 'fcrepo4-test-data' }
     SolrWrapper.wrap(solr_params) do |solr|
       solr.with_collection(name: 'hydra-test', dir: File.join(File.expand_path("../..", File.dirname(__FILE__)), "solr", "config")) do
         FcrepoWrapper.wrap(fcrepo_params) do


### PR DESCRIPTION
This puts development on ports 8983 and 8984 for Solr and Fcrepo respecively.  The test instances would be on 8985 and 8986 respectively.