### PR TITLE
Restore autocommit in the update handler

### DIFF
--- a/lib/generators/active_fedora/config/solr/templates/solr/config/solrconfig.xml
+++ b/lib/generators/active_fedora/config/solr/templates/solr/config/solrconfig.xml
@@ -57,6 +57,21 @@
     <defaultQuery>*:*</defaultQuery>
   </admin>
 
+  <updateHandler class="solr.DirectUpdateHandler2">
+    <updateLog>
+      <str name="dir">${solr.ulog.dir:}</str>
+    </updateLog>
+
+    <autoCommit>
+      <maxTime>${solr.autoCommit.maxTime:15000}</maxTime>
+      <openSearcher>false</openSearcher>
+    </autoCommit>
+
+    <autoSoftCommit>
+      <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime>
+    </autoSoftCommit>
+  </updateHandler>
+
   <!-- SearchHandler
 
        http://wiki.apache.org/solr/SearchHandler

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -57,6 +57,21 @@
     <defaultQuery>*:*</defaultQuery>
   </admin>
 
+  <updateHandler class="solr.DirectUpdateHandler2">
+    <updateLog>
+      <str name="dir">${solr.ulog.dir:}</str>
+    </updateLog>
+
+    <autoCommit>
+      <maxTime>${solr.autoCommit.maxTime:15000}</maxTime>
+      <openSearcher>false</openSearcher>
+    </autoCommit>
+
+    <autoSoftCommit>
+      <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime>
+    </autoSoftCommit>
+  </updateHandler>
+
   <!-- SearchHandler
 
        http://wiki.apache.org/solr/SearchHandler


### PR DESCRIPTION
When we moved to Solr 5, we inadvertently removed the autocommit from
solr. Thus no commit is ever sent.