### PR TITLE
Use local configurations for solr

### DIFF
--- a/lib/active_fedora/rake_support.rb
+++ b/lib/active_fedora/rake_support.rb
@@ -11,7 +11,14 @@ def with_test_server
                     enable_jms: false, fcrepo_home_dir: 'fcrepo4-test-data' }
   SolrWrapper.wrap(solr_params) do |solr|
     ENV['SOLR_TEST_PORT'] = solr.port
-    solr.with_collection(name: 'hydra-test', dir: File.join(File.expand_path("../..", File.dirname(__FILE__)), "solr", "config")) do
+    solr_config_path = File.join('solr', 'config')
+    # Check to see if configs exist in a path relative to the working directory
+    unless Dir.exist?(solr_config_path)
+      $stderr.puts "Solr configuration not found at #{solr_config_path}. Using ActiveFedora defaults"
+      # Otherwise use the configs delivered with ActiveFedora.
+      solr_config_path = File.join(File.expand_path("../..", File.dirname(__FILE__)), "solr", "config")
+    end
+    solr.with_collection(name: 'hydra-test', dir: solr_config_path) do
       FcrepoWrapper.wrap(fcrepo_params) do |fcrepo|
         ENV['FCREPO_TEST_PORT'] = fcrepo.port
         yield


### PR DESCRIPTION
If there is a solr configuration local to the current working directory
use them.  Otherwise use the defaults in ActiveFedora.