### PR TITLE
Have generators create wrapper config files for test

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "deprecation"
   s.add_dependency "ldp", '~> 0.5.0'
 
+  s.add_development_dependency "rails"
   s.add_development_dependency "rdoc"
   s.add_development_dependency "yard"
   # Pin rake to 10.0 due to https://github.com/lsegal/yard/issues/947

--- a/lib/generators/active_fedora/config/fedora/fedora_generator.rb
+++ b/lib/generators/active_fedora/config/fedora/fedora_generator.rb
@@ -10,6 +10,7 @@ module ActiveFedora
 
     def fcrepo_wrapper_config
       copy_file '.fcrepo_wrapper', '.fcrepo_wrapper'
+      copy_file 'fcrepo_wrapper_test.yml', 'config/fcrepo_wrapper_test.yml'
     end
   end
 end

--- a/lib/generators/active_fedora/config/fedora/templates/fcrepo_wrapper_test.yml
+++ b/lib/generators/active_fedora/config/fedora/templates/fcrepo_wrapper_test.yml
@@ -1,0 +1,4 @@
+#config/fcrepo_wrapper_test.yml.sample
+port: 8986
+enable_jms: false
+fcrepo_home_dir: tmp/fcrepo4-test-data

--- a/lib/generators/active_fedora/config/solr/solr_generator.rb
+++ b/lib/generators/active_fedora/config/solr/solr_generator.rb
@@ -12,6 +12,7 @@ module ActiveFedora
 
     def solr_wrapper_config
       copy_file '.solr_wrapper', '.solr_wrapper'
+      copy_file 'solr_wrapper_test.yml', 'config/solr_wrapper_test.yml'
     end
   end
 end

--- a/lib/generators/active_fedora/config/solr/templates/solr_wrapper_test.yml
+++ b/lib/generators/active_fedora/config/solr/templates/solr_wrapper_test.yml
@@ -1,0 +1,8 @@
+#config/solr_wrapper_test.yml
+# version: 6.0.0
+port: 8985
+instance_dir: tmp/solr-test
+collection:
+    persist: false
+    dir: solr/config
+    name: hydra-test

--- a/spec/integration/generators/fedora_generator_spec.rb
+++ b/spec/integration/generators/fedora_generator_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'generators/active_fedora/config/fedora/fedora_generator'
+
+describe ActiveFedora::Config::FedoraGenerator do
+  describe "#fcrepo_wrapper_config" do
+    let(:generator) { described_class.new }
+    let(:files_to_test) {[
+      'config/fcrepo_wrapper_test.yml',
+      '.fcrepo_wrapper'
+    ]}
+
+    before do
+      generator.fcrepo_wrapper_config
+    end
+
+    after do
+      files_to_test.each { |file| File.delete(file) if File.exist?(file) }
+    end
+
+    it "creates config files" do
+      files_to_test.each do |file|
+        expect(File).to exist(file), "Expected #{file} to exist"
+      end
+    end
+  end
+end

--- a/spec/integration/generators/solr_generator_spec.rb
+++ b/spec/integration/generators/solr_generator_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'generators/active_fedora/config/solr/solr_generator'
+
+describe ActiveFedora::Config::SolrGenerator do
+  describe "#solr_wrapper_config" do
+    let(:generator) { described_class.new }
+    let(:files_to_test) {[
+      'config/solr_wrapper_test.yml',
+      '.solr_wrapper'
+    ]}
+
+    before do
+      generator.solr_wrapper_config
+    end
+
+    after do
+      files_to_test.each { |file| File.delete(file) if File.exist?(file) }
+    end
+
+    it "creates config files" do
+      files_to_test.each do |file|
+        expect(File).to exist(file), "Expected #{file} to exist"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added development dependency on rails in order to include test for solr & fedora (rails) generators.

Closes projecthydra/hydra-head#339