### PR TITLE
Performance Improvements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,6 +89,7 @@ Metrics/ClassLength:
     - 'lib/active_fedora/reflection.rb'
     - 'lib/active_fedora/orders/ordered_list.rb'
     - 'lib/active_fedora/solr_service.rb'
+    - 'lib/active_fedora/associations/orders_association.rb'
 
 Metrics/MethodLength:
   Enabled: false

--- a/lib/active_fedora/associations/builder/orders.rb
+++ b/lib/active_fedora/associations/builder/orders.rb
@@ -14,6 +14,9 @@ module ActiveFedora::Associations::Builder
       mixin.redefine_method(target_accessor(name)) do
         association(name).target_reader
       end
+      mixin.redefine_method("#{target_accessor(name, pluralize: false)}_ids") do
+        association(name).target_ids_reader
+      end
       mixin.redefine_method("#{target_accessor(name)}=") do |nodes|
         association(name).target_writer(nodes)
       end
@@ -27,7 +30,7 @@ module ActiveFedora::Associations::Builder
       model.send(:define_method, :apply_first_and_last) do
         source = send(options[:through])
         source.save
-        return if head.map(&:rdf_subject) == source.head_id && tail.map(&:rdf_subject) == source.tail_id
+        return if head_ids == source.head_id && tail_ids == source.tail_id
         self.head = source.head_id
         self.tail = source.tail_id
         save! if changed?
@@ -50,8 +53,13 @@ module ActiveFedora::Associations::Builder
       end
     end
 
-    def self.target_accessor(name)
-      name.to_s.gsub("_proxies", "").pluralize
+    def self.target_accessor(name, pluralize: true)
+      name = name.to_s.gsub("_proxies", "")
+      if pluralize
+        name.pluralize
+      else
+        name
+      end
     end
     private_class_method :target_accessor
 

--- a/lib/active_fedora/associations/orders_association.rb
+++ b/lib/active_fedora/associations/orders_association.rb
@@ -27,6 +27,10 @@ module ActiveFedora::Associations
       @target_proxy ||= ActiveFedora::Orders::TargetProxy.new(self)
     end
 
+    def target_ids_reader
+      target_reader.ids
+    end
+
     def find_reflection
       reflection
     end

--- a/lib/active_fedora/fedora_attributes.rb
+++ b/lib/active_fedora/fedora_attributes.rb
@@ -43,7 +43,7 @@ module ActiveFedora
       # Appending the graph at the end is necessary because adding it as the
       # parent leaves behind triples not related to the ldp_source's rdf
       # subject.
-      @resource ||= self.class.resource_class.new(@ldp_source.graph.rdf_subject, @ldp_source.graph) << @ldp_source.graph
+      @resource ||= self.class.resource_class.new(@ldp_source.graph.rdf_subject, data: @ldp_source.graph.send(:graph).data)
     end
 
     # You can set the URI to use for the rdf_label on ClassMethods.rdf_label, then on

--- a/lib/active_fedora/orders/list_node.rb
+++ b/lib/active_fedora/orders/list_node.rb
@@ -4,7 +4,7 @@ module ActiveFedora::Orders
     attr_accessor :prev, :next, :target
     attr_writer :next_uri, :prev_uri
     attr_accessor :proxy_in, :proxy_for
-    def initialize(node_cache, rdf_subject, graph = ActiveTriples::Resource.new)
+    def initialize(node_cache, rdf_subject, graph = RDF::Repository.new)
       @rdf_subject = rdf_subject
       @graph = graph
       @node_cache = node_cache
@@ -144,7 +144,7 @@ module ActiveFedora::Orders
         private
 
           def resource
-            @resource ||= Resource.new(uri, graph)
+            @resource ||= Resource.new(uri, data: graph)
           end
       end
 

--- a/lib/active_fedora/orders/ordered_list.rb
+++ b/lib/active_fedora/orders/ordered_list.rb
@@ -13,7 +13,11 @@ module ActiveFedora
       # @param [::RDF::URI] head_subject URI of head node in list.
       # @param [::RDF::URI] tail_subject URI of tail node in list.
       def initialize(graph, head_subject, tail_subject)
-        @graph = graph
+        @graph = if graph.respond_to?(:graph, true)
+                   graph.send(:graph).data
+                 else
+                   graph
+                 end
         @head_subject = head_subject
         @tail_subject = tail_subject
         @node_cache ||= NodeCache.new

--- a/lib/active_fedora/orders/target_proxy.rb
+++ b/lib/active_fedora/orders/target_proxy.rb
@@ -24,6 +24,10 @@ module ActiveFedora
         self
       end
 
+      def ids
+        association.reader.map(&:target_id)
+      end
+
       # Deletes the element at the specified index, returning that element, or nil if
       # the index is out of range.
       def delete_at(loc)

--- a/spec/unit/ordered_spec.rb
+++ b/spec/unit/ordered_spec.rb
@@ -232,6 +232,7 @@ describe ActiveFedora::Orders do
       subject.save
       subject.reload
       expect(subject.ordered_members).to eq [member, member]
+      expect(subject.ordered_member_ids).to eq [member.id, member.id]
       expect(subject.list_source.resource.query([nil, ::RDF::Vocab::ORE.proxyIn, subject.resource.rdf_subject]).to_a.length).to eq 2
       expect(subject.head_ids).to eq subject.list_source.head_id
       expect(subject.tail_ids).to eq subject.list_source.tail_id


### PR DESCRIPTION
Shares an in-memory repository between the LDP graph and the AF::Base's
resource. Reduces graph copying by a significant amount.

Also adds an ids reader to ordered associations which doesn't instantiate objects.