### PR TITLE
Suppress AF::Cleaner errors when running the test suite

### DIFF
--- a/lib/active_fedora/ldp_cache.rb
+++ b/lib/active_fedora/ldp_cache.rb
@@ -29,9 +29,8 @@ module ActiveFedora
       end
 
       response
-    rescue StandardError => e
+    ensure
       reset_cache_settings
-      raise e
     end
 
     private

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,7 +42,11 @@ require 'active_fedora/cleaner'
 RSpec.configure do |config|
   # Stub out test stuff.
   config.before(:each) do
-    ActiveFedora::Cleaner.clean!
+    begin
+      ActiveFedora::Cleaner.clean!
+    rescue Faraday::ConnectionFailed, RSolr::Error::ConnectionRefused => e
+      $stderr.puts e.message
+    end
   end
   config.after(:each) do
     # cleanout_fedora


### PR DESCRIPTION
If `ActiveFedora::Cleaner` breaks because it can't connect to a resource, allow it to fail and just log a message. It's possible the test doesn't need those connections and may pass without active connections to external resources.