### PR TITLE
Update schema for Solr 6

### DIFF
--- a/lib/generators/active_fedora/config/solr/templates/solr/config/schema.xml
+++ b/lib/generators/active_fedora/config/solr/templates/solr/config/schema.xml
@@ -103,7 +103,7 @@
       http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4
     -->
     <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
-      geo="true" distErrPct="0.025" maxDistErr="0.000009" units="degrees" />
+      geo="true" distErrPct="0.025" maxDistErr="0.000009" distanceUnits="degrees" />
     
     <fieldType name="text" class="solr.TextField" omitNorms="false">
       <analyzer>


### PR DESCRIPTION
`units` is now `distanceUnits`

Mirrors https://github.com/projecthydra/sufia/pull/1820/files

Without this fix, Solr refuses to load the core, e.g.:
```
hydra-development:
org.apache.solr.common.SolrException:org.apache.solr.common.SolrException:
Could not load conf for core hydra-development: Can't load schema
/var/folders/6q/13dm9dcn1qx_gw9x66lhl7jc0000gq/T/solr-6.0.0/server/solr/hydra-development/conf/schema.xml:
Plugin Initializing failure for [schema.xml] fieldType
```