### PR TITLE
Cast RDF Literals to strings when indexing.

### DIFF
--- a/lib/active_fedora/rdf.rb
+++ b/lib/active_fedora/rdf.rb
@@ -7,5 +7,6 @@ module ActiveFedora
     autoload :ProjectHydra
     autoload :FieldMap
     autoload :FieldMapEntry
+    autoload :ValueCaster
   end
 end

--- a/lib/active_fedora/rdf/field_map_entry.rb
+++ b/lib/active_fedora/rdf/field_map_entry.rb
@@ -22,5 +22,11 @@ module ActiveFedora::RDF
       self.behaviors.uniq!
       self.values += values
     end
+
+    def values
+      @values.map do |value|
+        ValueCaster.new(value).value
+      end
+    end
   end
 end

--- a/lib/active_fedora/rdf/value_caster.rb
+++ b/lib/active_fedora/rdf/value_caster.rb
@@ -1,0 +1,15 @@
+module ActiveFedora::RDF
+  class ValueCaster
+    def initialize(value)
+      @value = value
+    end
+
+    def value
+      if @value.respond_to?(:language) # Cast RDF::Literals
+        @value.to_s
+      else
+        @value
+      end
+    end
+  end
+end

--- a/spec/unit/rdf/indexing_service_spec.rb
+++ b/spec/unit/rdf/indexing_service_spec.rb
@@ -20,7 +20,7 @@ describe ActiveFedora::RDF::IndexingService do
     MyObj.new.tap do |obj|
       obj.created = [Date.parse("2012-03-04")]
       obj.title = ["Of Mice and Men, The Sequel"]
-      obj.publisher = ["Bob's Blogtastic Publishing"]
+      obj.publisher = [RDF::Literal.new("Bob's Blogtastic Publishing", language: :fr)]
       obj.based_near = ["Tacoma, WA", "Renton, WA"]
       obj.related_url = ["http://example.org/blogtastic/"]
       obj.rights = ["Totally open, y'all"]


### PR DESCRIPTION
Temporary fix until we find a nicer way to index literal information.