### PR TITLE
Bump rubocop-rspec version

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "equivalent-xml"
   s.add_development_dependency "simplecov", '~> 0.8'
   s.add_development_dependency "rubocop", '~> 0.42.0'
-  s.add_development_dependency "rubocop-rspec", '~> 1.4'
+  s.add_development_dependency "rubocop-rspec", '~> 1.6'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec}/*`.split("\n")


### PR DESCRIPTION
This is required to prevent an incompatible alignment of rubocop and
rubocop-rspec versions.  It should not be our job to notice this
(rubocop-rspec should use greater precision to describe the version(s)
of rubocop each release is compatible with), but in practice, it falls to
us.

Without this bump, the error upon running `rake` was:
```
Running RuboCop...
undefined method `for_all_cops' for #<Hash:0x007fac583619e0>
/Users/atz/.rvm/gems/ruby-2.3.0/gems/rubocop-0.42.0/lib/rubocop/config_loader.rb:119:in `merge_with_default'
...
```