### PR TITLE
AF::File#save! should persist metadata

### DIFF
--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -48,12 +48,6 @@ module ActiveFedora
       end
     end
 
-    def save
-      super.tap do
-        metadata.save if metadata.changed?
-      end
-    end
-
     def described_by
       raise "#{self} isn't persisted yet" if new_record?
       links['describedby'].first
@@ -175,6 +169,12 @@ module ActiveFedora
       end
 
     private
+
+      def create_or_update(*options)
+        super.tap do
+          metadata.save if metadata.changed?
+        end
+      end
 
       # Rack::Test::UploadedFile is often set via content=, however it's not an IO, though it wraps an io object.
       def behaves_like_io?(obj)

--- a/spec/unit/file_spec.rb
+++ b/spec/unit/file_spec.rb
@@ -7,6 +7,21 @@ describe ActiveFedora::File do
 
   it { is_expected.not_to be_metadata }
 
+  describe "#save!" do
+    context "when updating metadata" do
+      before do
+        file.content = 'foo'
+        file.save!
+        file.mime_type = 'application/pdf'
+      end
+
+      it "Updates metadata" do
+        expect(file.metadata).to receive(:save)
+        file.save!
+      end
+    end
+  end
+
   describe "#behaves_like_io?" do
     subject { file.send(:behaves_like_io?, object) }
 


### PR DESCRIPTION
Previously metadata was only persisted when `save()` was called,
`save!()` was not persisting.