### PR TITLE
Add default scopes

### DIFF
--- a/lib/active_fedora/identifiable.rb
+++ b/lib/active_fedora/identifiable.rb
@@ -78,6 +78,11 @@ module ActiveFedora
       rescue ActiveFedora::ObjectNotFoundError, Ldp::Gone
         ActiveTriples::Resource.new(uri)
       end
+
+      # Abstract classes can't have default scopes.
+      def abstract_class?
+        self == Base
+      end
     end
   end
 end

--- a/lib/active_fedora/relation.rb
+++ b/lib/active_fedora/relation.rb
@@ -62,6 +62,23 @@ module ActiveFedora
       @records
     end
 
+    # Scope all queries to the current scope.
+    #
+    #   Comment.where(post_id: 1).scoping do
+    #     Comment.first
+    #   end
+    #   # => SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = 1 ORDER BY "comments"."id" ASC LIMIT 1
+    #
+    # Please check unscoped if you want to remove all previous scopes (including
+    # the default_scope) during the execution of a block.
+    def scoping
+      previous = klass.current_scope
+      klass.current_scope = self
+      yield
+    ensure
+      klass.current_scope = previous
+    end
+
     def ==(other)
       case other
       when Relation

--- a/lib/active_fedora/scoping.rb
+++ b/lib/active_fedora/scoping.rb
@@ -14,6 +14,11 @@ module ActiveFedora
       def current_scope=(scope) #:nodoc:
         Thread.current["#{self}_current_scope"] = scope
       end
+
+      # Are there attributes associated with this scope?
+      def scope_attributes? # :nodoc:
+        current_scope
+      end
     end
   end
 end

--- a/lib/active_fedora/scoping/default.rb
+++ b/lib/active_fedora/scoping/default.rb
@@ -3,6 +3,14 @@ module ActiveFedora
     module Default
       extend ActiveSupport::Concern
 
+      included do
+        class_attribute :default_scopes, instance_writer: false, instance_predicate: false
+        class_attribute :default_scope_override, instance_writer: false, instance_predicate: false
+
+        self.default_scopes = []
+        self.default_scope_override = nil
+      end
+
       module ClassMethods
         # Returns a scope for the model without the +default_scope+.
         #
@@ -32,6 +40,111 @@ module ActiveFedora
         def unscoped
           block_given? ? relation.scoping { yield } : relation
         end
+
+        # Are there attributes associated with this scope?
+        def scope_attributes? # :nodoc:
+          super || default_scopes.any? || respond_to?(:default_scope)
+        end
+
+        protected
+
+          # Use this macro in your model to set a default scope for all operations on
+          # the model.
+          #
+          #   class Article < ActiveRecord::Base
+          #     default_scope { where(published: true) }
+          #   end
+          #
+          #   Article.all # => SELECT * FROM articles WHERE published = true
+          #
+          # The #default_scope is also applied while creating/building a record.
+          # It is not applied while updating a record.
+          #
+          #   Article.new.published    # => true
+          #   Article.create.published # => true
+          #
+          # (You can also pass any object which responds to +call+ to the
+          # +default_scope+ macro, and it will be called when building the
+          # default scope.)
+          #
+          # If you use multiple #default_scope declarations in your model then
+          # they will be merged together:
+          #
+          #   class Article < ActiveRecord::Base
+          #     default_scope { where(published: true) }
+          #     default_scope { where(rating: 'G') }
+          #   end
+          #
+          #   Article.all # => SELECT * FROM articles WHERE published = true AND rating = 'G'
+          #
+          # This is also the case with inheritance and module includes where the
+          # parent or module defines a #default_scope and the child or including
+          # class defines a second one.
+          #
+          # If you need to do more complex things with a default scope, you can
+          # alternatively define it as a class method:
+          #
+          #   class Article < ActiveRecord::Base
+          #     def self.default_scope
+          #       # Should return a scope, you can call 'super' here etc.
+          #     end
+          #   end
+          def default_scope(scope = nil)
+            scope = Proc.new if block_given?
+
+            if scope.is_a?(Relation) || !scope.respond_to?(:call)
+              raise ArgumentError,
+                    "Support for calling #default_scope without a block is removed. For example instead " \
+                    "of `default_scope where(color: 'red')`, please use " \
+                    "`default_scope { where(color: 'red') }`. (Alternatively you can just redefine " \
+                    "self.default_scope.)"
+            end
+
+            self.default_scopes += [scope]
+          end
+
+          def build_default_scope(base_rel = nil) # :nodoc:
+            return if abstract_class?
+
+            if default_scope_override.nil?
+              self.default_scope_override = !Base.is_a?(method(:default_scope).owner)
+            end
+
+            if default_scope_override
+              # The user has defined their own default scope method, so call that
+              evaluate_default_scope { default_scope }
+            elsif default_scopes.any?
+              base_rel ||= relation
+              evaluate_default_scope do
+                default_scopes.inject(base_rel) do |default_scope, scope|
+                  scope = scope.respond_to?(:to_proc) ? scope : scope.method(:call)
+                  default_scope.merge(base_rel.instance_exec(&scope))
+                end
+              end
+            end
+          end
+
+          def ignore_default_scope? # :nodoc:
+            Thread.current["#{self}_ignore_default_scope"]
+          end
+
+          def ignore_default_scope=(ignore) # :nodoc:
+            Thread.current["#{self}_ignore_default_scope"] = ignore
+          end
+
+          # The ignore_default_scope flag is used to prevent an infinite recursion
+          # situation where a default scope references a scope which has a default
+          # scope which references a scope...
+          def evaluate_default_scope # :nodoc:
+            return if ignore_default_scope?
+
+            begin
+              self.ignore_default_scope = true
+              yield
+            ensure
+              self.ignore_default_scope = false
+            end
+          end
       end
     end
   end

--- a/lib/active_fedora/scoping/named.rb
+++ b/lib/active_fedora/scoping/named.rb
@@ -21,9 +21,17 @@ module ActiveFedora
           if current_scope
             current_scope.clone
           else
-            scope = relation
-            scope.default_scoped = true
-            scope
+            default_scoped
+          end
+        end
+
+        def default_scoped
+          scope = build_default_scope
+
+          if scope
+            relation.spawn.merge!(scope)
+          else
+            relation
           end
         end
       end

--- a/spec/unit/scoping_spec.rb
+++ b/spec/unit/scoping_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe ActiveFedora::Scoping::Default do
+  describe "when default_scope is overridden" do
+    before do
+      class Book < ActiveFedora::Base
+        property :published, predicate: ::RDF::Vocab::EBUCore.pubStatus do |index|
+          index.as :symbol
+        end
+
+        def self.default_scope
+          where published_ssim: 'true'
+        end
+      end
+
+      Book.destroy_all
+      Book.create!(published: [true])
+      Book.create!(published: [true])
+      Book.create!(published: [false])
+    end
+
+    after do
+      Object.send(:remove_const, :Book)
+    end
+
+    it "returns only the scoped records" do
+      expect(Book.all.size).to eq 2
+    end
+
+    it "returns all the records" do
+      Book.unscoped do
+        expect(Book.all.size).to eq 3
+      end
+    end
+  end
+
+  describe "when default_scope is called" do
+    before do
+      class Book < ActiveFedora::Base
+        property :published, predicate: ::RDF::Vocab::EBUCore.pubStatus do |index|
+          index.as :symbol
+        end
+
+        default_scope -> { where published_ssim: 'true' }
+      end
+
+      Book.destroy_all
+      Book.create!(published: [true])
+      Book.create!(published: [true])
+      Book.create!(published: [false])
+    end
+
+    after do
+      Object.send(:remove_const, :Book)
+    end
+
+    it "returns only the scoped records" do
+      expect(Book.all.size).to eq 2
+    end
+
+    it "returns all the records" do
+      Book.unscoped do
+        expect(Book.all.size).to eq 3
+      end
+    end
+  end
+end


### PR DESCRIPTION
These are used by GlobalID, which we should add in the future so we can
use ActiveFedora with ActiveJob