### PR TITLE
Rename find_with_conditions and find_in_batches to search_with_conditions and search_in_batches

### DIFF
--- a/lib/active_fedora/querying.rb
+++ b/lib/active_fedora/querying.rb
@@ -1,7 +1,7 @@
 module ActiveFedora
   module Querying
     delegate :find, :first, :exists?, :where, :limit, :offset, :order, :delete_all,
-             :destroy_all, :count, :last, :find_with_conditions, :find_in_batches, :find_each, to: :all
+             :destroy_all, :count, :last, :find_with_conditions, :find_in_batches, :search_with_conditions, :search_in_batches, :find_each, to: :all
 
     def self.extended(base)
       base.class_attribute :solr_query_handler

--- a/lib/active_fedora/solr_instance_loader.rb
+++ b/lib/active_fedora/solr_instance_loader.rb
@@ -37,7 +37,7 @@ module ActiveFedora
 
       def solr_doc
         @solr_doc ||= begin
-          result = context.find_with_conditions(id: id)
+          result = context.search_with_conditions(id: id)
           if result.empty?
             raise ActiveFedora::ObjectNotFoundError, "Object #{id} not found in solr"
           end

--- a/spec/integration/full_featured_model_spec.rb
+++ b/spec/integration/full_featured_model_spec.rb
@@ -131,7 +131,7 @@ describe ActiveFedora::Base do
 
     @test_history.save
 
-    @solr_result = OralHistory.find_with_conditions(id: @test_history.id)[0]
+    @solr_result = OralHistory.search_with_conditions(id: @test_history.id)[0]
     @properties_sample_values.each_pair do |field, value|
       next if field == :hard_copy_availability # FIXME: HYDRA-824
       next if field == :location # FIXME HYDRA-825
@@ -153,8 +153,8 @@ describe ActiveFedora::Base do
     expect(dc_xml.root.elements["dcterms:subject"].text).to eq "My Subject Heading"
   end
 
-  it "supports #find_with_conditions" do
-    solr_result = OralHistory.find_with_conditions({})
+  it "supports #search_with_conditions" do
+    solr_result = OralHistory.search_with_conditions({})
     expect(solr_result).to_not be_nil
   end
 end

--- a/spec/unit/finder_methods_spec.rb
+++ b/spec/unit/finder_methods_spec.rb
@@ -56,7 +56,7 @@ describe ActiveFedora::FinderMethods do
     end
   end
 
-  describe "#find_in_batches" do
+  describe "#search_in_batches" do
     let(:docs) { double('docs', has_next?: false) }
     let(:select_handler) { 'select' }
     let(:connection) { double('conn') }
@@ -70,14 +70,14 @@ describe ActiveFedora::FinderMethods do
     end
     it "yields the docs" do
       expect { |b|
-        finder.find_in_batches({ 'age_t' => '21' }, { other_opt: 'test' }, &b)
+        finder.search_in_batches({ 'age_t' => '21' }, { other_opt: 'test' }, &b)
       }.to yield_with_args(docs)
     end
 
     context "with custom select handler" do
       let(:select_handler) { 'select_test' }
       it "uses the custom select handler" do
-        finder.find_in_batches({ 'age_t' => '21' }, other_opt: 'test') do end
+        finder.search_in_batches({ 'age_t' => '21' }, other_opt: 'test') do end
       end
     end
   end

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -153,7 +153,7 @@ describe ActiveFedora::Base do
     end
   end
 
-  describe '#find_in_batches' do
+  describe '#search_in_batches' do
     describe "with conditions hash" do
       let(:solr) { ActiveFedora::SolrService.instance.conn }
       let(:expected_query) { "#{model_query} AND " \
@@ -168,7 +168,7 @@ describe ActiveFedora::Base do
         expect(solr).to receive(:paginate).with(1, 1002, 'select', expected_params).and_return('response' => { 'docs' => mock_docs })
         yielded = double("yielded method")
         expect(yielded).to receive(:run).with(mock_docs)
-        SpecModel::Basic.find_in_batches({ foo: 'bar', baz: ['quix', 'quack'] }, batch_size: 1002, fl: 'id') { |group| yielded.run group }
+        SpecModel::Basic.search_in_batches({ foo: 'bar', baz: ['quix', 'quack'] }, batch_size: 1002, fl: 'id') { |group| yielded.run group }
       end
     end
   end
@@ -240,10 +240,10 @@ describe ActiveFedora::Base do
     end
   end
 
-  describe '#find_with_conditions' do
+  describe '#search_with_conditions' do
     let(:mock_result) { double('Result') }
     let(:klass) { SpecModel::Basic }
-    subject { klass.find_with_conditions(conditions) }
+    subject { klass.search_with_conditions(conditions) }
 
     before do
       expect(ActiveFedora::SolrService).to receive(:query)

--- a/spec/unit/solr_config_options_spec.rb
+++ b/spec/unit/solr_config_options_spec.rb
@@ -24,7 +24,7 @@ describe ActiveFedora do
       expect(@test_object.to_solr[:id]).to be_nil
     end
 
-    it "is used by ActiveFedora::Base#find_with_conditions" do
+    it "is used by ActiveFedora::Base#search_with_conditions" do
       mock_response = double("SolrResponse")
       expect(ActiveFedora::SolrService).to receive(:query)
         .with("_query_:\"{!raw f=has_model_ssim}SolrSpecModel::Basic\" AND " \
@@ -32,7 +32,7 @@ describe ActiveFedora do
               sort: ["#{ActiveFedora::SolrQueryBuilder.solr_name('system_create', :stored_sortable, type: :date)} asc"])
         .and_return(mock_response)
 
-      expect(SolrSpecModel::Basic.find_with_conditions(id: "changeme:30")).to equal(mock_response)
+      expect(SolrSpecModel::Basic.search_with_conditions(id: "changeme:30")).to equal(mock_response)
     end
   end
 


### PR DESCRIPTION
`find_with_conditions` and `find_in_batches` return Solr results, not class instances. Rename these methods (and provide appropriate deprecation warnings) to clarify the intent.