### PR TITLE
Delegate count to the scope

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,7 @@ Metrics/PerceivedComplexity:
     - 'lib/active_fedora/associations/has_and_belongs_to_many_association.rb'
     - 'lib/active_fedora/associations/builder/indirectly_contains.rb'
     - 'lib/active_fedora/associations/builder/directly_contains_one.rb'
+    - 'lib/active_fedora/associations/collection_association.rb'
 
 Metrics/ModuleLength:
   Exclude:
@@ -74,6 +75,7 @@ Metrics/ClassLength:
     - 'lib/active_fedora/qualified_dublin_core_datastream.rb'
     - 'lib/active_fedora/file_configurator.rb'
     - 'lib/active_fedora/file.rb'
+    - 'lib/active_fedora/associations/association.rb'
     - 'lib/active_fedora/associations/builder/association.rb'
     - 'lib/active_fedora/associations/collection_proxy.rb'
     - 'lib/active_fedora/associations/collection_association.rb'

--- a/lib/active_fedora/associations/association.rb
+++ b/lib/active_fedora/associations/association.rb
@@ -18,7 +18,7 @@ module ActiveFedora
         @owner = owner
         @reflection = reflection
         reset
-        # construct_scope
+        reset_scope
       end
 
       # Resets the \loaded flag to +false+ and sets the \target to +nil+.
@@ -32,7 +32,7 @@ module ActiveFedora
       # Reloads the \target and returns +self+ on success.
       def reload
         reset
-        # construct_scope
+        reset_scope
         load_target
         self unless @target.nil?
       end
@@ -77,6 +77,10 @@ module ActiveFedora
       # actually gets built.
       def association_scope
         @association_scope ||= AssociationScope.new(self).scope if klass
+      end
+
+      def reset_scope
+        @association_scope = nil
       end
 
       # Set the inverse association, if possible

--- a/lib/active_fedora/associations/collection_association.rb
+++ b/lib/active_fedora/associations/collection_association.rb
@@ -14,7 +14,13 @@ module ActiveFedora
           force_reload = opts
         end
         reload if force_reload || stale_target?
-        @proxy ||= CollectionProxy.new(self)
+        if null_scope?
+          # Cache the proxy separately before the owner has an id
+          # or else a post-save proxy will still lack the id
+          @null_proxy ||= CollectionProxy.new(self)
+        else
+          @proxy ||= CollectionProxy.new(self)
+        end
       end
 
       # Implements the writer method, e.g. foo.items= for Foo.has_many :items
@@ -223,7 +229,7 @@ module ActiveFedora
       # Count all records using solr. Construct options and pass them with
       # scope to the target class's +count+.
       def count(_options = {})
-        @reflection.klass.count(conditions: construct_query)
+        scope.count
       end
 
       # Sets the target of this proxy to <tt>\target</tt>, and the \loaded flag to +true+.

--- a/lib/active_fedora/associations/collection_proxy.rb
+++ b/lib/active_fedora/associations/collection_proxy.rb
@@ -38,7 +38,7 @@ module ActiveFedora
       def initialize(association)
         @association = association
         super association.klass
-        merge! association.scope
+        merge! association.scope(nullify: false)
       end
 
       def target

--- a/lib/active_fedora/associations/has_many_association.rb
+++ b/lib/active_fedora/associations/has_many_association.rb
@@ -14,11 +14,7 @@ module ActiveFedora
       # If the collection is empty the target is set to an empty array and
       # the loaded flag is set to true as well.
       def count_records
-        count = if loaded?
-                  @target.size
-                else
-                  @reflection.klass.count(conditions: construct_query)
-                end
+        count = scope.count
 
         # If there's nothing in the database and @target has no new records
         # we are certain the current target is an empty array. This is a

--- a/lib/active_fedora/autosave_association.rb
+++ b/lib/active_fedora/autosave_association.rb
@@ -283,7 +283,7 @@ module ActiveFedora
           end
 
           # reconstruct the scope now that we know the owner's id
-          association.send(:construct_scope) if association.respond_to?(:construct_scope)
+          association.send(:reset_scope) if association.respond_to?(:reset_scope)
         end
       end
 

--- a/spec/integration/has_many_associations_spec.rb
+++ b/spec/integration/has_many_associations_spec.rb
@@ -27,6 +27,35 @@ describe ActiveFedora::Associations::HasManyAssociation do
         end
       end
 
+      context "when the owner is not saved, and potential targets (Books) exist" do
+        let!(:book) { Book.create }
+        let(:library) { Library.new }
+        subject { library.books.count }
+        it "it excludes the books that aren't associated" do
+          expect(subject).to eq 0
+        end
+      end
+
+      context "when the owner is saved with associations" do
+        let(:book) { Book.create }
+        let!(:library) { Library.create(books: [book]) }
+        subject { library.reload; library.books.count }
+        it "it excludes the books that are associated" do
+          expect(subject).to eq 1
+        end
+      end
+
+      context "when the owner is not saved after checking the count" do
+        let!(:book) { Book.create }
+        let(:library) { Library.new }
+        it "refreshes the cache" do
+          expect(library.books.count).to eq 0
+          library.books << book
+          library.save!
+          expect(library.books.count).to eq 1
+        end
+      end
+
       context "loading the association prior to a save that affects the association" do
         let(:library) { Library.new }
         before do

--- a/spec/unit/has_many_association_spec.rb
+++ b/spec/unit/has_many_association_spec.rb
@@ -71,4 +71,26 @@ describe ActiveFedora::Associations::HasManyAssociation do
       expect { described_class.new(owner, reflection) }.not_to raise_error
     end
   end
+
+  describe "scope" do
+    before do
+      class Library < ActiveFedora::Base
+        has_many :images
+      end
+
+      class Image < ActiveFedora::Base
+        belongs_to :library, predicate: ::RDF::URI('http://example.com/library')
+      end
+    end
+
+    after do
+      Object.send(:remove_const, :Library)
+      Object.send(:remove_const, :Image)
+    end
+
+    context "of an unsaved target" do
+      subject { Library.new.images.scope }
+      it { is_expected.to be_kind_of ActiveFedora::NullRelation }
+    end
+  end
 end


### PR DESCRIPTION
If the owner is unsaved, it will get the NullScope, which always returns
zero.  Fixes #1008