### PR TITLE
Adding in the terms handler so that generated apps inculde this by default

### DIFF
--- a/lib/generators/active_fedora/config/solr/templates/solr/config/solrconfig.xml
+++ b/lib/generators/active_fedora/config/solr/templates/solr/config/solrconfig.xml
@@ -187,6 +187,17 @@
     </lst>
   </requestHandler>
 
+  <searchComponent name="termsComponent" class="solr.TermsComponent" />
+
+  <requestHandler name="/terms" class="solr.SearchHandler">
+    <lst name="defaults">
+      <bool name="terms">true</bool>
+    </lst>
+    <arr name="components">
+      <str>termsComponent</str>
+    </arr>
+  </requestHandler>
+
 <!-- Spell Check
 
         The spell check component can return a list of alternative spelling


### PR DESCRIPTION
This PR is dependant on #1119 

Also adding in a few additional changes from Sufia that seemed reasonable

This change should fix the issue that some people have been seeing when running tests in other gems:

```
   Failure/Error:
       json = solr_connection.get 'terms', params: { 'terms.fl' => term,
```

The solr config that is currently generated by active fedora does not include the terms configuration.