### PR TITLE
Adds SSL options to config (closes #985)

### DIFF
--- a/lib/active_fedora/config.rb
+++ b/lib/active_fedora/config.rb
@@ -2,7 +2,7 @@ module ActiveFedora
   class Config
     attr_reader :credentials
     def initialize(val)
-      @credentials = val.symbolize_keys
+      @credentials = val.deep_symbolize_keys
       return if @credentials.key?(:url)
       raise ActiveFedora::ConfigurationError, "Fedora configuration must provide :url."
     end

--- a/lib/active_fedora/fedora.rb
+++ b/lib/active_fedora/fedora.rb
@@ -21,6 +21,10 @@ module ActiveFedora
       @config[:password]
     end
 
+    def ssl_options
+      @config[:ssl]
+    end
+
     def connection
       # The InboundRelationConnection does provide more data, useful for
       # things like ldp:IndirectContainers, but it's imposes a significant
@@ -58,7 +62,9 @@ module ActiveFedora
     end
 
     def authorized_connection
-      connection = Faraday.new(host)
+      options = {}
+      options[:ssl] = ssl_options if ssl_options
+      connection = Faraday.new(host, options)
       connection.basic_auth(user, password)
       connection
     end

--- a/spec/fixtures/rails_root/config/fedora.yml
+++ b/spec/fixtures/rails_root/config/fedora.yml
@@ -2,3 +2,11 @@ test:
   user: fedoraAdmin
   password: fedoraAdmin
   url: http://testhost.com:8983/fedora
+test_ssl:
+  user: fedoraAdmin
+  password: fedoraAdmin
+  url: https://testhost.com:8443/fedora
+  ssl:
+    verify: false
+    ca_path: /path/to/certs
+  

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -2,12 +2,17 @@ require 'spec_helper'
 
 describe ActiveFedora::Config do
   context "with a single fedora instance" do
-    let(:yaml) { Psych.load(File.read('spec/fixtures/rails_root/config/fedora.yml'))['test'] }
-    let(:conf) { described_class.new(yaml) }
+    let(:yaml) { Psych.load(File.read('spec/fixtures/rails_root/config/fedora.yml')) }
+    let(:section) { 'test' }
+    let(:conf) { described_class.new(yaml[section]) }
 
     describe "#credentials" do
       subject { conf.credentials }
-      it { should eq(url: 'http://testhost.com:8983/fedora', user: 'fedoraAdmin', password: 'fedoraAdmin') }
+      it { is_expected.to eq(url: 'http://testhost.com:8983/fedora', user: 'fedoraAdmin', password: 'fedoraAdmin') }
+      describe "with SSL options" do
+        let(:section) { 'test_ssl' }
+        its([:ssl]) { is_expected.to eq(verify: false, ca_path: '/path/to/certs') }
+      end
     end
   end
 end

--- a/spec/unit/fedora_spec.rb
+++ b/spec/unit/fedora_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe ActiveFedora::Fedora do
+  subject { described_class.new(config) }
+  describe "#authorized_connection" do
+    describe "with SSL options" do
+      let(:config) {
+        { url: "https://example.com",
+          user: "fedoraAdmin",
+          password: "fedoraAdmin",
+          ssl: { ca_path: '/path/to/certs' }
+        }
+      }
+      specify {
+        expect(Faraday).to receive(:new).with("https://example.com", ssl: { ca_path: '/path/to/certs' }).twice.and_call_original
+        subject.authorized_connection
+      }
+    end
+  end
+end


### PR DESCRIPTION
Faraday may require SSL options to work properly.  New code reads
optional :ssl key in fedora.yml, expecting one or two subkeys, :verify
and :ca_path.  If SSL options are present in the config, they are passed
to the Faraday connection contructor. See the Faraday docs for details.