### PR TITLE
Don't default facet.limit

### DIFF
--- a/lib/generators/active_fedora/config/solr/templates/solr/config/solrconfig.xml
+++ b/lib/generators/active_fedora/config/solr/templates/solr/config/solrconfig.xml
@@ -119,9 +119,6 @@
 
        <str name="facet">true</str>
        <str name="facet.mincount">1</str>
-       <str name="facet.limit">10</str>
-       <str name="facet.field">active_fedora_model_ssi</str>
-       <str name="facet.field">subject_sim</str>
 
        <str name="spellcheck">true</str>
        <str name="spellcheck.dictionary">default</str>

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -119,9 +119,6 @@
 
        <str name="facet">true</str>
        <str name="facet.mincount">1</str>
-       <str name="facet.limit">10</str>
-       <str name="facet.field">active_fedora_model_ssi</str>
-       <str name="facet.field">subject_sim</str>
 
        <str name="spellcheck">true</str>
        <str name="spellcheck.dictionary">default</str>


### PR DESCRIPTION
When this happens, facets only show the first 10 values and don't give
any indication that there is more than 10 (the more >>) link.  This will
allow users to customize a sensible limit in their Blacklight
Configuration