### PR TITLE
Sending multiple values from a where cluase will join with OR

### DIFF
--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -255,13 +255,13 @@ module ActiveFedora
       # @param [Hash<Symbol,String>] conditions
       # @return [Array<String>]
       def create_query_from_hash(conditions)
-        conditions.map { |key, value| condition_to_clauses(key, value) }.compact
+        conditions.map { |key, value| condition_to_clauses(key, value, ' OR ') }.compact
       end
 
       # @param [Symbol] key
       # @param [String] value
-      def condition_to_clauses(key, value)
-        SolrQueryBuilder.construct_query([[field_name_for(key), value]])
+      def condition_to_clauses(key, value, join_with = SolrQueryBuilder.default_join_with)
+        SolrQueryBuilder.construct_query([[field_name_for(key), value]], join_with)
       end
 
       # If the key is a property name, turn it into a solr field

--- a/lib/active_fedora/scoping/named.rb
+++ b/lib/active_fedora/scoping/named.rb
@@ -13,6 +13,7 @@ module ActiveFedora
         #
         #   fruits = Fruit.all
         #   fruits = fruits.where(color: 'red') if options[:red_only]
+        #   fruits = fruits.where(size: ['big', 'little']) # gets big or little fruit
         #   fruits = fruits.limit(10) if limited?
         #
         # You can define a scope that applies to all finders using

--- a/lib/active_fedora/solr_query_builder.rb
+++ b/lib/active_fedora/solr_query_builder.rb
@@ -19,7 +19,7 @@ module ActiveFedora
       #   # => _query_:"{!field f=has_model_ssim}info:fedora/afmodel:ComplexCollection" OR _query_:"{!field f=has_model_ssim}info:fedora/afmodel:ActiveFedora_Base"
       #
       #   construct_query_for_rel [[Book._reflect_on_association(:library), "foo/bar/baz"]]
-      def construct_query_for_rel(field_pairs, join_with = ' AND ')
+      def construct_query_for_rel(field_pairs, join_with = default_join_with)
         field_pairs = field_pairs.to_a if field_pairs.is_a? Hash
         construct_query(property_values_to_solr(field_pairs), join_with)
       end
@@ -31,8 +31,15 @@ module ActiveFedora
       # @example
       #   construct_query([['library_id_ssim', '123'], ['owner_ssim', 'Fred']])
       #   # => "_query_:\"{!field f=library_id_ssim}123\" AND _query_:\"{!field f=owner_ssim}Fred\""
-      def construct_query(field_pairs, join_with = ' AND ')
-        pairs_to_clauses(field_pairs).join(join_with)
+      def construct_query(field_pairs, join_with = default_join_with)
+        clauses = pairs_to_clauses(field_pairs)
+        return "" if clauses.count == 0
+        return clauses.first if clauses.count == 1
+        "(#{clauses.join(join_with)})"
+      end
+
+      def default_join_with
+        ' AND '
       end
 
       private

--- a/spec/integration/scoped_query_spec.rb
+++ b/spec/integration/scoped_query_spec.rb
@@ -65,6 +65,7 @@ describe ActiveFedora::Querying do
         field = ActiveFedora.index_field_mapper.solr_name('foo', type: :string)
         expect(ModelIntegrationSpec::Basic.where(field => 'Beta')).to eq [test_instance1]
         expect(ModelIntegrationSpec::Basic.where('foo' => 'Beta')).to eq [test_instance1]
+        expect(ModelIntegrationSpec::Basic.where('foo' => ['Beta', 'Alpha'])).to eq [test_instance1, test_instance2]
       end
       it "orders" do
         expect(ModelIntegrationSpec::Basic.order(ActiveFedora.index_field_mapper.solr_name('foo', :sortable) + ' asc')).to eq [test_instance2, test_instance1, test_instance3]

--- a/spec/unit/finder_methods_spec.rb
+++ b/spec/unit/finder_methods_spec.rb
@@ -51,8 +51,8 @@ describe ActiveFedora::FinderMethods do
 
     context "when value is an array" do
       let(:value) { ['one', 'four'] }
-      it { is_expected.to eq "_query_:\"{!field f=library_id}one\" AND " \
-                             "_query_:\"{!field f=library_id}four\"" }
+      it { is_expected.to eq "(_query_:\"{!field f=library_id}one\" AND " \
+                             "_query_:\"{!field f=library_id}four\")" }
     end
   end
 

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -79,8 +79,8 @@ describe ActiveFedora::Base do
     let(:solr) { ActiveFedora::SolrService.instance.conn }
     let(:expected_query) { "#{model_query} AND " \
                            "_query_:\"{!field f=foo}bar\" AND " \
-                           "_query_:\"{!field f=baz}quix\" AND " \
-                           "_query_:\"{!field f=baz}quack\"" }
+                           "(_query_:\"{!field f=baz}quix\" OR " \
+                           "_query_:\"{!field f=baz}quack\")" }
     let(:expected_params) { { params: { sort: [sort_query], fl: 'id', q: expected_query, qt: 'standard' } } }
     let(:expected_sort_params) { { params: { sort: ["title_t desc"], fl: 'id', q: expected_query, qt: 'standard' } } }
     let(:mock_docs) { [{ "id" => "changeme:30" }, { "id" => "changeme:22" }] }
@@ -138,8 +138,8 @@ describe ActiveFedora::Base do
       let(:solr) { ActiveFedora::SolrService.instance.conn }
       let(:expected_query) { "#{model_query} AND " \
                              "_query_:\"{!field f=foo}bar\" AND " \
-                             "_query_:\"{!field f=baz}quix\" AND " \
-                             "_query_:\"{!field f=baz}quack\"" }
+                             "(_query_:\"{!field f=baz}quix\" OR " \
+                             "_query_:\"{!field f=baz}quack\")" }
       let(:expected_params) { { params: { sort: [sort_query], fl: 'id', q: expected_query, qt: 'standard' } } }
       let(:mock_docs) { [{ "id" => "changeme-30" }, { "id" => "changeme-22" }] }
 
@@ -159,8 +159,8 @@ describe ActiveFedora::Base do
       let(:solr) { ActiveFedora::SolrService.instance.conn }
       let(:expected_query) { "#{model_query} AND " \
                              "_query_:\"{!field f=foo}bar\" AND " \
-                             "_query_:\"{!field f=baz}quix\" AND " \
-                             "_query_:\"{!field f=baz}quack\"" }
+                             "(_query_:\"{!field f=baz}quix\" OR " \
+                             "_query_:\"{!field f=baz}quack\")" }
       let(:expected_params) { { params: { sort: [sort_query], fl: 'id', q: expected_query, qt: 'standard' } } }
       let(:mock_docs) { double('docs') }
 
@@ -254,8 +254,8 @@ describe ActiveFedora::Base do
     context "with a hash of conditions" do
       let(:expected_query) { "#{model_query} AND " \
                              "_query_:\"{!field f=foo}bar\" AND " \
-                             "_query_:\"{!field f=baz}quix\" AND " \
-                             "_query_:\"{!field f=baz}quack\"" }
+                             "(_query_:\"{!field f=baz}quix\" OR " \
+                             "_query_:\"{!field f=baz}quack\")" }
       let(:conditions) { { foo: 'bar', baz: ['quix', 'quack'] } }
 
       it "makes a query to solr and returns the results" do
@@ -266,8 +266,8 @@ describe ActiveFedora::Base do
     context "with quotes in the params" do
       let(:expected_query) { "#{model_query} AND " \
                              "_query_:\"{!field f=foo}9\\\" Nails\" AND " \
-                             "_query_:\"{!field f=baz}7\\\" version\" AND " \
-                             "_query_:\"{!field f=baz}quack\"" }
+                             "(_query_:\"{!field f=baz}7\\\" version\" OR " \
+                             "_query_:\"{!field f=baz}quack\")" }
       let(:conditions) { { foo: '9" Nails', baz: ['7" version', 'quack'] } }
 
       it "escapes quotes" do


### PR DESCRIPTION
This allows for finding all the objects that are 'this OR that' which is how the active record where with an array works.
Added parens around clauses since 'abc' AND  'ddd' OR 'fff' is not the same as 'abc' AND ('ddd' OR 'fff').  This was not an issue before since all the clauses were joined with AND

This is an update for master that matches with the PR that was put into the 9.7.x branch and merged yesterday.