### PR TITLE
Defer `init_base_path` until it is required

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -86,6 +86,7 @@ module ActiveFedora #:nodoc:
     autoload :InheritableAccessors
     autoload :Inheritance
     autoload :InboundRelationConnection
+    autoload :InitializingConnection
     autoload :LdpCache
     autoload :LdpResource
     autoload :LdpResourceService

--- a/lib/active_fedora/fedora.rb
+++ b/lib/active_fedora/fedora.rb
@@ -18,6 +18,8 @@ module ActiveFedora
 
     def initialize(config)
       @config = config
+
+      validate_options
     end
 
     def host
@@ -42,7 +44,6 @@ module ActiveFedora
 
     def connection
       @connection ||= begin
-        init_base_path
         build_connection
       end
     end
@@ -51,28 +52,16 @@ module ActiveFedora
       @clean_connection ||= CleanConnection.new(connection)
     end
 
+    def caching_connection(options = {})
+      CachingConnection.new(authorized_connection, options)
+    end
+
     def ldp_resource_service
       @service ||= LdpResourceService.new(connection)
     end
 
     SLASH = '/'.freeze
     BLANK = ''.freeze
-
-    # Call this to create a Container Resource to act as the base path for this connection
-    def init_base_path
-      return if @initialized
-      connection = build_connection
-
-      connection.head(root_resource_path)
-      ActiveFedora::Base.logger.info "Attempted to init base path `#{root_resource_path}`, but it already exists" if ActiveFedora::Base.logger
-      @initialized = true
-      false
-    rescue Ldp::NotFound
-      unless host.downcase.end_with?("/rest")
-        ActiveFedora::Base.logger.warn "Fedora URL (#{host}) does not end with /rest. This could be a problem. Check your fedora.yml config"
-      end
-      @initialized = connection.put(root_resource_path, BLANK).success?
-    end
 
     # Remove a leading slash from the base_path
     def root_resource_path
@@ -83,8 +72,8 @@ module ActiveFedora
       # The InboundRelationConnection does provide more data, useful for
       # things like ldp:IndirectContainers, but it's imposes a significant
       # performance penalty on every request
-      #   @connection ||= InboundRelationConnection.new(CachingConnection.new(authorized_connection))
-      CachingConnection.new(authorized_connection, omit_ldpr_interaction_model: true)
+      #   @connection ||= InboundRelationConnection.new(caching_connection(omit_ldpr_interaction_model: true))
+      InitializingConnection.new(caching_connection(omit_ldpr_interaction_model: true), root_resource_path)
     end
 
     def authorized_connection
@@ -93,6 +82,12 @@ module ActiveFedora
       connection = Faraday.new(host, options)
       connection.basic_auth(user, password)
       connection
+    end
+
+    def validate_options
+      unless host.downcase.end_with?("/rest")
+        ActiveFedora::Base.logger.warn "Fedora URL (#{host}) does not end with /rest. This could be a problem. Check your fedora.yml config"
+      end
     end
   end
 end

--- a/lib/active_fedora/initializing_connection.rb
+++ b/lib/active_fedora/initializing_connection.rb
@@ -1,0 +1,64 @@
+module ActiveFedora
+  class InitializingConnection < Delegator
+    attr_reader :connection, :root_resource_path
+
+    def initialize(connection, root_resource_path)
+      super(connection)
+      @connection = connection
+      @root_resource_path = root_resource_path
+      @initialized = false
+    end
+
+    def __getobj__
+      @connection
+    end
+
+    def __setobj__(connection)
+      @connection = connection
+    end
+
+    def head(*)
+      init_base_path
+      super
+    end
+
+    def get(*)
+      init_base_path
+      super
+    end
+
+    def delete(*)
+      init_base_path
+      super
+    end
+
+    def post(*)
+      init_base_path
+      super
+    end
+
+    def put(*)
+      init_base_path
+      super
+    end
+
+    def patch(*)
+      init_base_path
+      super
+    end
+
+    private
+
+      # Call this to create a Container Resource to act as the base path for this connection
+      def init_base_path
+        return if @initialized
+
+        connection.head(root_resource_path)
+        ActiveFedora::Base.logger.info "Attempted to init base path `#{root_resource_path}`, but it already exists" if ActiveFedora::Base.logger
+        @initialized = true
+        false
+      rescue Ldp::NotFound
+        @initialized = connection.put(root_resource_path, '').success?
+      end
+  end
+end

--- a/spec/unit/active_fedora_spec.rb
+++ b/spec/unit/active_fedora_spec.rb
@@ -28,7 +28,7 @@ describe ActiveFedora do
     it "does not connect and warn" do
       expect(ActiveFedora::Base.logger).to receive(:warn)
       expect {
-        ActiveFedora::Fedora.new(url: bad_url, base_path: '/test', user: user, password: password).connection
+        ActiveFedora::Fedora.new(url: bad_url, base_path: '/test', user: user, password: password).connection.head
       }.to raise_error Ldp::HttpError
     end
   end


### PR DESCRIPTION
This is an attempt to allow runtime configuration of Fedora by deferring blocking and potentially breaking requests until they are actually necessary.