### PR TITLE
ActiveFedora::File.mime_type should be updatable

### DIFF
--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -63,6 +63,12 @@ module ActiveFedora
       end
     end
 
+    def save
+      super.tap do
+        metadata.save if metadata.changed?
+      end
+    end
+
     def described_by
       raise "#{self} isn't persisted yet" if new_record?
       links['describedby'].first
@@ -114,6 +120,7 @@ module ActiveFedora
     def attribute_will_change!(attr)
       if attr == 'content'
         changed_attributes['content'] = true
+      elsif attr == 'type'
       else
         super
       end
@@ -138,7 +145,15 @@ module ActiveFedora
     end
 
     def changed?
-      super || content_changed?
+      super || content_changed? || metadata_changed?
+    end
+
+    def metadata_changed?
+      if new_record? || links['describedby'].blank?
+        false
+      else
+        metadata.changed?
+      end
     end
 
     def inspect

--- a/lib/active_fedora/file/attributes.rb
+++ b/lib/active_fedora/file/attributes.rb
@@ -1,9 +1,9 @@
 module ActiveFedora::File::Attributes
-  attr_writer :mime_type
-
   def mime_type
-    @mime_type ||= fetch_mime_type
+    fetch_mime_type
   end
+
+  delegate :mime_type=, to: :metadata
 
   def original_name
     @original_name ||= fetch_original_name
@@ -25,7 +25,7 @@ module ActiveFedora::File::Attributes
   end
 
   def dirty_size
-    content.size if changed? && content.respond_to?(:size)
+    content.size if content_changed? && content.respond_to?(:size)
   end
 
   def size
@@ -68,8 +68,8 @@ module ActiveFedora::File::Attributes
     end
 
     def fetch_mime_type
-      return default_mime_type if new_record?
-      ldp_source.head.content_type
+      return default_mime_type if new_record? && metadata.mime_type.blank?
+      metadata.mime_type.first
     end
 
     def fetch_original_name

--- a/lib/active_fedora/with_metadata/metadata_node.rb
+++ b/lib/active_fedora/with_metadata/metadata_node.rb
@@ -2,6 +2,7 @@ module ActiveFedora
   module WithMetadata
     class MetadataNode < ActiveTriples::Resource
       include ActiveModel::Dirty
+      property :mime_type, predicate: ::RDF::URI("http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasMimeType")
       attr_reader :file
 
       def initialize(file)
@@ -45,7 +46,7 @@ module ActiveFedora
 
       def changed_attributes
         super.tap do |changed|
-          changed['type'] = true if type.present?
+          changed['type'] = true if type.present? && new_record?
         end
       end
 

--- a/spec/integration/attached_files_spec.rb
+++ b/spec/integration/attached_files_spec.rb
@@ -63,13 +63,13 @@ describe ActiveFedora::AttachedFiles do
 
     it "creates datastreams from the spec on new objects" do
       has_file.file_ds.content = "blah blah blah"
-      expect(has_file.file_ds).to be_changed
-      expect(has_file.file_ds2).to_not be_changed # no autocreate
+      expect(has_file.file_ds).to be_content_changed
+      expect(has_file.file_ds2).to_not be_content_changed # no autocreate
       expect(has_file.file_ds2).to be_new_record
       has_file.save
       has_file.reload
-      expect(has_file.file_ds).to_not be_changed
-      expect(has_file.file_ds2).to_not be_changed # no autocreate
+      expect(has_file.file_ds).to_not be_content_changed
+      expect(has_file.file_ds2).to_not be_content_changed # no autocreate
       expect(has_file.file_ds2).to be_new_record
     end
   end

--- a/spec/integration/file_spec.rb
+++ b/spec/integration/file_spec.rb
@@ -109,7 +109,7 @@ describe ActiveFedora::File do
       end
 
       it "is not changed" do
-        expect(test_object.attached_files[path]).to_not be_changed
+        expect(test_object.attached_files[path]).to_not be_content_changed
       end
 
       it "is able to read the content from fedora" do

--- a/spec/integration/om_datastream_spec.rb
+++ b/spec/integration/om_datastream_spec.rb
@@ -30,15 +30,15 @@ describe ActiveFedora::OmDatastream do
     end
     it "does not be changed if the new xml matches the old xml" do
       subject.content = subject.content
-      expect(subject).to_not be_changed
+      expect(subject).to_not be_content_changed
     end
 
     it "is changed if there are minor differences in whitespace" do
       subject.content = "<a><b>1</b></a>"
       obj.save
-      expect(subject).to_not be_changed
+      expect(subject).to_not be_content_changed
       subject.content = "<a>\n<b>1</b>\n</a>"
-      expect(subject).to be_changed
+      expect(subject).to be_content_changed
     end
   end
 
@@ -56,11 +56,11 @@ describe ActiveFedora::OmDatastream do
       obj.reload
     end
 
-    it "does not be dirty after .update_values is saved" do
+    it "is not dirty after .update_values is saved" do
       obj.descMetadata.update_values([{ name: 0 }, { role: 0 }, :text] => "Funder")
-      expect(obj.descMetadata).to be_changed
+      expect(obj.descMetadata).to be_content_changed
       obj.save
-      expect(obj.descMetadata).to_not be_changed
+      expect(obj.descMetadata).to_not be_content_changed
       expect(obj.descMetadata.term_values({ name: 0 }, { role: 0 }, :text)).to eq ["Funder"]
     end
   end

--- a/spec/unit/file_spec.rb
+++ b/spec/unit/file_spec.rb
@@ -185,6 +185,25 @@ describe ActiveFedora::File do
     end
   end
 
+  describe "#mime_type" do
+    let(:parent) { ActiveFedora::Base.create }
+    before do
+      parent.add_file('banana', path: 'apple', mime_type: 'video/webm')
+      parent.save!
+    end
+    it "persists" do
+      expect(parent.reload.apple.mime_type).to eq "video/webm"
+    end
+    it "can be updated" do
+      parent.reload
+      parent.apple.mime_type = "text/awesome"
+      expect(parent.apple.mime_type).to eq "text/awesome"
+      parent.save
+
+      expect(parent.reload.apple.mime_type).to eq "text/awesome"
+    end
+  end
+
   context "original_name" do
     subject { file.original_name }
 


### PR DESCRIPTION
Squash and rebase of file_mime_types branch by @tpendragon