### PR TITLE
Share the test server method with downstream apps

### DIFF
--- a/lib/active_fedora/rake_support.rb
+++ b/lib/active_fedora/rake_support.rb
@@ -1,0 +1,22 @@
+# Starts a fedora server and a solr server on a random port and then
+# yields the passed block
+def with_test_server
+  return yield if ENV['SERVER_STARTED']
+
+  ENV['SERVER_STARTED'] = 'true'
+
+  # setting port: nil assigns a random port.
+  solr_params = { port: nil, verbose: true, managed: true }
+  fcrepo_params = { port: nil, verbose: true, managed: true,
+                    enable_jms: false, fcrepo_home_dir: 'fcrepo4-test-data' }
+  SolrWrapper.wrap(solr_params) do |solr|
+    ENV['SOLR_TEST_PORT'] = solr.port
+    solr.with_collection(name: 'hydra-test', dir: File.join(File.expand_path("../..", File.dirname(__FILE__)), "solr", "config")) do
+      FcrepoWrapper.wrap(fcrepo_params) do |fcrepo|
+        ENV['FCREPO_TEST_PORT'] = fcrepo.port
+        yield
+      end
+    end
+  end
+  ENV['SERVER_STARTED'] = 'false'
+end

--- a/lib/tasks/active_fedora_dev.rake
+++ b/lib/tasks/active_fedora_dev.rake
@@ -2,6 +2,7 @@ APP_ROOT = File.expand_path("#{File.dirname(__FILE__)}/../../")
 
 require 'solr_wrapper'
 require 'fcrepo_wrapper'
+require 'active_fedora/rake_support'
 
 namespace :active_fedora do
   # Use yard to build docs
@@ -70,28 +71,5 @@ namespace :active_fedora do
     with_test_server do
       Rake::Task["active_fedora:rspec"].invoke
     end
-  end
-
-  # Starts a fedora server and a solr server on a random port and then
-  # yields the passed block
-  def with_test_server
-    return yield if ENV['SERVER_STARTED']
-
-    ENV['SERVER_STARTED'] = 'true'
-
-    # setting port: nil assigns a random port.
-    solr_params = { port: nil, verbose: true, managed: true }
-    fcrepo_params = { port: nil, verbose: true, managed: true,
-                      enable_jms: false, fcrepo_home_dir: 'fcrepo4-test-data' }
-    SolrWrapper.wrap(solr_params) do |solr|
-      ENV['SOLR_TEST_PORT'] = solr.port
-      solr.with_collection(name: 'hydra-test', dir: File.join(File.expand_path("../..", File.dirname(__FILE__)), "solr", "config")) do
-        FcrepoWrapper.wrap(fcrepo_params) do |fcrepo|
-          ENV['FCREPO_TEST_PORT'] = fcrepo.port
-          yield
-        end
-      end
-    end
-    ENV['SERVER_STARTED'] = 'false'
   end
 end


### PR DESCRIPTION
In your rake file add:
```ruby
 require 'active_fedora/rake_support'
```
Then you can define a task using with_test_server. For example:
```ruby
  task :ci do
    with_test_server do
      Rake::Task['spec'].invoke
    end
  end
```