### PR TITLE
Renamed `contains` to `has_subresource`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ Lint/HandleExceptions:
     - 'spec/unit/**/*'
     - 'spec/integration/**/*'
     - 'lib/active_fedora/cleaner.rb'
-    - 'lib/active_fedora/associations/builder/contains.rb'
+    - 'lib/active_fedora/associations/builder/has_subresource.rb'
 
 Lint/AssignmentInCondition:
   Enabled: false

--- a/lib/active_fedora/associations.rb
+++ b/lib/active_fedora/associations.rb
@@ -24,7 +24,7 @@ module ActiveFedora
     autoload :HasManyAssociation
     autoload :BelongsToAssociation
     autoload :HasAndBelongsToManyAssociation
-    autoload :BasicContainsAssociation
+    autoload :HasSubresourceAssociation
     autoload :DirectlyContainsAssociation
     autoload :DirectlyContainsOneAssociation
     autoload :IndirectlyContainsAssociation
@@ -45,7 +45,7 @@ module ActiveFedora
       autoload :BelongsTo,           'active_fedora/associations/builder/belongs_to'
       autoload :HasMany,             'active_fedora/associations/builder/has_many'
       autoload :HasAndBelongsToMany, 'active_fedora/associations/builder/has_and_belongs_to_many'
-      autoload :Contains,            'active_fedora/associations/builder/contains'
+      autoload :HasSubresource,      'active_fedora/associations/builder/has_subresource'
       autoload :DirectlyContains,    'active_fedora/associations/builder/directly_contains'
       autoload :DirectlyContainsOne, 'active_fedora/associations/builder/directly_contains_one'
       autoload :IndirectlyContains,  'active_fedora/associations/builder/indirectly_contains'
@@ -176,9 +176,25 @@ module ActiveFedora
         # @option options [Boolean] :autocreate Always create this resource on new objects
         # @yield block executed by some types of child resources
         def contains(name, options = {}, &block)
+          Deprecation.warn(Associations, "contains is deprecated. Use has_subresource instead. This will be removed in ActiveFedora 10")
+          has_subresource(name, options, &block)
+        end
+
+        # This method is used to specify the details of a contained resource.
+        # Pass the name as the first argument and a hash of options as the second argument
+        # Note that this method doesn't actually execute the block, but stores it, to be executed
+        # by any the implementation of the resource(specified as :class_name)
+        #
+        # @param [String] name the handle to refer to this child as
+        # @param [Hash] options
+        # @option options [Class] :class_name The class that will represent this child, should extend ``ActiveFedora::File'' or ``ActiveFedora::Base''
+        # @option options [String] :url
+        # @option options [Boolean] :autocreate Always create this resource on new objects
+        # @yield block executed by some types of child resources
+        def has_subresource(name, options = {}, &block)
           options[:block] = block if block
-          raise ArgumentError, "You must provide a name (dsid) for the datastream" unless name
-          Associations::Builder::Contains.build(self, name.to_sym, options)
+          raise ArgumentError, "You must provide a path name (f.k.a. dsid) for the resource" unless name
+          Associations::Builder::HasSubresource.build(self, name.to_sym, options)
         end
 
         # Specifies a one-to-one association with another class. This method should only be used

--- a/lib/active_fedora/associations/builder/aggregation.rb
+++ b/lib/active_fedora/associations/builder/aggregation.rb
@@ -6,7 +6,7 @@ module ActiveFedora::Associations::Builder
 
     def self.build(model, name, options)
       model.indirectly_contains name, { has_member_relation: has_member_relation(options), through: proxy_class, foreign_key: proxy_foreign_key, inserted_content_relation: inserted_content_relation }.merge(indirect_options(options))
-      model.contains contains_key(options), class_name: list_source_class
+      model.has_subresource contains_key(options), class_name: list_source_class
       model.orders name, through: contains_key(options)
     end
 

--- a/lib/active_fedora/associations/builder/has_subresource.rb
+++ b/lib/active_fedora/associations/builder/has_subresource.rb
@@ -1,7 +1,7 @@
 module ActiveFedora::Associations::Builder
-  class Contains < SingularAssociation #:nodoc:
+  class HasSubresource < SingularAssociation #:nodoc:
     def self.macro
-      :contains
+      :has_subresource
     end
 
     def self.valid_options(options)

--- a/lib/active_fedora/associations/has_subresource_association.rb
+++ b/lib/active_fedora/associations/has_subresource_association.rb
@@ -1,6 +1,6 @@
 module ActiveFedora
   module Associations
-    class BasicContainsAssociation < SingularAssociation #:nodoc:
+    class HasSubresourceAssociation < SingularAssociation #:nodoc:
       # Implements the reader method, e.g. foo.bar for Foo.has_one :bar
       def reader(force_reload = false)
         super || build

--- a/lib/active_fedora/attached_files.rb
+++ b/lib/active_fedora/attached_files.rb
@@ -132,7 +132,7 @@ module ActiveFedora
       def create_singleton_association(file_path)
         undeclared_files << file_path.to_sym
 
-        association = Associations::BasicContainsAssociation.new(self, Reflection::ContainsReflection.new(file_path, nil, { class_name: 'ActiveFedora::File' }, self.class))
+        association = Associations::HasSubresourceAssociation.new(self, Reflection::HasSubresourceReflection.new(file_path, nil, { class_name: 'ActiveFedora::File' }, self.class))
         @association_cache[file_path.to_sym] = association
 
         singleton_class.send :define_method, accessor_name(file_path) do
@@ -187,7 +187,7 @@ module ActiveFedora
           name = args.delete(:name)
           raise ArgumentError, "You must provide a :type property for the datastream '#{name}'" unless args[:type]
           args[:class_name] = args.delete(:type).to_s
-          contains(name, args, &block)
+          has_subresource(name, args, &block)
         end
         deprecation_deprecate :has_metadata
 
@@ -213,7 +213,7 @@ module ActiveFedora
           end
           name = args.delete(:name)
           args[:class_name] = args.delete(:type).to_s
-          contains(name, args)
+          has_subresource(name, args)
         end
         deprecation_deprecate :has_file_datastream
       end

--- a/lib/active_fedora/reflection.rb
+++ b/lib/active_fedora/reflection.rb
@@ -20,8 +20,8 @@ module ActiveFedora
                   BelongsToReflection
                 when :has_and_belongs_to_many
                   HasAndBelongsToManyReflection
-                when :contains
-                  ContainsReflection
+                when :has_subresource
+                  HasSubresourceReflection
                 when :directly_contains
                   DirectlyContainsReflection
                 when :directly_contains_one
@@ -107,11 +107,11 @@ module ActiveFedora
       end
 
       def child_resource_reflections
-        reflect_on_all_associations(:contains).select { |_, reflection| reflection.klass <= ActiveFedora::File }
+        reflect_on_all_associations(:has_subresource).select { |_, reflection| reflection.klass <= ActiveFedora::File }
       end
 
       def contained_rdf_source_reflections
-        reflect_on_all_associations(:contains).select { |_, reflection| !(reflection.klass <= ActiveFedora::File) }
+        reflect_on_all_associations(:has_subresource).select { |_, reflection| !(reflection.klass <= ActiveFedora::File) }
       end
 
       # Returns the AssociationReflection object for the +association+ (use the symbol).
@@ -503,13 +503,13 @@ module ActiveFedora
       end
     end
 
-    class ContainsReflection < AssociationReflection # :nodoc:
+    class HasSubresourceReflection < AssociationReflection # :nodoc:
       def macro
-        :contains
+        :has_subresource
       end
 
       def association_class
-        Associations::BasicContainsAssociation
+        Associations::HasSubresourceAssociation
       end
     end
 

--- a/spec/integration/attached_files_spec.rb
+++ b/spec/integration/attached_files_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe ActiveFedora::AttachedFiles do
-  describe "#contains" do
+  describe "#has_subresource" do
     before do
       class FooHistory < ActiveFedora::Base
-        contains 'child'
+        has_subresource 'child'
       end
     end
     after do

--- a/spec/integration/attributes_spec.rb
+++ b/spec/integration/attributes_spec.rb
@@ -18,7 +18,7 @@ describe "delegating attributes" do
       end
     end
     class RdfObject < ActiveFedora::Base
-      contains 'foo', class_name: 'PropertiesDatastream'
+      has_subresource 'foo', class_name: 'PropertiesDatastream'
       Deprecation.silence(ActiveFedora::Attributes) do
         has_attributes :depositor, datastream: :foo, multiple: false do |index|
           index.as :stored_searchable

--- a/spec/integration/complex_rdf_datastream_spec.rb
+++ b/spec/integration/complex_rdf_datastream_spec.rb
@@ -177,7 +177,7 @@ END
         end
 
         class SpecContainer < ActiveFedora::Base
-          contains :info, class_name: 'SpecDatastream'
+          has_subresource :info, class_name: 'SpecDatastream'
         end
 
         class SpecDatastream < ActiveFedora::NtriplesRDFDatastream

--- a/spec/integration/file_fixity_spec.rb
+++ b/spec/integration/file_fixity_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "Checking fixity" do
   before(:all) do
     class MockAFBase < ActiveFedora::Base
-      contains "data", autocreate: true
+      has_subresource "data", autocreate: true
     end
   end
 

--- a/spec/integration/has_subresource_spec.rb
+++ b/spec/integration/has_subresource_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe ActiveFedora::Base do
   before do
     class Source < ActiveFedora::Base
-      contains :sub_resource, class_name: "Source"
+      has_subresource :sub_resource, class_name: "Source"
       property :title, predicate: ::RDF::Vocab::DC.title, multiple: false
     end
   end

--- a/spec/integration/versionable_spec.rb
+++ b/spec/integration/versionable_spec.rb
@@ -142,7 +142,7 @@ describe ActiveFedora::Versionable do
       end
 
       class MockAFBase < ActiveFedora::Base
-        contains "descMetadata", class_name: 'VersionableDatastream', autocreate: true
+        has_subresource "descMetadata", class_name: 'VersionableDatastream', autocreate: true
       end
     end
 
@@ -272,7 +272,7 @@ describe ActiveFedora::Versionable do
       end
 
       class MockAFBase < ActiveFedora::Base
-        contains "descMetadata", class_name: 'VersionableDatastream', autocreate: true
+        has_subresource "descMetadata", class_name: 'VersionableDatastream', autocreate: true
       end
     end
 
@@ -395,7 +395,7 @@ describe ActiveFedora::Versionable do
       end
 
       class MockAFBase < ActiveFedora::Base
-        contains "content", class_name: 'BinaryDatastream', autocreate: true
+        has_subresource "content", class_name: 'BinaryDatastream', autocreate: true
       end
     end
 

--- a/spec/unit/attached_files_spec.rb
+++ b/spec/unit/attached_files_spec.rb
@@ -2,15 +2,15 @@ require 'spec_helper'
 
 describe ActiveFedora::AttachedFiles do
   subject { ActiveFedora::Base.new }
-  describe "contains" do
+  describe "has_subresource" do
     before do
       class Z < ActiveFedora::File
       end
       class FooHistory < ActiveFedora::Base
-        contains 'dsid', class_name: 'ActiveFedora::SimpleDatastream'
-        contains 'complex_ds', autocreate: true, class_name: 'Z'
-        contains 'thumbnail'
-        contains 'child_resource', class_name: 'ActiveFedora::Base'
+        has_subresource 'dsid', class_name: 'ActiveFedora::SimpleDatastream'
+        has_subresource 'complex_ds', autocreate: true, class_name: 'Z'
+        has_subresource 'thumbnail'
+        has_subresource 'child_resource', class_name: 'ActiveFedora::Base'
       end
     end
     after do
@@ -30,8 +30,8 @@ describe ActiveFedora::AttachedFiles do
     end
 
     it "raises an error if you don't give a dsid" do
-      expect { FooHistory.contains nil, type: ActiveFedora::SimpleDatastream }.to raise_error ArgumentError,
-                                                                                              "You must provide a name (dsid) for the datastream"
+      expect { FooHistory.has_subresource nil, type: ActiveFedora::SimpleDatastream }.to raise_error ArgumentError,
+                                                                                                     "You must provide a path name (f.k.a. dsid) for the resource"
     end
   end
 
@@ -72,7 +72,7 @@ describe ActiveFedora::AttachedFiles do
 
     it "raises an error if you don't give a dsid" do
       expect { FooHistory.has_metadata type: ActiveFedora::SimpleDatastream }.to raise_error ArgumentError,
-                                                                                             "You must provide a name (dsid) for the datastream"
+                                                                                             "You must provide a path name (f.k.a. dsid) for the resource"
     end
 
     describe "creates accessors" do
@@ -105,7 +105,7 @@ describe ActiveFedora::AttachedFiles do
       class Bar < ActiveFedora::File; end
 
       class FooHistory < ActiveFedora::Base
-        contains :content, class_name: 'Bar'
+        has_subresource :content, class_name: 'Bar'
       end
     end
 
@@ -183,7 +183,7 @@ describe ActiveFedora::AttachedFiles do
     context "when there are declared attached files" do
       before do
         class FooHistory < ActiveFedora::Base
-          contains 'thumbnail'
+          has_subresource 'thumbnail'
         end
       end
 


### PR DESCRIPTION
`contains` is deprectated until AF 10. The plan is to add a true basic
containment, where I post to the BasicContainer to get a URI (rather
than knowing the relative path ahead of time).