### PR TITLE
Use ActiveFedora::NullLogger

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -89,6 +89,7 @@ module ActiveFedora #:nodoc:
     autoload :ModelClassifier
     autoload :NestedAttributes
     autoload :NullRelation
+    autoload :NullLogger
     autoload :Orders
     autoload :Pathing
     autoload :Persistence

--- a/lib/active_fedora/associations/collection_association.rb
+++ b/lib/active_fedora/associations/collection_association.rb
@@ -305,7 +305,7 @@ module ActiveFedora
           records.each { |record| set_inverse_instance(record) }
           records
         rescue ObjectNotFoundError, Ldp::Gone => e
-          ActiveFedora::Base.logger.error "Solr and Fedora may be out of sync:\n" + e.message if ActiveFedora::Base.logger
+          ActiveFedora::Base.logger.error "Solr and Fedora may be out of sync:\n" + e.message
           reset
           []
         end

--- a/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
+++ b/lib/active_fedora/associations/has_and_belongs_to_many_association.rb
@@ -21,7 +21,7 @@ module ActiveFedora
         if reflection.options[:inverse_of]
           inverse = reflection.inverse_of
           if owner.new_record?
-            ActiveFedora::Base.logger.warn("has_and_belongs_to_many #{reflection.inspect} is cowardly refusing to insert the inverse relationship into #{record}, because #{owner} is not persisted yet.") if ActiveFedora::Base.logger
+            ActiveFedora::Base.logger.warn("has_and_belongs_to_many #{reflection.inspect} is cowardly refusing to insert the inverse relationship into #{record}, because #{owner} is not persisted yet.")
           elsif inverse.has_and_belongs_to_many?
             record[inverse.foreign_key] ||= []
             record[inverse.foreign_key] += [owner.id]

--- a/lib/active_fedora/attributes.rb
+++ b/lib/active_fedora/attributes.rb
@@ -138,7 +138,7 @@ module ActiveFedora
           def warn_duplicate_predicates(new_name, new_properties)
             new_predicate = new_properties[:predicate]
             properties.select { |_k, existing| existing.predicate == new_predicate }.each do |key, _value|
-              ActiveFedora::Base.logger.warn "Same predicate (#{new_predicate}) used for properties #{key} and #{new_name}" if ActiveFedora::Base.logger
+              ActiveFedora::Base.logger.warn "Same predicate (#{new_predicate}) used for properties #{key} and #{new_name}"
             end
           end
 

--- a/lib/active_fedora/cleaner.rb
+++ b/lib/active_fedora/cleaner.rb
@@ -48,7 +48,7 @@ module ActiveFedora
     end
 
     def self.log(message)
-      ActiveFedora::Base.logger.debug message if ActiveFedora::Base.logger
+      ActiveFedora::Base.logger.debug message
     end
   end
 end

--- a/lib/active_fedora/core.rb
+++ b/lib/active_fedora/core.rb
@@ -8,13 +8,21 @@ module ActiveFedora
     autoload :FedoraUriTranslator
 
     included do
-      ##
-      # :singleton-method:
-      #
+      mattr_accessor :belongs_to_required_by_default, instance_accessor: false
+
       # Accepts a logger conforming to the interface of Log4r which can be
       # retrieved on both a class and instance level by calling +logger+.
-      mattr_accessor :logger, instance_writer: false
-      mattr_accessor :belongs_to_required_by_default, instance_accessor: false
+      class_attribute :logger
+
+      # Use NullLogger if none is set and all messages sent to it are retuned as nil
+      def self.logger
+        self.logger ||= ActiveFedora::NullLogger.new
+      end
+
+      # All instances default to the class-level logger
+      def logger
+        self.class.logger
+      end
     end
 
     # Constructor.  You may supply a custom +:id+, or we call the Fedora Rest API for the

--- a/lib/active_fedora/fedora.rb
+++ b/lib/active_fedora/fedora.rb
@@ -86,7 +86,7 @@ module ActiveFedora
 
     def validate_options
       unless host.downcase.end_with?("/rest")
-        ActiveFedora::Base.logger.warn "Fedora URL (#{host}) does not end with /rest. This could be a problem. Check your fedora.yml config" if ActiveFedora::Base.logger
+        ActiveFedora::Base.logger.warn "Fedora URL (#{host}) does not end with /rest. This could be a problem. Check your fedora.yml config"
       end
     end
   end

--- a/lib/active_fedora/file_configurator.rb
+++ b/lib/active_fedora/file_configurator.rb
@@ -99,7 +99,7 @@ module ActiveFedora
     def load_fedora_config
       return @fedora_config unless @fedora_config.empty?
       @fedora_config_path = config_path(:fedora)
-      ActiveFedora::Base.logger.info("ActiveFedora: loading fedora config from #{::File.expand_path(@fedora_config_path)}") if ActiveFedora::Base.logger
+      ActiveFedora::Base.logger.info("ActiveFedora: loading fedora config from #{::File.expand_path(@fedora_config_path)}")
 
       begin
         config_erb = ERB.new(IO.read(@fedora_config_path)).result(binding)
@@ -124,7 +124,7 @@ module ActiveFedora
       return @solr_config unless @solr_config.empty?
       @solr_config_path = config_path(:solr)
 
-      ActiveFedora::Base.logger.info "ActiveFedora: loading solr config from #{::File.expand_path(@solr_config_path)}" if ActiveFedora::Base.logger
+      ActiveFedora::Base.logger.info "ActiveFedora: loading solr config from #{::File.expand_path(@solr_config_path)}"
       begin
         config_erb = ERB.new(IO.read(@solr_config_path)).result(binding)
       rescue StandardError
@@ -188,7 +188,7 @@ module ActiveFedora
       # Last choice, check for the default config file
       config_path = ::File.join(ActiveFedora.root, "config", "#{config_type}.yml")
       if ::File.file? config_path
-        ActiveFedora::Base.logger.warn "Using the default #{config_type}.yml that comes with active-fedora.  If you want to override this, pass the path to #{config_type}.yml to ActiveFedora - ie. ActiveFedora.init(:#{config_type}_config_path => '/path/to/#{config_type}.yml') - or set Rails.root and put #{config_type}.yml into \#{Rails.root}/config." if ActiveFedora::Base.logger
+        ActiveFedora::Base.logger.warn "Using the default #{config_type}.yml that comes with active-fedora.  If you want to override this, pass the path to #{config_type}.yml to ActiveFedora - ie. ActiveFedora.init(:#{config_type}_config_path => '/path/to/#{config_type}.yml') - or set Rails.root and put #{config_type}.yml into \#{Rails.root}/config."
         return config_path
       else
         raise ConfigurationError, "Couldn't load #{config_type} config file!"

--- a/lib/active_fedora/initializing_connection.rb
+++ b/lib/active_fedora/initializing_connection.rb
@@ -54,7 +54,7 @@ module ActiveFedora
         return if @initialized
 
         connection.head(root_resource_path)
-        ActiveFedora::Base.logger.info "Attempted to init base path `#{root_resource_path}`, but it already exists" if ActiveFedora::Base.logger
+        ActiveFedora::Base.logger.info "Attempted to init base path `#{root_resource_path}`, but it already exists"
         @initialized = true
         false
       rescue Ldp::NotFound

--- a/lib/active_fedora/loadable_from_json.rb
+++ b/lib/active_fedora/loadable_from_json.rb
@@ -176,7 +176,7 @@ module ActiveFedora
       def property_reflection(attribute_name)
         self.class.reflect_on_property(attribute_name)
       rescue ActiveTriples::UndefinedPropertyError
-        ActiveFedora::Base.logger.info "Undefined property #{attribute_name} reflected." if ActiveFedora::Base.logger
+        ActiveFedora::Base.logger.info "Undefined property #{attribute_name} reflected."
         nil
       end
 

--- a/lib/active_fedora/model_classifier.rb
+++ b/lib/active_fedora/model_classifier.rb
@@ -60,7 +60,7 @@ module ActiveFedora
 
       def classify(model_value)
         unless class_exists?(model_value)
-          ActiveFedora::Base.logger.warn "'#{model_value}' is not a real class" if ActiveFedora::Base.logger
+          ActiveFedora::Base.logger.warn "'#{model_value}' is not a real class"
           return nil
         end
         ActiveFedora::ModelClassifier.class_from_string(model_value)

--- a/lib/active_fedora/null_logger.rb
+++ b/lib/active_fedora/null_logger.rb
@@ -1,0 +1,10 @@
+module ActiveFedora
+  class NullLogger < Logger
+    def initialize(*args)
+    end
+
+    # allows all the usual logger method calls (warn, info, error, etc.)
+    def add(*args, &block)
+    end
+  end
+end

--- a/lib/active_fedora/orders/ordered_list.rb
+++ b/lib/active_fedora/orders/ordered_list.rb
@@ -174,7 +174,7 @@ module ActiveFedora
       def proxy_in
         proxies = to_a.map(&:proxy_in_id).compact.uniq
         if proxies.length > 1
-          ActiveFedora::Base.logger.warn "WARNING: List contains nodes aggregated under different URIs. Returning only the first." if ActiveFedora::Base.logger
+          ActiveFedora::Base.logger.warn "WARNING: List contains nodes aggregated under different URIs. Returning only the first."
         end
         proxies.first
       end

--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -130,7 +130,7 @@ module ActiveFedora
           begin
             yield(load_from_fedora(hit[ActiveFedora.id_field], cast))
           rescue Ldp::Gone
-            ActiveFedora::Base.logger.error "Although #{hit[ActiveFedora.id_field]} was found in Solr, it doesn't seem to exist in Fedora. The index is out of synch." if ActiveFedora::Base.logger
+            ActiveFedora::Base.logger.error "Although #{hit[ActiveFedora.id_field]} was found in Solr, it doesn't seem to exist in Fedora. The index is out of synch."
           end
         end
       end

--- a/lib/active_fedora/solr_hit.rb
+++ b/lib/active_fedora/solr_hit.rb
@@ -36,7 +36,7 @@ module ActiveFedora
 
     def model(opts = {})
       best_model_match = classifier.best_model(opts)
-      ActiveFedora::Base.logger.warn "Could not find a model for #{id}, defaulting to ActiveFedora::Base" if ActiveFedora::Base.logger && best_model_match == ActiveFedora::Base
+      ActiveFedora::Base.logger.warn "Could not find a model for #{id}, defaulting to ActiveFedora::Base" if best_model_match == ActiveFedora::Base
       best_model_match
     end
 

--- a/spec/unit/core/logger_spec.rb
+++ b/spec/unit/core/logger_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe ActiveFedora::NullLogger do
+  before { ActiveFedora::Base.logger = described_class.new }
+  describe "::logger" do
+    let(:logger) { ActiveFedora::Base.logger }
+    it "when calling the logger" do
+      expect(logger.warn("warning!")).to be_nil
+    end
+  end
+
+  describe "#logger" do
+    let(:logger) { ActiveFedora::Base.new.logger }
+    it "when calling the logger" do
+      expect(logger.warn("warning!")).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Use a null logging object, and now we'll hopefully never have to check `if ActiveFedora::Base.logger` ever again.