### PR TITLE
Rename to_class_uri to to_rdf_representation

### DIFF
--- a/lib/active_fedora/associations/collection_association.rb
+++ b/lib/active_fedora/associations/collection_association.rb
@@ -291,7 +291,7 @@ module ActiveFedora
         def construct_query
           @solr_query ||= begin
             clauses = { find_reflection => @owner.id }
-            clauses[:has_model] = @reflection.class_name.constantize.to_class_uri if @reflection.class_name && @reflection.class_name != 'ActiveFedora::Base'
+            clauses[:has_model] = @reflection.klass.to_rdf_representation if @reflection.klass != ActiveFedora::Base
             ActiveFedora::SolrQueryBuilder.construct_query_for_rel(clauses)
           end
         end

--- a/lib/active_fedora/associations/contained_finder.rb
+++ b/lib/active_fedora/associations/contained_finder.rb
@@ -40,7 +40,7 @@ module ActiveFedora::Associations
       # a slow fedora call
       def relation_subjects(record)
         query = ActiveFedora::SolrQueryBuilder.construct_query_for_rel(
-          [[:has_model, proxy_class.to_class_uri], [:proxyFor, record.id]]
+          [[:has_model, proxy_class.to_rdf_representation], [:proxyFor, record.id]]
         )
         ActiveFedora::SolrService.query(query, fl: 'id').map(&:rdf_uri)
       end

--- a/lib/active_fedora/core.rb
+++ b/lib/active_fedora/core.rb
@@ -96,13 +96,14 @@ module ActiveFedora
 
     protected
 
-      # This can be overriden to assert a different model
-      # It's normally called once in the lifecycle, by #create#
+      # This method is normally called once in the lifecycle, by #create#
       def assert_content_model
-        self.has_model = self.class.to_s
+        self.has_model = self.class.to_rdf_representation
       end
 
       module ClassMethods
+        extend Deprecation
+
         def generated_association_methods
           @generated_association_methods ||= begin
             mod = const_set(:GeneratedAssociationMethods, Module.new)
@@ -111,12 +112,22 @@ module ActiveFedora
           end
         end
 
-        # Returns a suitable uri object for :has_model
-        # Should reverse Model#from_class_uri
-        # TODO this is a poorly named method
-        def to_class_uri(_attrs = {})
+        # Returns a suitable string representation for :has_model
+        # Override this method if you want to change how this class
+        # is represented in RDF.
+        def to_rdf_representation
           name
         end
+
+        # Returns a suitable string representation for :has_model
+        # @deprecated use to_rdf_representation instead
+        def to_class_uri(attrs = nil)
+          if attrs
+            Deprecation.warn ActiveFedora::Core, "to_class_uri no longer acceps an argument"
+          end
+          to_rdf_representation
+        end
+        deprecation_deprecate to_class_uri: "use 'to_rdf_representation()' instead"
 
         private
 

--- a/spec/unit/base_extra_spec.rb
+++ b/spec/unit/base_extra_spec.rb
@@ -30,20 +30,4 @@ describe ActiveFedora::Base do
       object.delete
     end
   end
-
-  describe "to_class_uri" do
-    before :all do
-      module SpecModel
-        class CamelCased < ActiveFedora::Base
-        end
-      end
-    end
-
-    after :all do
-      Object.send(:remove_const, :SpecModel)
-    end
-    subject { SpecModel::CamelCased.to_class_uri }
-
-    it { should == 'SpecModel::CamelCased' }
-  end
 end

--- a/spec/unit/core_spec.rb
+++ b/spec/unit/core_spec.rb
@@ -169,4 +169,40 @@ describe ActiveFedora::Base do
       it { should eq '123456w' }
     end
   end
+
+  describe "to_class_uri" do
+    before do
+      module SpecModel
+        class CamelCased < ActiveFedora::Base
+        end
+      end
+    end
+
+    after do
+      Object.send(:remove_const, :SpecModel)
+    end
+    subject do
+      Deprecation.silence(ActiveFedora::Core::ClassMethods) do
+        SpecModel::CamelCased.to_class_uri
+      end
+    end
+
+    it { is_expected.to eq 'SpecModel::CamelCased' }
+  end
+
+  describe "to_rdf_representation" do
+    before do
+      module SpecModel
+        class CamelCased < ActiveFedora::Base
+        end
+      end
+    end
+
+    after do
+      Object.send(:remove_const, :SpecModel)
+    end
+    subject { SpecModel::CamelCased.to_rdf_representation }
+
+    it { is_expected.to eq 'SpecModel::CamelCased' }
+  end
 end


### PR DESCRIPTION
to_class_uri was a poorly chosen name in light of the fact that it
doesn't return URIs.