### PR TITLE
Update graph instead of destroying it

### DIFF
--- a/lib/active_fedora/associations/collection_association.rb
+++ b/lib/active_fedora/associations/collection_association.rb
@@ -103,11 +103,11 @@ module ActiveFedora
         other_array.each { |val| raise_on_type_mismatch!(val) }
 
         load_target
-        other   = other_array.size < 100 ? other_array : other_array.to_set
-        current = @target.size < 100 ? @target : @target.to_set
+        deletions = @target - other_array
+        additions = other_array - @target
 
-        delete(@target.select { |v| !other.include?(v) })
-        concat(other_array.select { |v| !current.include?(v) })
+        delete(deletions)
+        concat(additions)
       end
 
       def include?(record)
@@ -254,7 +254,7 @@ module ActiveFedora
       end
 
       def add_to_target(record, skip_callbacks = false)
-        #  transaction do
+        # Start transaction
         callback(:before_add, record) unless skip_callbacks
         yield(record) if block_given?
 
@@ -266,7 +266,7 @@ module ActiveFedora
 
         callback(:after_add, record) unless skip_callbacks
         set_inverse_instance(record)
-        # end
+        # End transaction
 
         record
       end

--- a/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
+++ b/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
@@ -14,7 +14,6 @@ module ActiveFedora
             return false unless record.save(validate: validate)
           end
         end
-
         owner[reflection.foreign_key] ||= []
         owner[reflection.foreign_key] += [record.id]
 


### PR DESCRIPTION
By not destroying the entire graph every time performance grows linearly instead of in an exponential fashion. It still needs to be tested on a large scale ( > 1000 members) but for hasCollectionMember relationships of < 500 it goes from 1200 seconds to 192 in my test environment.