### PR TITLE
Unify type to model mapping code

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -68,6 +68,7 @@ module ActiveFedora #:nodoc:
       autoload :OmAttribute
       autoload :RdfDatastreamAttribute
     end
+    autoload :DefaultModelMapper
     autoload :Fedora
     autoload :FedoraAttributes
     autoload :File
@@ -250,7 +251,7 @@ module ActiveFedora #:nodoc:
     end
 
     def model_mapper
-      Model
+      ActiveFedora::DefaultModelMapper
     end
   end
 

--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -246,7 +246,11 @@ module ActiveFedora #:nodoc:
     #   ActiveFedora.class_from_string("TermProxy", ActiveFedora::RdfNode)
     #   => ActiveFedora::RdfNode::TermProxy
     def class_from_string(*args)
-      Model.class_from_string(*args)
+      model_mapper.class_from_string(*args)
+    end
+
+    def model_mapper
+      Model
     end
   end
 

--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -88,6 +88,7 @@ module ActiveFedora #:nodoc:
     autoload :LdpResourceService
     autoload :LoadableFromJson
     autoload :Model
+    autoload :ModelClassifier
     autoload :NestedAttributes
     autoload :NomDatastream
     autoload :NullRelation
@@ -247,11 +248,11 @@ module ActiveFedora #:nodoc:
     #   ActiveFedora.class_from_string("TermProxy", ActiveFedora::RdfNode)
     #   => ActiveFedora::RdfNode::TermProxy
     def class_from_string(*args)
-      model_mapper.class_from_string(*args)
+      ActiveFedora::ModelClassifier.class_from_string(*args)
     end
 
     def model_mapper
-      ActiveFedora::DefaultModelMapper
+      ActiveFedora::DefaultModelMapper.new
     end
   end
 

--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -245,19 +245,8 @@ module ActiveFedora #:nodoc:
     # @example Search within ActiveFedora::RdfNode for a class called "TermProxy"
     #   ActiveFedora.class_from_string("TermProxy", ActiveFedora::RdfNode)
     #   => ActiveFedora::RdfNode::TermProxy
-    def class_from_string(full_class_name, container_class = Kernel)
-      container_class = container_class.name if container_class.is_a? Module
-      container_parts = container_class.split('::')
-      (container_parts + full_class_name.split('::')).flatten.inject(Kernel) do |mod, class_name|
-        if mod == Kernel
-          Object.const_get(class_name)
-        elsif mod.const_defined? class_name.to_sym
-          mod.const_get(class_name)
-        else
-          container_parts.pop
-          class_from_string(class_name, container_parts.join('::'))
-        end
-      end
+    def class_from_string(*args)
+      Model.class_from_string(*args)
     end
   end
 

--- a/lib/active_fedora/default_model_mapper.rb
+++ b/lib/active_fedora/default_model_mapper.rb
@@ -1,0 +1,24 @@
+module ActiveFedora
+  # Create model classifiers for resources or solr documents
+  class DefaultModelMapper
+    attr_reader :classifier_class, :solr_field, :predicate
+
+    def initialize(classifier_class: ActiveFedora::ModelClassifier, solr_field: ActiveFedora::QueryResultBuilder::HAS_MODEL_SOLR_FIELD, predicate: ActiveFedora::RDF::Fcrepo::Model.hasModel)
+      @classifier_class = classifier_class
+      @solr_field = solr_field
+      @predicate = predicate
+    end
+
+    def classifier(resource)
+      models = if resource.respond_to? :graph
+                 resource.graph.query([nil, predicate, nil]).map { |rg| rg.object.to_s }
+               elsif resource.respond_to? :[]
+                 resource[solr_field] || []
+               else
+                 []
+               end
+
+      classifier_class.new(models)
+    end
+  end
+end

--- a/lib/active_fedora/model.rb
+++ b/lib/active_fedora/model.rb
@@ -53,7 +53,7 @@ module ActiveFedora
         ActiveFedora::Base.logger.warn "'#{model_value}' is not a real class" if ActiveFedora::Base.logger
         return nil
       end
-      ActiveFedora.class_from_string(model_value)
+      ActiveFedora::Model.class_from_string(model_value)
     end
 
     def self.class_exists?(class_name)

--- a/lib/active_fedora/model.rb
+++ b/lib/active_fedora/model.rb
@@ -5,6 +5,30 @@ module ActiveFedora
   # This module mixes various methods into the including class,
   # much in the way ActiveRecord does.
   module Model
+    # Convenience method for getting class constant based on a string
+    # @example
+    #   ActiveFedora::Model.class_from_string("Om")
+    #   => Om
+    #   ActiveFedora::Model.class_from_string("ActiveFedora::RdfNode::TermProxy")
+    #   => ActiveFedora::RdfNode::TermProxy
+    # @example Search within ActiveFedora::RdfNode for a class called "TermProxy"
+    #   ActiveFedora::Model.class_from_string("TermProxy", ActiveFedora::RdfNode)
+    #   => ActiveFedora::RdfNode::TermProxy
+    def self.class_from_string(full_class_name, container_class = Kernel)
+      container_class = container_class.name if container_class.is_a? Module
+      container_parts = container_class.split('::')
+      (container_parts + full_class_name.split('::')).flatten.inject(Kernel) do |mod, class_name|
+        if mod == Kernel
+          Object.const_get(class_name)
+        elsif mod.const_defined? class_name.to_sym
+          mod.const_get(class_name)
+        else
+          container_parts.pop
+          class_from_string(class_name, container_parts.join('::'))
+        end
+      end
+    end
+
     # Takes a Fedora URI for a cModel, and returns a
     # corresponding Model if available
     # This method should reverse ClassMethods#to_class_uri

--- a/lib/active_fedora/model.rb
+++ b/lib/active_fedora/model.rb
@@ -5,6 +5,21 @@ module ActiveFedora
   # This module mixes various methods into the including class,
   # much in the way ActiveRecord does.
   module Model
+    def self.best_class_from_uris(uris, default: nil)
+      best_model_match = default
+
+      uris.each do |uri|
+        model_value = from_class_uri(uri)
+        next unless model_value
+        best_model_match ||= model_value
+
+        # If there is an inheritance structure, use the most specific case.
+        best_model_match = model_value if best_model_match > model_value
+      end
+
+      best_model_match || ActiveFedora::Base
+    end
+
     # Convenience method for getting class constant based on a string
     # @example
     #   ActiveFedora::Model.class_from_string("Om")

--- a/lib/active_fedora/model_classifier.rb
+++ b/lib/active_fedora/model_classifier.rb
@@ -1,0 +1,77 @@
+module ActiveFedora
+  # Translate model names to classes
+  class ModelClassifier
+    # Convenience method for getting class constant based on a string
+    # @example
+    #   ActiveFedora::Model.class_from_string("Om")
+    #   => Om
+    #   ActiveFedora::Model.class_from_string("ActiveFedora::RdfNode::TermProxy")
+    #   => ActiveFedora::RdfNode::TermProxy
+    # @example Search within ActiveFedora::RdfNode for a class called "TermProxy"
+    #   ActiveFedora::Model.class_from_string("TermProxy", ActiveFedora::RdfNode)
+    #   => ActiveFedora::RdfNode::TermProxy
+    def self.class_from_string(full_class_name, container_class = Kernel)
+      container_class = container_class.name if container_class.is_a? Module
+      container_parts = container_class.split('::')
+      (container_parts + full_class_name.split('::')).flatten.inject(Kernel) do |mod, class_name|
+        if mod == Kernel
+          Object.const_get(class_name)
+        elsif mod.const_defined? class_name.to_sym
+          mod.const_get(class_name)
+        else
+          container_parts.pop
+          class_from_string(class_name, container_parts.join('::'))
+        end
+      end
+    end
+
+    attr_reader :class_names, :default
+
+    def initialize(class_names, default: ActiveFedora::Base)
+      @class_names = Array(class_names)
+      @default = default
+    end
+
+    ##
+    # Convert all the provided class names to class instances
+    def models
+      class_names.map do |uri|
+        classify(uri)
+      end.compact
+    end
+
+    ##
+    # Select the "best" class from the list of class names. We define
+    #    the "best" class as:
+    #     - a subclass of the given default, base class
+    #     - preferring subclasses over the parent class
+    def best_model(opts = {})
+      best_model_match = opts.fetch(:default, default)
+
+      models.each do |model_value|
+        # If there is an inheritance structure, use the most specific case.
+        best_model_match = model_value if best_model_match.nil? || best_model_match > model_value
+      end
+
+      best_model_match
+    end
+
+    private
+
+      def classify(model_value)
+        unless class_exists?(model_value)
+          ActiveFedora::Base.logger.warn "'#{model_value}' is not a real class" if ActiveFedora::Base.logger
+          return nil
+        end
+        ActiveFedora::ModelClassifier.class_from_string(model_value)
+      end
+
+      def class_exists?(class_name)
+        return false if class_name.empty?
+        klass = class_name.constantize
+        return klass.is_a?(Class)
+      rescue NameError
+        return false
+      end
+  end
+end

--- a/lib/active_fedora/query_result_builder.rb
+++ b/lib/active_fedora/query_result_builder.rb
@@ -19,12 +19,12 @@ module ActiveFedora
 
     # Returns all possible classes for the solr object
     def self.classes_from_solr_document(hit, _opts = {})
-      ActiveFedora.model_mapper.from_solr_document(hit).models
+      ActiveFedora.model_mapper.classifier(hit).models
     end
 
     # Returns the best singular class for the solr object
     def self.class_from_solr_document(hit, opts = {})
-      best_model_match = ActiveFedora.model_mapper.from_solr_document(hit).best_model(opts)
+      best_model_match = ActiveFedora.model_mapper.classifier(hit).best_model(opts)
       ActiveFedora::Base.logger.warn "Could not find a model for #{hit['id']}, defaulting to ActiveFedora::Base" if ActiveFedora::Base.logger && best_model_match == ActiveFedora::Base
       best_model_match
     end

--- a/lib/active_fedora/query_result_builder.rb
+++ b/lib/active_fedora/query_result_builder.rb
@@ -19,22 +19,13 @@ module ActiveFedora
 
     # Returns all possible classes for the solr object
     def self.classes_from_solr_document(hit, _opts = {})
-      classes = []
-
-      hit[HAS_MODEL_SOLR_FIELD].each { |value| classes << ActiveFedora.model_mapper.from_class_uri(value) }
-
-      classes.compact
+      ActiveFedora.model_mapper.from_solr_document(hit).models
     end
 
     # Returns the best singular class for the solr object
     def self.class_from_solr_document(hit, opts = {})
-      # Set the default starting point to the class specified, if available.
-      default_model = ActiveFedora.model_mapper.from_class_uri(opts[:class]) unless opts[:class].nil?
-
-      models = Array(hit[HAS_MODEL_SOLR_FIELD])
-      best_model_match = ActiveFedora.model_mapper.best_class_from_uris(models, default: default_model)
-
-      ActiveFedora::Base.logger.warn "Could not find a model for #{hit['id']}, defaulting to ActiveFedora::Base" if ActiveFedora::Base.logger && !best_model_match
+      best_model_match = ActiveFedora.model_mapper.from_solr_document(hit).best_model(opts)
+      ActiveFedora::Base.logger.warn "Could not find a model for #{hit['id']}, defaulting to ActiveFedora::Base" if ActiveFedora::Base.logger && best_model_match == ActiveFedora::Base
       best_model_match
     end
 

--- a/lib/active_fedora/query_result_builder.rb
+++ b/lib/active_fedora/query_result_builder.rb
@@ -21,7 +21,7 @@ module ActiveFedora
     def self.classes_from_solr_document(hit, _opts = {})
       classes = []
 
-      hit[HAS_MODEL_SOLR_FIELD].each { |value| classes << Model.from_class_uri(value) }
+      hit[HAS_MODEL_SOLR_FIELD].each { |value| classes << ActiveFedora.model_mapper.from_class_uri(value) }
 
       classes.compact
     end
@@ -29,10 +29,10 @@ module ActiveFedora
     # Returns the best singular class for the solr object
     def self.class_from_solr_document(hit, opts = {})
       # Set the default starting point to the class specified, if available.
-      default_model = Model.from_class_uri(opts[:class]) unless opts[:class].nil?
+      default_model = ActiveFedora.model_mapper.from_class_uri(opts[:class]) unless opts[:class].nil?
 
       models = Array(hit[HAS_MODEL_SOLR_FIELD])
-      best_model_match = Model.best_class_from_uris(models, default: default_model)
+      best_model_match = ActiveFedora.model_mapper.best_class_from_uris(models, default: default_model)
 
       ActiveFedora::Base.logger.warn "Could not find a model for #{hit['id']}, defaulting to ActiveFedora::Base" if ActiveFedora::Base.logger && !best_model_match
       best_model_match

--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -203,16 +203,9 @@ module ActiveFedora
       end
 
       def has_model_value(resource)
-        best_model_match = nil
+        models = resource.graph.query([nil, ActiveFedora::RDF::Fcrepo::Model.hasModel, nil]).map { |rg| rg.object.to_s }
 
-        resource.graph.query([nil, ActiveFedora::RDF::Fcrepo::Model.hasModel, nil]).each do |rg|
-          model_value = Model.from_class_uri(rg.object.to_s)
-          next unless model_value
-          best_model_match ||= model_value
-
-          # If there is an inheritance structure, use the most specific case.
-          best_model_match = model_value if best_model_match > model_value
-        end
+        best_model_match = ActiveFedora::Model.best_class_from_uris(models)
 
         best_model_match.to_s
       end

--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -193,7 +193,6 @@ module ActiveFedora
         if @klass == ActiveFedora::Base && cast == false
           ActiveFedora::Base
         else
-          # The true class may be a subclass of @klass, so always use from_class_uri
           resource_class = has_model_value(resource)
           unless equivalent_class?(resource_class)
             raise ActiveFedora::ActiveFedoraError, "Model mismatch. Expected #{@klass}. Got: #{resource_class}"
@@ -203,7 +202,7 @@ module ActiveFedora
       end
 
       def has_model_value(resource)
-        ActiveFedora.model_mapper.from_resource(resource).best_model
+        ActiveFedora.model_mapper.classifier(resource).best_model
       end
 
       def equivalent_class?(other_class)

--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -194,7 +194,7 @@ module ActiveFedora
           ActiveFedora::Base
         else
           # The true class may be a subclass of @klass, so always use from_class_uri
-          resource_class = Model.from_class_uri(has_model_value(resource)) || ActiveFedora::Base
+          resource_class = ActiveFedora.model_mapper.from_class_uri(has_model_value(resource)) || ActiveFedora::Base
           unless equivalent_class?(resource_class)
             raise ActiveFedora::ActiveFedoraError, "Model mismatch. Expected #{@klass}. Got: #{resource_class}"
           end
@@ -205,7 +205,7 @@ module ActiveFedora
       def has_model_value(resource)
         models = resource.graph.query([nil, ActiveFedora::RDF::Fcrepo::Model.hasModel, nil]).map { |rg| rg.object.to_s }
 
-        best_model_match = ActiveFedora::Model.best_class_from_uris(models)
+        best_model_match = ActiveFedora.model_mapper.best_class_from_uris(models)
 
         best_model_match.to_s
       end

--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -194,7 +194,7 @@ module ActiveFedora
           ActiveFedora::Base
         else
           # The true class may be a subclass of @klass, so always use from_class_uri
-          resource_class = ActiveFedora.model_mapper.from_class_uri(has_model_value(resource)) || ActiveFedora::Base
+          resource_class = has_model_value(resource)
           unless equivalent_class?(resource_class)
             raise ActiveFedora::ActiveFedoraError, "Model mismatch. Expected #{@klass}. Got: #{resource_class}"
           end
@@ -203,11 +203,7 @@ module ActiveFedora
       end
 
       def has_model_value(resource)
-        models = resource.graph.query([nil, ActiveFedora::RDF::Fcrepo::Model.hasModel, nil]).map { |rg| rg.object.to_s }
-
-        best_model_match = ActiveFedora.model_mapper.best_class_from_uris(models)
-
-        best_model_match.to_s
+        ActiveFedora.model_mapper.from_resource(resource).best_model
       end
 
       def equivalent_class?(other_class)

--- a/spec/integration/bug_spec.rb
+++ b/spec/integration/bug_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 require 'active_fedora'
 require 'active_fedora/model'
 require "rexml/document"
-include ActiveFedora::Model
 
 describe 'bugs' do
   before do

--- a/spec/unit/active_fedora_spec.rb
+++ b/spec/unit/active_fedora_spec.rb
@@ -115,30 +115,4 @@ describe ActiveFedora do
       end
     end
   end
-
-  describe "#class_from_string" do
-    before do
-      module ParentClass
-        class SiblingClass
-        end
-        class OtherSiblingClass
-        end
-      end
-    end
-    it "returns class constants based on strings" do
-      expect(described_class.class_from_string("Om")).to eq Om
-      expect(described_class.class_from_string("ActiveFedora::RDF::IndexingService")).to eq ActiveFedora::RDF::IndexingService
-      expect(described_class.class_from_string("IndexingService", ActiveFedora::RDF)).to eq ActiveFedora::RDF::IndexingService
-    end
-
-    it "finds sibling classes" do
-      expect(described_class.class_from_string("SiblingClass", ParentClass::OtherSiblingClass)).to eq ParentClass::SiblingClass
-    end
-
-    it "raises a NameError if the class isn't found" do
-      expect {
-        described_class.class_from_string("FooClass", ParentClass::OtherSiblingClass)
-      }.to raise_error NameError, /uninitialized constant (Object::)?FooClass/
-    end
-  end
 end

--- a/spec/unit/default_model_mapper_spec.rb
+++ b/spec/unit/default_model_mapper_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe ActiveFedora::DefaultModelMapper do
+  let(:classifier) { double }
+  let(:classifier_instance) { double }
+  let(:solr_field) { 'solr_field' }
+  let(:predicate) { 'info:predicate' }
+  subject { described_class.new classifier_class: classifier, solr_field: solr_field, predicate: predicate }
+
+  describe '#classifier' do
+    context 'with a solr document' do
+      let(:solr_document) { { 'solr_field' => ['xyz'] } }
+
+      before do
+        expect(classifier).to receive(:new).with(['xyz']).and_return(classifier_instance)
+      end
+
+      it 'creates a classifier from the solr field data' do
+        expect(subject.classifier(solr_document)).to eq classifier_instance
+      end
+    end
+
+    context 'with a resource' do
+      let(:graph) do
+        RDF::Graph.new << [:hello, predicate, 'xyz']
+      end
+
+      let(:resource) { double(graph: graph) }
+
+      before do
+        expect(classifier).to receive(:new).with(['xyz']).and_return(classifier_instance)
+      end
+
+      it 'creates a classifier from the resource model predicate' do
+        expect(subject.classifier(resource)).to eq classifier_instance
+      end
+    end
+  end
+end

--- a/spec/unit/model_classifier_spec.rb
+++ b/spec/unit/model_classifier_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe ActiveFedora::ModelClassifier do
+  module ParentClass
+    class SiblingClass
+    end
+    class OtherSiblingClass
+    end
+    class SubclassClass < SiblingClass
+    end
+  end
+
+  let(:class_names) { ["ParentClass::SiblingClass", "ParentClass::OtherSiblingClass", "ParentClass::SubclassClass", "ParentClass::NoSuchClass"] }
+  subject { described_class.new class_names }
+
+  describe ".class_from_string" do
+    it "returns class constants based on strings" do
+      expect(described_class.class_from_string("Om")).to eq Om
+      expect(described_class.class_from_string("ActiveFedora::RDF::IndexingService")).to eq ActiveFedora::RDF::IndexingService
+      expect(described_class.class_from_string("IndexingService", ActiveFedora::RDF)).to eq ActiveFedora::RDF::IndexingService
+    end
+
+    it "finds sibling classes" do
+      expect(described_class.class_from_string("SiblingClass", ParentClass::OtherSiblingClass)).to eq ParentClass::SiblingClass
+    end
+
+    it "raises a NameError if the class isn't found" do
+      expect {
+        described_class.class_from_string("FooClass", ParentClass::OtherSiblingClass)
+      }.to raise_error NameError, /uninitialized constant (Object::)?FooClass/
+    end
+  end
+
+  describe '#models' do
+    it 'converts class names to classes' do
+      expect(subject.models).to match_array [ParentClass::SiblingClass, ParentClass::OtherSiblingClass, ParentClass::SubclassClass]
+    end
+  end
+
+  describe '#best_model' do
+    it 'selects the most specific matching model' do
+      expect(subject.best_model(default: nil)).to eq ParentClass::SubclassClass
+    end
+
+    it 'filters models to subclasses of the default' do
+      expect(subject.best_model(default: ActiveFedora::Base)).to eq ActiveFedora::Base
+    end
+  end
+end

--- a/spec/unit/model_spec.rb
+++ b/spec/unit/model_spec.rb
@@ -27,39 +27,4 @@ describe ActiveFedora::Model do
       it { should eq 'search' }
     end
   end
-
-  describe ".from_class_uri" do
-    subject { described_class.from_class_uri(uri) }
-    context "a blank string" do
-      before { expect(ActiveFedora::Base.logger).to receive(:warn) }
-      let(:uri) { '' }
-      it { should be_nil }
-    end
-  end
-
-  describe ".class_from_string" do
-    before do
-      module ParentClass
-        class SiblingClass
-        end
-        class OtherSiblingClass
-        end
-      end
-    end
-    it "returns class constants based on strings" do
-      expect(described_class.class_from_string("Om")).to eq Om
-      expect(described_class.class_from_string("ActiveFedora::RDF::IndexingService")).to eq ActiveFedora::RDF::IndexingService
-      expect(described_class.class_from_string("IndexingService", ActiveFedora::RDF)).to eq ActiveFedora::RDF::IndexingService
-    end
-
-    it "finds sibling classes" do
-      expect(described_class.class_from_string("SiblingClass", ParentClass::OtherSiblingClass)).to eq ParentClass::SiblingClass
-    end
-
-    it "raises a NameError if the class isn't found" do
-      expect {
-        described_class.class_from_string("FooClass", ParentClass::OtherSiblingClass)
-      }.to raise_error NameError, /uninitialized constant (Object::)?FooClass/
-    end
-  end
 end

--- a/spec/unit/model_spec.rb
+++ b/spec/unit/model_spec.rb
@@ -36,4 +36,30 @@ describe ActiveFedora::Model do
       it { should be_nil }
     end
   end
+
+  describe ".class_from_string" do
+    before do
+      module ParentClass
+        class SiblingClass
+        end
+        class OtherSiblingClass
+        end
+      end
+    end
+    it "returns class constants based on strings" do
+      expect(described_class.class_from_string("Om")).to eq Om
+      expect(described_class.class_from_string("ActiveFedora::RDF::IndexingService")).to eq ActiveFedora::RDF::IndexingService
+      expect(described_class.class_from_string("IndexingService", ActiveFedora::RDF)).to eq ActiveFedora::RDF::IndexingService
+    end
+
+    it "finds sibling classes" do
+      expect(described_class.class_from_string("SiblingClass", ParentClass::OtherSiblingClass)).to eq ParentClass::SiblingClass
+    end
+
+    it "raises a NameError if the class isn't found" do
+      expect {
+        described_class.class_from_string("FooClass", ParentClass::OtherSiblingClass)
+      }.to raise_error NameError, /uninitialized constant (Object::)?FooClass/
+    end
+  end
 end

--- a/spec/unit/query_result_builder_spec.rb
+++ b/spec/unit/query_result_builder_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe ActiveFedora::QueryResultBuilder do
   describe "reify solr results" do
     before(:all) do
-      class AudioRecord
+      class AudioRecord < ActiveFedora::Base
         attr_accessor :id
         def self.connection_for_id(_id)
         end


### PR DESCRIPTION
This pull request extracts two new classes from formerly class-level methods:

- `ModelClassifier` - for turning strings into class instances, and choosing the "best" match from a list
- `DefaultModelMapper` - for extracting model mapping information from resources or solr documents

This is a start at providing a flexible way to select appropriate model classes from resource data (say, from a different Solr field, or more complex logic).