### PR TITLE
Move indexer to a class attribute

### DIFF
--- a/lib/active_fedora/indexing.rb
+++ b/lib/active_fedora/indexing.rb
@@ -15,6 +15,16 @@ module ActiveFedora
       autoload :Map
     end
 
+    included do
+      # Because the previous method of setting indexer was to override
+      # the class method, we must ensure that we aren't using the instance
+      # reader so that the old method still works.
+      class_attribute :indexer, instance_accessor: false
+
+      # This is the default indexer class to use for this model.
+      self.indexer = IndexingService
+    end
+
     # Return a Hash representation of this object where keys in the hash are appropriate Solr field names.
     # @param [Hash] _solr_doc (optional) Hash to insert the fields into
     # @param [Hash] _opts (optional)
@@ -70,10 +80,6 @@ module ActiveFedora
                             else
                               ActiveFedora::Indexing::Map.new
                             end
-        end
-
-        def indexer
-          IndexingService
         end
 
         def reindex_everything

--- a/spec/unit/indexing_spec.rb
+++ b/spec/unit/indexing_spec.rb
@@ -1,6 +1,20 @@
 require 'spec_helper'
 
 describe ActiveFedora::Indexing do
+  describe '.indexer' do
+    let(:indexing_class) { Class.new }
+    let(:klass) { Class.new }
+    before do
+      klass.include described_class
+    end
+
+    it "is settable as a class attribute" do
+      expect(klass.indexer).to eq ActiveFedora::IndexingService
+      klass.indexer = indexing_class
+      expect(klass.indexer).to eq indexing_class
+    end
+  end
+
   context "internal methods" do
     before :all do
       class SpecNode


### PR DESCRIPTION
Now we can set an indexer without having to override a class method.