### PR TITLE
Bump dependency on rsolr to >= 1.1.2

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license = "APACHE2"
   s.required_ruby_version = '~> 2.0'
 
-  s.add_dependency 'rsolr', '~> 1.0', '>= 1.0.10'
+  s.add_dependency 'rsolr', '~> 1.1', '>= 1.1.2'
   s.add_dependency 'solrizer', '~> 3.4'
   s.add_dependency "activesupport", '>= 4.2.4', '< 6'
   s.add_dependency "activemodel", '>= 4.2', '< 6'


### PR DESCRIPTION
1.1.2 correctly solrizes the ActiveTriple::Relations that exist in AT 0.10