### PR TITLE
Deprecate datastreams

### DIFF
--- a/lib/active_fedora/nom_datastream.rb
+++ b/lib/active_fedora/nom_datastream.rb
@@ -3,10 +3,16 @@ require "nom"
 module ActiveFedora
   class NomDatastream < File
     include Datastreams::NokogiriDatastreams
+    extend Deprecation
 
     def self.set_terminology(options = {}, &block)
       @terminology_options = options || {}
       @terminology = block
+    end
+
+    def initialize(*args)
+      super
+      Deprecation.warn(NomDatastream, "NomDatastream is deprecated and will be removed in ActiveFedora 11")
     end
 
     class << self

--- a/lib/active_fedora/om_datastream.rb
+++ b/lib/active_fedora/om_datastream.rb
@@ -12,9 +12,15 @@ module ActiveFedora
     include OM::XML::Document
     include OM::XML::TerminologyBasedSolrizer # this adds support for calling .to_solr
     include Datastreams::NokogiriDatastreams
+    extend Deprecation
 
     alias om_term_values term_values unless method_defined?(:om_term_values)
     alias om_update_values update_values unless method_defined?(:om_update_values)
+
+    def initialize(*args)
+      super
+      Deprecation.warn(OmDatastream, "OmDatastream is deprecated and will be removed in ActiveFedora 11")
+    end
 
     def default_mime_type
       'text/xml'

--- a/lib/active_fedora/rdf/ntriples_rdf_datastream.rb
+++ b/lib/active_fedora/rdf/ntriples_rdf_datastream.rb
@@ -5,5 +5,9 @@ module ActiveFedora
     def serialization_format
       :ntriples
     end
+
+    def deprecation_warning
+      Deprecation.warn(NtriplesRDFDatastream, "NtriplesRDFDatastream is deprecated and will be removed in ActiveFedora 11", caller(2))
+    end
   end
 end

--- a/lib/active_fedora/rdf/rdf_datastream.rb
+++ b/lib/active_fedora/rdf/rdf_datastream.rb
@@ -4,8 +4,17 @@ module ActiveFedora
     include RDF::DatastreamIndexing
     include ActiveTriples::Properties
     include ActiveTriples::Reflection
+    extend Deprecation
 
     delegate :rdf_subject, :set_value, :get_values, :attributes=, to: :resource
+    def initialize(*args)
+      super
+      deprecation_warning
+    end
+
+    def deprecation_warning
+      Deprecation.warn(RDFDatastream, "RDFDatastream is deprecated and will be removed in ActiveFedora 11", caller(2))
+    end
 
     class << self
       def rdf_subject(&block)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,12 @@ restore_spec_configuration
 
 require 'active_fedora/cleaner'
 RSpec.configure do |config|
+  config.before(:suite) do
+    ActiveFedora::RDFDatastream.deprecation_behavior = :silence
+    ActiveFedora::NtriplesRDFDatastream.deprecation_behavior = :silence
+    ActiveFedora::OmDatastream.deprecation_behavior = :silence
+    ActiveFedora::NomDatastream.deprecation_behavior = :silence
+  end
   # Stub out test stuff.
   config.before(:each) do
     begin


### PR DESCRIPTION
Datastreams no longer need to be part of ActiveFedora. They are just ActiveFedora::Files.