### PR TITLE
Convert specs to RSpec 3.5.4 syntax with Transpec

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "yard"
   s.add_development_dependency "rake"
   s.add_development_dependency "jettywrapper", ">=1.4.0"
-  s.add_development_dependency "rspec", "~> 2.99"
+  s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "rspec-its"
   s.add_development_dependency "equivalent-xml"
   s.add_development_dependency "rest-client"
@@ -43,4 +43,3 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
 end
-

--- a/spec/config_helper.rb
+++ b/spec/config_helper.rb
@@ -1,8 +1,8 @@
 def mock_yaml(hash, path)
   mock_file = double(path.split("/")[-1])
-  File.stub(:exist?).with(path).and_return(true)
-  File.stub(:open).with(path).and_return(mock_file)
-  Psych.stub(:load).and_return(hash)
+  allow(File).to receive(:exist?).with(path).and_return(true)
+  allow(File).to receive(:open).with(path).and_return(mock_file)
+  allow(Psych).to receive(:load).and_return(hash)
 end
 
 def default_predicate_mapping_file

--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -63,75 +63,75 @@ describe ActiveFedora::Base do
 
         it "should build child" do
           new_book = @library.books.build({})
-          new_book.should be_new_record
-          new_book.should be_kind_of Book
-          new_book.library.should be_kind_of Library
-          @library.books.should == [new_book]
+          expect(new_book).to be_new_record
+          expect(new_book).to be_kind_of Book
+          expect(new_book.library).to be_kind_of Library
+          expect(@library.books).to eq([new_book])
         end
 
         it "should make a new child" do
           new_book = @library.books.new
-          new_book.should be_new_record
-          new_book.should be_kind_of Book
-          new_book.library.should be_kind_of Library
-          @library.books.should == [new_book]
+          expect(new_book).to be_new_record
+          expect(new_book).to be_kind_of Book
+          expect(new_book.library).to be_kind_of Library
+          expect(@library.books).to eq([new_book])
         end
 
         it "should not create children if the parent isn't saved" do
-          lambda {@library.books.create({})}.should raise_error ActiveFedora::RecordNotSaved, "You cannot call create unless the parent is saved"
+          expect {@library.books.create({})}.to raise_error ActiveFedora::RecordNotSaved, "You cannot call create unless the parent is saved"
         end
 
         it "should create children" do
           @library.save!
           new_book = @library.books.create({})
-          new_book.should_not be_new_record
-          new_book.should be_kind_of Book
-          new_book.library.should == @library
+          expect(new_book).not_to be_new_record
+          expect(new_book).to be_kind_of Book
+          expect(new_book.library).to eq(@library)
         end
 
         it "should build parent" do
           new_library = @book.build_library({})
-          new_library.should be_new_record
-          new_library.should be_kind_of Library
-          @book.library.should == new_library
+          expect(new_library).to be_new_record
+          expect(new_library).to be_kind_of Library
+          expect(@book.library).to eq(new_library)
         end
 
         it "should create parent" do
           new_library = @book.create_library({})
-          new_library.should_not be_new_record
-          new_library.should be_kind_of Library
-          @book.library.should == new_library
+          expect(new_library).not_to be_new_record
+          expect(new_library).to be_kind_of Library
+          expect(@book.library).to eq(new_library)
         end
 
         it "should let you shift onto the association" do
-          @library.new_record?.should be_true
-          @library.books.size.should == 0
-          @library.books.should == []
-          @library.book_ids.should == []
+          expect(@library.new_record?).to be_truthy
+          expect(@library.books.size).to eq(0)
+          expect(@library.books).to eq([])
+          expect(@library.book_ids).to eq([])
           @library.books << @book
-          @library.books.should == [@book]
-          @library.book_ids.should ==[@book.pid]
+          expect(@library.books).to eq([@book])
+          expect(@library.book_ids).to eq([@book.pid])
 
         end
 
         it "should let you set an array of objects" do
           @library.books = [@book, @book2]
-          @library.books.should == [@book, @book2]
+          expect(@library.books).to eq([@book, @book2])
           @library.save
 
           @library.books = [@book]
-          @library.books.should == [@book]
+          expect(@library.books).to eq([@book])
         
         end
         it "should let you set an array of object ids" do
           @library.book_ids = [@book.pid, @book2.pid]
-          @library.books.should == [@book, @book2]
+          expect(@library.books).to eq([@book, @book2])
         end
 
         it "setter should wipe out previously saved relations" do
           @library.book_ids = [@book.pid, @book2.pid]
           @library.book_ids = [@book2.pid]
-          @library.books.should == [@book2]
+          expect(@library.books).to eq([@book2])
           
         end
 
@@ -140,7 +140,7 @@ describe ActiveFedora::Base do
           @library.books = [@book, @book2]
           @library.save
           @library = Library.find(@library.pid)
-          @library.books.should == [@book, @book2]
+          expect(@library.books).to eq([@book, @book2])
         end
 
 
@@ -152,12 +152,12 @@ describe ActiveFedora::Base do
           @book2.save
 
           @library = Library.find(@library.pid)
-          @library.books.should == [@book, @book2]
+          expect(@library.books).to eq([@book, @book2])
         
           solr_resp =  @library.books(:response_format=>:solr)
-          solr_resp.size.should == 2
-          solr_resp[0]['id'].should == @book.pid 
-          solr_resp[1]['id'].should == @book2.pid 
+          expect(solr_resp.size).to eq(2)
+          expect(solr_resp[0]['id']).to eq(@book.pid) 
+          expect(solr_resp[1]['id']).to eq(@book2.pid) 
         
         end
 
@@ -181,10 +181,10 @@ describe ActiveFedora::Base do
         end
         it "should be settable from the book side" do
           @book.library_id = @library.pid
-          @book.library.should == @library
-          @book.library.pid.should == @library.pid
+          expect(@book.library).to eq(@library)
+          expect(@book.library.pid).to eq(@library.pid)
           @book.attributes= {:library_id => ""}
-          @book.library_id.should be_nil
+          expect(@book.library_id).to be_nil
         end
         after do
           @library.delete
@@ -208,12 +208,12 @@ describe ActiveFedora::Base do
         it "should have many books once it has been saved" do
           @library.books << @book
 
-          @book.library.pid.should == @library.pid
+          expect(@book.library.pid).to eq(@library.pid)
           @library.books.reload
-          @library.books.should == [@book]
+          expect(@library.books).to eq([@book])
 
           @library2 = Library.find(@library.pid)
-          @library2.books.should == [@book]
+          expect(@library2.books).to eq([@book])
         end
 
         it "should have a count once it has been saved" do
@@ -221,14 +221,14 @@ describe ActiveFedora::Base do
           @library.save
 
           @library2 = Library.find(@library.pid)
-          @library2.books.size.should == 2
+          expect(@library2.books.size).to eq(2)
         end
 
         it "should respect the :class_name parameter" do
           @book.author = @person
           @book.save
-          Book.find(@book.id).author_id.should == @person.pid
-          Book.find(@book.id).author.should be_kind_of Person
+          expect(Book.find(@book.id).author_id).to eq(@person.pid)
+          expect(Book.find(@book.id).author).to be_kind_of Person
         end
 
         it "should respect multiple associations that share the same :property and respect associated class" do
@@ -236,11 +236,11 @@ describe ActiveFedora::Base do
           @book.publisher = @publisher
           @book.save
           
-          Book.find(@book.id).publisher_id.should == @publisher.pid
-          Book.find(@book.id).publisher.should be_kind_of Publisher
+          expect(Book.find(@book.id).publisher_id).to eq(@publisher.pid)
+          expect(Book.find(@book.id).publisher).to be_kind_of Publisher
 
-          Book.find(@book.id).author_id.should == @person.pid
-          Book.find(@book.id).author.should be_kind_of Person
+          expect(Book.find(@book.id).author_id).to eq(@person.pid)
+          expect(Book.find(@book.id).author).to be_kind_of Person
         end
 
         describe "when changing the belonger" do
@@ -250,10 +250,10 @@ describe ActiveFedora::Base do
             @library2 = Library.create
           end
           it "should replace an existing instance" do
-            @book.library_id.should == @library.id
+            expect(@book.library_id).to eq(@library.id)
             @book.library = @library2
             @book.save
-            Book.find(@book.id).library_id.should == @library2.id
+            expect(Book.find(@book.id).library_id).to eq(@library2.id)
           end
           after do
             @library2.delete
@@ -282,11 +282,11 @@ describe ActiveFedora::Base do
       end
       it "should set the association" do
         @book.library = @library
-        @book.library.pid.should == @library.pid
+        expect(@book.library.pid).to eq(@library.pid)
         @book.save
 
 
-        Book.find(@book.pid).library.pid.should == @library.pid
+        expect(Book.find(@book.pid).library.pid).to eq(@library.pid)
         
       end
       it "should clear the association" do
@@ -294,7 +294,7 @@ describe ActiveFedora::Base do
         @book.library = nil
         @book.save
 
-        Book.find(@book.pid).library.should be_nil 
+        expect(Book.find(@book.pid).library).to be_nil 
         
       end
 
@@ -305,7 +305,7 @@ describe ActiveFedora::Base do
         @book.save
         @book.library = @library2
         @book.save
-        Book.find(@book.pid).library.pid.should == @library2.pid 
+        expect(Book.find(@book.pid).library.pid).to eq(@library2.pid) 
 
       end
 
@@ -320,8 +320,8 @@ describe ActiveFedora::Base do
         @book.publisher = @publisher2
         @book.save
 
-        Book.find(@book.pid).publisher.pid.should == @publisher2.pid
-        Book.find(@book.pid).author.pid.should == @author.pid
+        expect(Book.find(@book.pid).publisher.pid).to eq(@publisher2.pid)
+        expect(Book.find(@book.pid).author.pid).to eq(@author.pid)
       end
 
       it "should only clear the matching class association" do
@@ -332,16 +332,16 @@ describe ActiveFedora::Base do
         @book.author = nil
         @book.save
 
-        Book.find(@book.pid).author.should be_nil
-        Book.find(@book.pid).publisher.pid.should == @publisher.pid
+        expect(Book.find(@book.pid).author).to be_nil
+        expect(Book.find(@book.pid).publisher.pid).to eq(@publisher.pid)
       end
 
       it "should be able to be set by id" do
         @book.library_id = @library.pid
-        @book.library_id.should == @library.pid
-        @book.library.pid.should == @library.pid
+        expect(@book.library_id).to eq(@library.pid)
+        expect(@book.library.pid).to eq(@library.pid)
         @book.save
-        Book.find(@book.pid).library_id.should == @library.pid
+        expect(Book.find(@book.pid).library_id).to eq(@library.pid)
       end
 
       after do
@@ -381,7 +381,7 @@ describe ActiveFedora::Base do
 
       it "should load the association stored in the parent" do
         @reloaded_course = Course.find(@course.pid)
-        @reloaded_course.textbooks.should == [@t1, @t2]
+        expect(@reloaded_course.textbooks).to eq([@t1, @t2])
       end
 
       it "should allow a parent to be deleted from the has_many association" do
@@ -390,7 +390,7 @@ describe ActiveFedora::Base do
         @reloaded_course.save
 
         @reloaded_course = Course.find(@course.pid)
-        @reloaded_course.textbooks.should == [@t2]
+        expect(@reloaded_course.textbooks).to eq([@t2])
       end
 
       it "should allow replacing the children" do
@@ -399,7 +399,7 @@ describe ActiveFedora::Base do
         @course.textbooks = [@t3, @t4]
         @course.save
 
-        @course.reload.textbooks.should == [@t3, @t4]
+        expect(@course.reload.textbooks).to eq([@t3, @t4])
       end
 
       it "should allow a child to be deleted from the has_and_belongs_to_many association" do
@@ -409,7 +409,7 @@ describe ActiveFedora::Base do
         @t1.save
 
         @reloaded_course = Course.find(@course.pid)
-        @reloaded_course.textbooks.should == [@t2]
+        expect(@reloaded_course.textbooks).to eq([@t2])
       end
     end
   end
@@ -451,7 +451,7 @@ describe ActiveFedora::Base do
           subject.save!
         end
         it "should save between the before and after hooks" do
-          subject.should_receive(:say_hi).with(@p2).twice
+          expect(subject).to receive(:say_hi).with(@p2).twice
           subject.pages.delete(@p2)
         end
       end
@@ -479,7 +479,7 @@ describe ActiveFedora::Base do
           @p2 = subject.pages.build
         end
         it "should run the hooks" do
-          subject.should_receive(:say_hi).with(@p2)
+          expect(subject).to receive(:say_hi).with(@p2)
           subject.pages.delete(@p2)
         end
       end
@@ -502,7 +502,7 @@ describe ActiveFedora::Base do
       end
 
       it "it should find the predicate" do
-        MediaObject.new.association(:baubles).send(:find_predicate).should == :is_part_of
+        expect(MediaObject.new.association(:baubles).send(:find_predicate)).to eq(:is_part_of)
       end
     end
 
@@ -521,7 +521,7 @@ describe ActiveFedora::Base do
       end
 
       it "it should find the predicate" do
-        MediaObject.new.association(:parts).send(:find_predicate).should == :is_part_of
+        expect(MediaObject.new.association(:parts).send(:find_predicate)).to eq(:is_part_of)
       end
     end
 
@@ -540,7 +540,7 @@ describe ActiveFedora::Base do
       end
 
       it "it should find the predicate" do
-        MediaObject.new.association(:baubles).send(:find_predicate).should == :has_baubles
+        expect(MediaObject.new.association(:baubles).send(:find_predicate)).to eq(:has_baubles)
       end
     end
     describe "an object doesn't have a property" do
@@ -601,20 +601,20 @@ describe ActiveFedora::Base do
           book2.contents = [text2, image2]
           book2.save!
 
-          book1.reload.contents.should include(text1, image1)
-          text1.reload.books.should == [book1]
-          image1.reload.books.should == [book1]
+          expect(book1.reload.contents).to include(text1, image1)
+          expect(text1.reload.books).to eq([book1])
+          expect(image1.reload.books).to eq([book1])
 
-          book2.reload.contents.should include(text2, image2)
-          text2.reload.books.should == [book2]
-          image2.reload.books.should == [book2]
+          expect(book2.reload.contents).to include(text2, image2)
+          expect(text2.reload.books).to eq([book2])
+          expect(image2.reload.books).to eq([book2])
         end
 
         it "should work when added via the has_many" do
           text2.books << book2
           book2.save
-          book2.reload.contents.should == [text2]
-          text2.reload.books.should == [book2]
+          expect(book2.reload.contents).to eq([text2])
+          expect(text2.reload.books).to eq([book2])
         end
       end
     end

--- a/spec/integration/auditable_spec.rb
+++ b/spec/integration/auditable_spec.rb
@@ -13,17 +13,17 @@ describe ActiveFedora::Auditable do
     @test_object.delete
   end
   it "should have the correct number of audit records" do
-    @test_object.audit_trail.records.length.should == 1
+    expect(@test_object.audit_trail.records.length).to eq(1)
   end
   it "should return all the data from each audit record" do
     record = @test_object.audit_trail.records.last
-    record.id.should == "AUDREC1"
-    record.process_type.should == "Fedora API-M"
-    record.action.should == "addDatastream"
-    record.component_id.should == "RELS-EXT"
-    record.responsibility.should == "fedoraAdmin"
+    expect(record.id).to eq("AUDREC1")
+    expect(record.process_type).to eq("Fedora API-M")
+    expect(record.action).to eq("addDatastream")
+    expect(record.component_id).to eq("RELS-EXT")
+    expect(record.responsibility).to eq("fedoraAdmin")
     expect(DateTime.parse(record.date)).to eq DateTime.parse(@test_object.modified_date)
-    record.justification.should == ""
+    expect(record.justification).to eq("")
   end
   
 end

--- a/spec/integration/autosave_association_spec.rb
+++ b/spec/integration/autosave_association_spec.rb
@@ -14,9 +14,9 @@ describe ActiveFedora::Base do
 
   context '#changed_for_autosave?' do
     before(:each) do
-      subject.stub(:new_record?).and_return(false)
-      subject.stub(:changed?).and_return(false)
-      subject.stub(:marked_for_destruction?).and_return(false)
+      allow(subject).to receive(:new_record?).and_return(false)
+      allow(subject).to receive(:changed?).and_return(false)
+      allow(subject).to receive(:marked_for_destruction?).and_return(false)
     end
     it {
       expect { subject.changed_for_autosave? }.to_not raise_error

--- a/spec/integration/base_spec.rb
+++ b/spec/integration/base_spec.rb
@@ -18,8 +18,8 @@ describe "A base object with metadata" do
     end
     it "should save the datastream." do
       obj = ActiveFedora::Base.find(@obj.pid)
-      obj.foo.should_not be_new
-      obj.foo.person.should == ['bob']
+      expect(obj.foo).not_to be_new
+      expect(obj.foo.person).to eq(['bob'])
       person_field = ActiveFedora::SolrService.solr_name('foo__person', type: :string)
       solr_result = ActiveFedora::SolrService.query("{!raw f=id}#{@obj.pid}", :fl=>"id #{person_field}").first
       expect(solr_result).to eq("id"=>@obj.pid, person_field =>['bob'])
@@ -32,7 +32,7 @@ describe "A base object with metadata" do
       obj.state='D'
       obj.save!
       obj.reload
-      obj.state.should == 'D'
+      expect(obj.state).to eq('D')
     end
   end
 
@@ -50,9 +50,9 @@ describe "A base object with metadata" do
         @release.save!
       end
       it "should save the datastream." do
-        MockAFBaseRelationship.find(@release.pid).foo.person.should == ['frank']
+        expect(MockAFBaseRelationship.find(@release.pid).foo.person).to eq(['frank'])
         person_field = ActiveFedora::SolrService.solr_name('foo__person', type: :string)
-        ActiveFedora::SolrService.query("id:#{@release.pid.gsub(":", "\\:")}", :fl=>"id #{person_field}").first.should == {"id"=>@release.pid, person_field =>['frank']}
+        expect(ActiveFedora::SolrService.query("id:#{@release.pid.gsub(":", "\\:")}", :fl=>"id #{person_field}").first).to eq({"id"=>@release.pid, person_field =>['frank']})
       end
     end
     describe "clone_into a new object" do
@@ -68,7 +68,7 @@ describe "A base object with metadata" do
         @new_object = MockAFBaseRelationship.find('test:999')
       end
       it "should have all the assertions" do
-        @new_object.rels_ext.content.should be_equivalent_to '<rdf:RDF xmlns:ns1="info:fedora/fedora-system:def/model#" xmlns:ns2="info:fedora/fedora-system:def/relations-external#" xmlns:ns0="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        expect(@new_object.rels_ext.content).to be_equivalent_to '<rdf:RDF xmlns:ns1="info:fedora/fedora-system:def/model#" xmlns:ns2="info:fedora/fedora-system:def/relations-external#" xmlns:ns0="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
          <rdf:Description rdf:about="info:fedora/test:999">
            <ns0:isGovernedBy rdf:resource="info:fedora/test:catalog-fixture"/>
            <ns1:hasModel rdf:resource="info:fedora/afmodel:MockAFBaseRelationship"/>
@@ -78,8 +78,8 @@ describe "A base object with metadata" do
        </rdf:RDF>'
       end
       it "should have the other datastreams too" do
-        @new_object.datastreams.keys.should include "foo"
-        @new_object.foo.content.should be_equivalent_to @release.foo.content
+        expect(@new_object.datastreams.keys).to include "foo"
+        expect(@new_object.foo.content).to be_equivalent_to @release.foo.content
       end
     end
     describe "clone" do
@@ -87,7 +87,7 @@ describe "A base object with metadata" do
         @new_object = @release.clone
       end
       it "should have all the assertions" do
-        @new_object.rels_ext.content.should be_equivalent_to '<rdf:RDF xmlns:ns1="info:fedora/fedora-system:def/model#" xmlns:ns2="info:fedora/fedora-system:def/relations-external#" xmlns:ns0="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        expect(@new_object.rels_ext.content).to be_equivalent_to '<rdf:RDF xmlns:ns1="info:fedora/fedora-system:def/model#" xmlns:ns2="info:fedora/fedora-system:def/relations-external#" xmlns:ns0="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
          <rdf:Description rdf:about="info:fedora/'+ @new_object.pid+'">
            <ns0:isGovernedBy rdf:resource="info:fedora/test:catalog-fixture"/>
            <ns1:hasModel rdf:resource="info:fedora/afmodel:MockAFBaseRelationship"/>
@@ -97,8 +97,8 @@ describe "A base object with metadata" do
        </rdf:RDF>'
       end
       it "should have the other datastreams too" do
-        @new_object.datastreams.keys.should include "foo"
-        @new_object.foo.content.should be_equivalent_to @release.foo.content
+        expect(@new_object.datastreams.keys).to include "foo"
+        expect(@new_object.foo.content).to be_equivalent_to @release.foo.content
       end
     end
   end
@@ -117,7 +117,7 @@ describe "A base object with metadata" do
 
     it 'should requery Fedora' do
       @object.reload
-      @object.foo.person.should == ['dave']
+      expect(@object.foo.person).to eq(['dave'])
     end
 
     it 'should raise an error if not persisted' do
@@ -141,12 +141,12 @@ describe "Datastreams synched together" do
   it "Should update datastream" do
     @nc = DSTest.new
     @nc.save
-    @nc.test_ds.content.should == 'XXX'
+    expect(@nc.test_ds.content).to eq('XXX')
     ds  = @nc.datastreams['test_ds']
     ds.content = "Foobar"
     @nc.save
-    DSTest.find(@nc.pid).datastreams['test_ds'].content.should == 'Foobar'
-    DSTest.find(@nc.pid).test_ds.content.should == 'Foobar'
+    expect(DSTest.find(@nc.pid).datastreams['test_ds'].content).to eq('Foobar')
+    expect(DSTest.find(@nc.pid).test_ds.content).to eq('Foobar')
   end
 
 end
@@ -213,8 +213,8 @@ describe ActiveFedora::Base do
   
   describe ".initialize" do
     it "calling constructor should create a new Fedora Object" do    
-      @test_object.should have(0).errors
-      @test_object.pid.should_not be_nil
+      expect(@test_object.size).to eq(0)
+      expect(@test_object.pid).not_to be_nil
     end
   end
   
@@ -231,20 +231,20 @@ describe ActiveFedora::Base do
       @test_object2 = ActiveFedora::Base.new({:namespace=>"randomNamespace"})
       # will be nil if match failed, otherwise will equal pid
       @test_object2.save
-      @test_object2.pid.match('randomNamespace:\d+').to_a.first.should == @test_object2.pid
+      expect(@test_object2.pid.match('randomNamespace:\d+').to_a.first).to eq(@test_object2.pid)
     end
 
     it "should set the CMA hasModel relationship in the Rels-EXT" do 
       @test_object2.save
       rexml = REXML::Document.new(@test_object2.datastreams["RELS-EXT"].content)
       # Purpose: confirm that the isMemberOf entries exist and have real RDF in them
-      rexml.root.elements["rdf:Description/ns0:hasModel"].attributes["rdf:resource"].should == 'info:fedora/afmodel:ActiveFedora_Base'
+      expect(rexml.root.elements["rdf:Description/ns0:hasModel"].attributes["rdf:resource"]).to eq('info:fedora/afmodel:ActiveFedora_Base')
     end
     it "should merge attributes from fedora into attributes hash" do
       @test_object2.save
       inner_object = @test_object2.inner_object
-      inner_object.pid.should == @test_object2.pid
-      inner_object.should respond_to(:lastModifiedDate)
+      expect(inner_object.pid).to eq(@test_object2.pid)
+      expect(inner_object).to respond_to(:lastModifiedDate)
     end
 
     it 'when the object is updated, it also updates modification time field in solr' do
@@ -262,25 +262,25 @@ describe ActiveFedora::Base do
 
       new_time_fedora = Time.parse(@test_object2.modified_date).to_i
       new_time_solr = Time.parse(solr_doc.first['system_modified_dtsi']).to_i
-      new_time_solr.should == new_time_fedora
+      expect(new_time_solr).to eq(new_time_fedora)
     end
   end
   
   describe ".datastreams" do
     it "should return a Hash of datastreams from fedora" do
       datastreams = @test_object.datastreams
-      datastreams.should be_a_kind_of(ActiveFedora::DatastreamHash) 
+      expect(datastreams).to be_a_kind_of(ActiveFedora::DatastreamHash) 
       datastreams.each_value do |ds| 
-        ds.should be_a_kind_of(ActiveFedora::Datastream)
+        expect(ds).to be_a_kind_of(ActiveFedora::Datastream)
       end
-      @test_object.datastreams["DC"].should be_an_instance_of(ActiveFedora::Datastream)
-      datastreams["DC"].should_not be_nil
-      datastreams["DC"].should be_an_instance_of(ActiveFedora::Datastream)       
+      expect(@test_object.datastreams["DC"]).to be_an_instance_of(ActiveFedora::Datastream)
+      expect(datastreams["DC"]).not_to be_nil
+      expect(datastreams["DC"]).to be_an_instance_of(ActiveFedora::Datastream)       
     end
     it "should initialize the datastream pointers with @new_object=false" do
       datastreams = @test_object.datastreams
       datastreams.each_value do |ds| 
-        ds.should_not be_new
+        expect(ds).not_to be_new
       end
     end
   end
@@ -295,23 +295,23 @@ describe ActiveFedora::Base do
       @test_object.add_datastream(fds)      
       
       result = @test_object.metadata_streams
-      result.length.should == 2
-      result.should include(mds1)
-      result.should include(mds2)
+      expect(result.length).to eq(2)
+      expect(result).to include(mds1)
+      expect(result).to include(mds2)
     end
   end
   
   describe '.rels_ext' do
     it "should retrieve RelsExtDatastream object via rels_ext method" do
-      @test_object.rels_ext.should be_instance_of(ActiveFedora::RelsExtDatastream)
+      expect(@test_object.rels_ext).to be_instance_of(ActiveFedora::RelsExtDatastream)
     end
     
     it 'should create the RELS-EXT datastream if it doesnt exist' do
       test_object = ActiveFedora::Base.new
       #test_object.datastreams["RELS-EXT"].should == nil
       test_object.rels_ext
-      test_object.datastreams["RELS-EXT"].should_not == nil
-      test_object.datastreams["RELS-EXT"].class.should == ActiveFedora::RelsExtDatastream
+      expect(test_object.datastreams["RELS-EXT"]).not_to eq(nil)
+      expect(test_object.datastreams["RELS-EXT"].class).to eq(ActiveFedora::RelsExtDatastream)
     end
   end
 
@@ -323,9 +323,9 @@ describe ActiveFedora::Base do
       @test_object.save
       rexml = REXML::Document.new(@test_object.datastreams["RELS-EXT"].content)
       # Purpose: confirm that the isMemberOf entries exist and have real RDF in them
-      rexml.root.attributes["xmlns:ns1"].should == 'info:fedora/fedora-system:def/relations-external#'
-      rexml.root.elements["rdf:Description/ns1:isMemberOf[@rdf:resource='info:fedora/demo:5']"].should_not be_nil
-      rexml.root.elements["rdf:Description/ns1:isMemberOf[@rdf:resource='info:fedora/demo:10']"].should_not be_nil
+      expect(rexml.root.attributes["xmlns:ns1"]).to eq('info:fedora/fedora-system:def/relations-external#')
+      expect(rexml.root.elements["rdf:Description/ns1:isMemberOf[@rdf:resource='info:fedora/demo:5']"]).not_to be_nil
+      expect(rexml.root.elements["rdf:Description/ns1:isMemberOf[@rdf:resource='info:fedora/demo:10']"]).not_to be_nil
     end
   end
 
@@ -337,25 +337,25 @@ describe ActiveFedora::Base do
      @test_object.save
      test_obj = ActiveFedora::Base.find(@test_object.pid)
      #check case where nothing passed in does not have correct mime type
-     test_obj.datastreams["DS1"].mimeType.should == "application/octet-stream"
+     expect(test_obj.datastreams["DS1"].mimeType).to eq("application/octet-stream")
      @test_object2 = ActiveFedora::Base.new
      f = File.new(File.join( File.dirname(__FILE__), "../fixtures/dino_jpg_no_file_ext" ))
      @test_object2.add_file_datastream(f,{:mimeType=>"image/jpeg"})
      @test_object2.save
      test_obj = ActiveFedora::Base.find(@test_object2.pid)
-     test_obj.datastreams["DS1"].mimeType.should == "image/jpeg"
+     expect(test_obj.datastreams["DS1"].mimeType).to eq("image/jpeg")
      @test_object3 = ActiveFedora::Base.new
      f = File.new(File.join( File.dirname(__FILE__), "../fixtures/dino_jpg_no_file_ext" ))
      @test_object3.add_file_datastream(f,{:mime_type=>"image/jpeg"})
      @test_object3.save
      test_obj = ActiveFedora::Base.find(@test_object3.pid)
-     test_obj.datastreams["DS1"].mimeType.should == "image/jpeg"
+     expect(test_obj.datastreams["DS1"].mimeType).to eq("image/jpeg")
      @test_object4 = ActiveFedora::Base.new
      f = File.new(File.join( File.dirname(__FILE__), "../fixtures/dino_jpg_no_file_ext" ))
      @test_object4.add_file_datastream(f,{:content_type=>"image/jpeg"})
      @test_object4.save
      test_obj = ActiveFedora::Base.find(@test_object4.pid)
-     test_obj.datastreams["DS1"].mimeType.should == "image/jpeg"
+     expect(test_obj.datastreams["DS1"].mimeType).to eq("image/jpeg")
    end
   end
   
@@ -363,16 +363,16 @@ describe ActiveFedora::Base do
   
     it "should be able to add datastreams" do
       ds = ActiveFedora::Datastream.new(@test_object.inner_object, 'DS1')
-      @test_object.add_datastream(ds).should be_true
+      expect(@test_object.add_datastream(ds)).to be_truthy
     end
       
     it "adding and saving should add the datastream to the datastreams array" do
       ds = ActiveFedora::Datastream.new(@test_object.inner_object, 'DS1') 
       ds.content = fixture('dino.jpg').read
-      @test_object.datastreams.should_not have_key("DS1")
+      expect(@test_object.datastreams).not_to have_key("DS1")
       @test_object.add_datastream(ds)
       ds.save
-      @test_object.datastreams.should have_key("DS1")
+      expect(@test_object.datastreams).to have_key("DS1")
     end
     
   end
@@ -382,18 +382,18 @@ describe ActiveFedora::Base do
     ds.content = "foo"
     new_ds = ds.save
     @test_object.add_datastream(new_ds)
-    @test_object.class.find(@test_object.pid).datastreams["DS1"].content.should == new_ds.content
+    expect(@test_object.class.find(@test_object.pid).datastreams["DS1"].content).to eq(new_ds.content)
   end
   
   describe ".create_date" do 
     it "should return W3C date" do 
-      @test_object.create_date.should_not be_nil
+      expect(@test_object.create_date).not_to be_nil
     end
   end
   
   describe ".modified_date" do 
     it "should return nil before saving and a W3C date after saving" do       
-      @test_object.modified_date.should_not be_nil
+      expect(@test_object.modified_date).not_to be_nil
     end  
   end
   
@@ -401,10 +401,10 @@ describe ActiveFedora::Base do
     
     it "should delete the object from Fedora and Solr" do
       @test_object.save
-      ActiveFedora::Base.find_with_conditions(:id=>@test_object.pid).first["id"].should == @test_object.pid
+      expect(ActiveFedora::Base.find_with_conditions(:id=>@test_object.pid).first["id"]).to eq(@test_object.pid)
       pid = @test_object.pid # store so we can access it after deletion
       @test_object.delete
-      ActiveFedora::Base.find_with_conditions(:id=>pid).should be_empty
+      expect(ActiveFedora::Base.find_with_conditions(:id=>pid)).to be_empty
     end
   end
 
@@ -421,11 +421,11 @@ describe ActiveFedora::Base do
         puts "#{e.message}\n#{e.backtrace}"
         raise e
       end
-      @test_object.object_relations[:has_part].should include @test_object2.internal_uri
+      expect(@test_object.object_relations[:has_part]).to include @test_object2.internal_uri
       @test_object.remove_relationship(:has_part,@test_object2)
       @test_object.save
       @test_object = ActiveFedora::Base.find(@pid)
-      @test_object.object_relations[:has_part].should be_empty
+      expect(@test_object.object_relations[:has_part]).to be_empty
     end
   end
 

--- a/spec/integration/belongs_to_association_spec.rb
+++ b/spec/integration/belongs_to_association_spec.rb
@@ -25,7 +25,7 @@ describe ActiveFedora::Base do
   describe "setting the id property" do
     it "should store it" do
       book.library_id = library.id
-      book.library_id.should == library.id
+      expect(book.library_id).to eq(library.id)
     end
 
     describe "reassigning the parent_id" do
@@ -43,19 +43,19 @@ describe ActiveFedora::Base do
 
     it "should be settable via []=" do
       book[:library_id] = library.id
-      book.library_id.should == library.id
+      expect(book.library_id).to eq(library.id)
     end
 
     it "safely handles invalid data" do
       book[:library_id] = 'bad:identifier'
-      book.library.should be_nil
+      expect(book.library).to be_nil
     end
   end
 
   describe "getting the id property" do
     it "should be accessable via []" do
       book[:library_id] = library.id
-      book[:library_id].should == library.id
+      expect(book[:library_id]).to eq(library.id)
     end
   end
 
@@ -135,40 +135,40 @@ describe ActiveFedora::Base do
 
       it "casted association methods should work and return the most complex class" do
 
-        @complex_object.simple_collection.should be_instance_of SimpleCollection
-        @complex_object.complex_collection.should be_nil
+        expect(@complex_object.simple_collection).to be_instance_of SimpleCollection
+        expect(@complex_object.complex_collection).to be_nil
 
-        @complex_object_second.simple_collection.should be_instance_of ComplexCollection
-        @complex_object_second.complex_collection.should be_instance_of ComplexCollection
+        expect(@complex_object_second.simple_collection).to be_instance_of ComplexCollection
+        expect(@complex_object_second.complex_collection).to be_instance_of ComplexCollection
 
-        @simple_object.simple_collection.should be_instance_of SimpleCollection
-        @simple_object.complex_collection.should be_nil
+        expect(@simple_object.simple_collection).to be_instance_of SimpleCollection
+        expect(@simple_object.complex_collection).to be_nil
 
-        @simple_object_second.simple_collection.should be_instance_of SimpleCollection
-        @simple_object_second.complex_collection.should be_nil
+        expect(@simple_object_second.simple_collection).to be_instance_of SimpleCollection
+        expect(@simple_object_second.complex_collection).to be_nil
 
-        @simple_object_third.simple_collection.should be_instance_of ComplexCollection
-        @simple_object_third.complex_collection.should be_instance_of ComplexCollection
+        expect(@simple_object_third.simple_collection).to be_instance_of ComplexCollection
+        expect(@simple_object_third.complex_collection).to be_instance_of ComplexCollection
 
-        @simple_collection.objects.size.should == 3
-        @simple_collection.objects[0].should be_instance_of SimpleObject
-        @simple_collection.objects[1].should be_instance_of SimpleObject
-        @simple_collection.objects[2].should be_instance_of ComplexObject
+        expect(@simple_collection.objects.size).to eq(3)
+        expect(@simple_collection.objects[0]).to be_instance_of SimpleObject
+        expect(@simple_collection.objects[1]).to be_instance_of SimpleObject
+        expect(@simple_collection.objects[2]).to be_instance_of ComplexObject
 
-        @complex_collection.objects.size.should == 2
-        @complex_collection.objects[0].should be_instance_of SimpleObject
-        @complex_collection.objects[1].should be_instance_of ComplexObject
+        expect(@complex_collection.objects.size).to eq(2)
+        expect(@complex_collection.objects[0]).to be_instance_of SimpleObject
+        expect(@complex_collection.objects[1]).to be_instance_of ComplexObject
 
       end
 
       it "specified ending relationships should ignore classes not specified" do
-        @simple_collection.complex_objects.size.should == 1
-        @simple_collection.complex_objects[0].should be_instance_of ComplexObject
-        @simple_collection.complex_objects[1].should be_nil
+        expect(@simple_collection.complex_objects.size).to eq(1)
+        expect(@simple_collection.complex_objects[0]).to be_instance_of ComplexObject
+        expect(@simple_collection.complex_objects[1]).to be_nil
 
-        @complex_collection.complex_objects.size.should == 1
-        @complex_collection.complex_objects[0].should be_instance_of ComplexObject
-        @complex_collection.complex_objects[1].should be_nil
+        expect(@complex_collection.complex_objects.size).to eq(1)
+        expect(@complex_collection.complex_objects[0]).to be_instance_of ComplexObject
+        expect(@complex_collection.complex_objects[1]).to be_nil
       end
 
       after do

--- a/spec/integration/bug_spec.rb
+++ b/spec/integration/bug_spec.rb
@@ -36,7 +36,7 @@ describe 'bugs' do
 
 
     x = FooHistory.find(@test_object.pid)
-    x.someData.fubar.should == ["replacement"] # recall the value
+    expect(x.someData.fubar).to eq(["replacement"]) # recall the value
     x.save
   end
 end

--- a/spec/integration/collection_association_spec.rb
+++ b/spec/integration/collection_association_spec.rb
@@ -20,10 +20,10 @@ describe ActiveFedora::Base do
   end
   describe "load_from_solr" do
     it "should set rows to count, if not specified" do
-      library.books(response_format: :solr).size.should == 2
+      expect(library.books(response_format: :solr).size).to eq(2)
     end
     it "should limit rows returned if option passed" do
-      library.books(response_format: :solr, rows: 1).size.should == 1
+      expect(library.books(response_format: :solr, rows: 1).size).to eq(1)
     end
   end
 

--- a/spec/integration/complex_rdf_datastream_spec.rb
+++ b/spec/integration/complex_rdf_datastream_spec.rb
@@ -25,14 +25,14 @@ describe "Nested Rdf Objects" do
     describe "#new_record?" do
       it "should be true when its built" do
         v = ds.parts.build(label: 'Alternator')
-        v.should be_new_record
+        expect(v).to be_new_record
       end
 
       it "should not be new when it's loaded from fedora" do
         ds.content = '_:g70324142325120 <http://purl.org/dc/terms/title> "Alternator" .
 <info:fedora/test:124> <http://purl.org/dc/terms/hasPart> _:g70324142325120 .'
         ds.resource.persist!
-        ds.parts.first.should_not be_new_record
+        expect(ds.parts.first).not_to be_new_record
       end
     end
 
@@ -40,24 +40,24 @@ describe "Nested Rdf Objects" do
       comp = SpecDatastream::Component.new(ds.graph)
       comp.label = ["Alternator"]
       ds.parts = comp
-      ds.parts.first.label.should == ["Alternator"]
+      expect(ds.parts.first.label).to eq(["Alternator"])
     end
 
     it "should be able to replace attributes" do
       v = ds.parts.build(label: 'Alternator')
-      ds.parts.first.label.should == ['Alternator']
+      expect(ds.parts.first.label).to eq(['Alternator'])
       ds.parts.first.label = ['Distributor']
-      ds.parts.first.label.should == ['Distributor']
+      expect(ds.parts.first.label).to eq(['Distributor'])
     end
 
     it "should be able to replace objects" do
       ds.parts.build(label: 'Alternator')
       ds.parts.build(label: 'Distributor')
-      ds.parts.size.should == 2
+      expect(ds.parts.size).to eq(2)
       comp = SpecDatastream::Component.new(ds.graph)
       comp.label = "Injector port"
       ds.parts = [comp]
-      ds.parts.size.should == 1
+      expect(ds.parts.size).to eq(1)
     end
 
     it "should be able to nest many complex objects" do
@@ -66,8 +66,8 @@ describe "Nested Rdf Objects" do
       comp2 = SpecDatastream::Component.new ds.graph
       comp2.label = ["Crankshaft"]
       ds.parts = [comp1, comp2]
-      ds.parts.first.label.should == ["Alternator"]
-      ds.parts.last.label.should == ["Crankshaft"]
+      expect(ds.parts.first.label).to eq(["Alternator"])
+      expect(ds.parts.last.label).to eq(["Crankshaft"])
     end
 
     it "should be able to clear complex objects" do
@@ -77,7 +77,7 @@ describe "Nested Rdf Objects" do
       comp2.label = ["Crankshaft"]
       ds.parts = [comp1, comp2]
       ds.parts = []
-      ds.parts.should == []
+      expect(ds.parts).to eq([])
     end
 
     it "should load complex objects" do
@@ -87,41 +87,41 @@ _:g70350851837440 <http://purl.org/dc/terms/title> "Alternator" .
 <info:fedora/test:124> <http://purl.org/dc/terms/hasPart> _:g70350851833380 .
 _:g70350851833380 <http://purl.org/dc/terms/title> "Crankshaft" .
 END
-      ds.parts.first.label.should == ["Alternator"]
+      expect(ds.parts.first.label).to eq(["Alternator"])
     end
 
     it "should build complex objects when a parent node doesn't exist" do
       part = ds.parts.build
-      part.should be_kind_of SpecDatastream::Component
+      expect(part).to be_kind_of SpecDatastream::Component
       part.label = "Wheel bearing"
-      ds.parts.first.label.should == ['Wheel bearing']
+      expect(ds.parts.first.label).to eq(['Wheel bearing'])
     end
 
     it "should not create a child node when hitting the accessor" do
       ds.parts
-      ds.parts.first.should be_nil
-      ds.serialize.should == ''
+      expect(ds.parts.first).to be_nil
+      expect(ds.serialize).to eq('')
     end
 
     it "should build complex objects when a parent node exists" do
       part = ds.parts.build
-      part.should be_kind_of SpecDatastream::Component
+      expect(part).to be_kind_of SpecDatastream::Component
       part.label = "Wheel bearing"
-      ds.parts.first.label.should == ['Wheel bearing']
+      expect(ds.parts.first.label).to eq(['Wheel bearing'])
     end
 
     describe "#first_or_create" do
       it "should return a result if the predicate exists" do
         part1 = ds.parts.build
         part2 = ds.parts.build
-        ds.parts.first_or_create.should == part1
+        expect(ds.parts.first_or_create).to eq(part1)
       end
 
       it "should create a new result if the predicate doesn't exist" do
-        ds.parts.should == []
+        expect(ds.parts).to eq([])
         part = ds.parts.first_or_create(label: 'Front control arm bushing')
-        part.label.should == ['Front control arm bushing']
-        ds.parts.should == [part]
+        expect(part.label).to eq(['Front control arm bushing'])
+        expect(ds.parts).to eq([part])
       end
 
     end
@@ -155,9 +155,9 @@ END
         comp = SpecDatastream::MediatorUser.new ds.graph
         comp.title = ["Doctor"]
         ds.mediator = comp
-        ds.mediator.first.type.first.should be_instance_of RDF::URI
-        ds.mediator.first.type.first.to_s.should == "http://purl.org/dc/terms/AgentClass"
-        ds.mediator.first.title.first.should == 'Doctor'
+        expect(ds.mediator.first.type.first).to be_instance_of RDF::URI
+        expect(ds.mediator.first.type.first.to_s).to eq("http://purl.org/dc/terms/AgentClass")
+        expect(ds.mediator.first.title.first).to eq('Doctor')
       end
 
       it "should add the type of complex object when it is not provided" do
@@ -165,7 +165,7 @@ END
   _:g70350851837440 <http://purl.org/dc/terms/title> "Mediation Person" .
   <info:fedora/test:124> <http://purl.org/dc/terms/mediator> _:g70350851837440 .
 END
-        ds.mediator.first.type.first.to_s.should == "http://purl.org/dc/terms/AgentClass"
+        expect(ds.mediator.first.type.first.to_s).to eq("http://purl.org/dc/terms/AgentClass")
       end
 
       it "should add load the type of complex objects when provided (superceeding what is specified by the class)" do
@@ -174,7 +174,7 @@ END
   _:g70350851837440 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.ebu.ch/metadata/ontologies/ebucore#Organisation> .
   <info:fedora/test:124> <http://purl.org/dc/terms/mediator> _:g70350851837440 .
 END
-        ds.mediator.first.type.first.to_s.should == "http://www.ebu.ch/metadata/ontologies/ebucore#Organisation"
+        expect(ds.mediator.first.type.first.to_s).to eq("http://www.ebu.ch/metadata/ontologies/ebucore#Organisation")
       end
     end
 
@@ -221,15 +221,15 @@ END
         program.title = ["This old House"]
         ds.program = program
 
-        ds.program.first.type.size.should == 1
-        ds.program.first.type.first.to_s.should == 'http://www.ebu.ch/metadata/ontologies/ebucore#Programme'
-        ds.series.first.type.size.should == 1
-        ds.series.first.type.first.to_s.should == 'http://www.ebu.ch/metadata/ontologies/ebucore#Series'
+        expect(ds.program.first.type.size).to eq(1)
+        expect(ds.program.first.type.first.to_s).to eq('http://www.ebu.ch/metadata/ontologies/ebucore#Programme')
+        expect(ds.series.first.type.size).to eq(1)
+        expect(ds.series.first.type.first.to_s).to eq('http://www.ebu.ch/metadata/ontologies/ebucore#Series')
       end
 
       it "should create an object of the correct type" do
-        ds.program.build.should be_kind_of SpecDatastream::Program
-        ds.series.build.should be_kind_of SpecDatastream::Series
+        expect(ds.program.build).to be_kind_of SpecDatastream::Program
+        expect(ds.series.build).to be_kind_of SpecDatastream::Series
       end
     end
   end

--- a/spec/integration/datastream_collections_spec.rb
+++ b/spec/integration/datastream_collections_spec.rb
@@ -17,31 +17,31 @@ describe ActiveFedora::DatastreamCollections do
       @test_object2 = MockAFBaseDatastream.new
       f = File.open(File.join( File.dirname(__FILE__), "../fixtures/minivan.jpg"), 'rb')
       f2 = File.open(File.join( File.dirname(__FILE__), "../fixtures/dino.jpg" ), 'rb')
-      f2.stub(:original_filename).and_return("dino.jpg")
-      f.stub(:content_type).and_return("image/jpeg")
+      allow(f2).to receive(:original_filename).and_return("dino.jpg")
+      allow(f).to receive(:content_type).and_return("image/jpeg")
       @test_object2.add_named_datastream("thumbnail",{:content_type=>"image/jpeg",:blob=>f, :label=>"testDS"})
       @test_object2.add_named_datastream("high",{:content_type=>"image/jpeg",:blob=>f2})
       ds = @test_object2.thumbnail.first
       ds2 = @test_object2.high.first
       @test_object2.save
       @test_object2 = MockAFBaseDatastream.find(@test_object2.pid)
-      @test_object2.named_datastreams.keys.size.should == 2
-      @test_object2.named_datastreams.keys.include?("thumbnail").should == true
-      @test_object2.named_datastreams.keys.include?("high").should == true
-      @test_object2.named_datastreams["thumbnail"].size.should == 1
-      @test_object2.named_datastreams["high"].size.should == 1
+      expect(@test_object2.named_datastreams.keys.size).to eq(2)
+      expect(@test_object2.named_datastreams.keys.include?("thumbnail")).to eq(true)
+      expect(@test_object2.named_datastreams.keys.include?("high")).to eq(true)
+      expect(@test_object2.named_datastreams["thumbnail"].size).to eq(1)
+      expect(@test_object2.named_datastreams["high"].size).to eq(1)
       t2_thumb1 = @test_object2.named_datastreams["thumbnail"].first
-      t2_thumb1.dsid.should == ds.dsid
-      t2_thumb1.mimeType.should == ds.mimeType
-      t2_thumb1.pid.should == ds.pid
-      t2_thumb1.dsLabel.should == ds.dsLabel
-      t2_thumb1.controlGroup.should == ds.controlGroup
+      expect(t2_thumb1.dsid).to eq(ds.dsid)
+      expect(t2_thumb1.mimeType).to eq(ds.mimeType)
+      expect(t2_thumb1.pid).to eq(ds.pid)
+      expect(t2_thumb1.dsLabel).to eq(ds.dsLabel)
+      expect(t2_thumb1.controlGroup).to eq(ds.controlGroup)
       t2_high1 = @test_object2.named_datastreams["high"].first
-      t2_high1.dsid.should == ds2.dsid
-      t2_high1.mimeType.should == ds2.mimeType
-      t2_high1.pid.should == ds2.pid
-      t2_high1.dsLabel.should == ds2.dsLabel
-      t2_high1.controlGroup.should == ds2.controlGroup
+      expect(t2_high1.dsid).to eq(ds2.dsid)
+      expect(t2_high1.mimeType).to eq(ds2.mimeType)
+      expect(t2_high1.pid).to eq(ds2.pid)
+      expect(t2_high1.dsLabel).to eq(ds2.dsLabel)
+      expect(t2_high1.controlGroup).to eq(ds2.controlGroup)
     end
   end
   
@@ -49,18 +49,18 @@ describe ActiveFedora::DatastreamCollections do
     it 'should add a file datastream with the given name to the object in fedora' do
       @test_object2 = MockAFBaseDatastream.new
       f = File.open(File.join( File.dirname(__FILE__), "../fixtures/minivan.jpg"), 'rb')
-      f.stub(:content_type).and_return("image/jpeg")
+      allow(f).to receive(:content_type).and_return("image/jpeg")
       @test_object2.add_named_file_datastream("thumbnail",f)
       ds = @test_object2.thumbnail.first
       @test_object2.save
       @test_object2 = MockAFBaseDatastream.find(@test_object2.pid)
-      @test_object2.named_datastreams["thumbnail"].size.should == 1
+      expect(@test_object2.named_datastreams["thumbnail"].size).to eq(1)
       t2_thumb1 = @test_object2.named_datastreams["thumbnail"].first
-      t2_thumb1.dsid.should == "THUMB1"
-      t2_thumb1.mimeType.should == "image/jpeg"
-      t2_thumb1.pid.should == @test_object2.pid
-      t2_thumb1.dsLabel.should == "minivan.jpg"
-      t2_thumb1.controlGroup.should == "M"
+      expect(t2_thumb1.dsid).to eq("THUMB1")
+      expect(t2_thumb1.mimeType).to eq("image/jpeg")
+      expect(t2_thumb1.pid).to eq(@test_object2.pid)
+      expect(t2_thumb1.dsLabel).to eq("minivan.jpg")
+      expect(t2_thumb1.controlGroup).to eq("M")
     end
   end
   
@@ -73,37 +73,37 @@ describe ActiveFedora::DatastreamCollections do
       f2 = File.open(File.join( File.dirname(__FILE__), "../fixtures/dino.jpg" ), 'rb')
       dino = f2.read
       f2.rewind
-      f.stub(:content_type).and_return("image/jpeg")
-      f.stub(:original_filename).and_return("minivan.jpg")
-      f2.stub(:content_type).and_return("image/jpeg")
-      f2.stub(:original_filename).and_return("dino.jpg")
+      allow(f).to receive(:content_type).and_return("image/jpeg")
+      allow(f).to receive(:original_filename).and_return("minivan.jpg")
+      allow(f2).to receive(:content_type).and_return("image/jpeg")
+      allow(f2).to receive(:original_filename).and_return("dino.jpg")
       #check raise exception if dsid not supplied
       @test_object2.add_named_datastream("thumbnail",{:file=>f})
       @test_object2.save
       @test_object2 = MockAFBaseDatastream.find(@test_object2.pid)
       
-      @test_object2.thumbnail.size.should == 1
+      expect(@test_object2.thumbnail.size).to eq(1)
       @test_object2.thumbnail_ids == ["THUMB1"]
       ds = @test_object2.thumbnail.first
-      ds.dsid.should == "THUMB1"
-      ds.mimeType.should == "image/jpeg"
-      ds.pid.should == @test_object2.pid
-      ds.dsLabel.should == "minivan.jpg"
-      ds.controlGroup.should == "M"
+      expect(ds.dsid).to eq("THUMB1")
+      expect(ds.mimeType).to eq("image/jpeg")
+      expect(ds.pid).to eq(@test_object2.pid)
+      expect(ds.dsLabel).to eq("minivan.jpg")
+      expect(ds.controlGroup).to eq("M")
 
-      ds.content.should == minivan 
+      expect(ds.content).to eq(minivan) 
       @test_object2.update_named_datastream("thumbnail",{:file=>f2,:dsid=>"THUMB1"})
       @test_object2.save
       @test_object2 = MockAFBaseDatastream.find(@test_object2.pid)
-      @test_object2.thumbnail.size.should == 1
+      expect(@test_object2.thumbnail.size).to eq(1)
       @test_object2.thumbnail_ids == ["THUMB1"]
       ds2 = @test_object2.thumbnail.first
-      ds2.dsid.should == "THUMB1"
-      ds2.mimeType.should == "image/jpeg"
-      ds2.pid.should == @test_object2.pid
-      ds2.dsLabel.should == "dino.jpg"
-      ds2.controlGroup.should == "M"
-      (ds2.content == dino).should be_true
+      expect(ds2.dsid).to eq("THUMB1")
+      expect(ds2.mimeType).to eq("image/jpeg")
+      expect(ds2.pid).to eq(@test_object2.pid)
+      expect(ds2.dsLabel).to eq("dino.jpg")
+      expect(ds2.controlGroup).to eq("M")
+      expect(ds2.content == dino).to be_truthy
     end
   end
   

--- a/spec/integration/datastream_spec.rb
+++ b/spec/integration/datastream_spec.rb
@@ -22,13 +22,13 @@ describe ActiveFedora::Datastream do
 
   it "should be able to access Datastreams using datastreams method" do
     descMetadata = @test_object.datastreams["descMetadata"]
-    descMetadata.should be_a_kind_of(ActiveFedora::Datastream)
-    descMetadata.dsid.should eql("descMetadata")
+    expect(descMetadata).to be_a_kind_of(ActiveFedora::Datastream)
+    expect(descMetadata.dsid).to eql("descMetadata")
   end
 
   it "should be able to access Datastream content using content method" do    
     descMetadata = @test_object.datastreams["descMetadata"].content
-    descMetadata.should_not be_nil
+    expect(descMetadata).not_to be_nil
   end
   
   it "should be able to update XML Datastream content and save to Fedora" do    
@@ -37,25 +37,25 @@ describe ActiveFedora::Datastream do
     title.content = "Test Title"
     xml_content.root.add_child title
     
-    @test_object.datastreams["descMetadata"].stub(:before_save)
+    allow(@test_object.datastreams["descMetadata"]).to receive(:before_save)
     @test_object.datastreams["descMetadata"].content = xml_content.to_s
     @test_object.datastreams["descMetadata"].save
     
     found = Nokogiri::XML::Document.parse(@test_object.class.find(@test_object.pid).datastreams['descMetadata'].content)
-    found.xpath('//dc/title/text()').first.inner_text.should == title.content
+    expect(found.xpath('//dc/title/text()').first.inner_text).to eq(title.content)
   end
   
   it "should be able to update Blob Datastream content and save to Fedora" do    
     dsid = "ds#{Time.now.to_i}"
     ds = ActiveFedora::Datastream.new(@test_object.inner_object, dsid)
     ds.content = fixture('dino.jpg')
-    @test_object.add_datastream(ds).should be_true
+    expect(@test_object.add_datastream(ds)).to be_truthy
     @test_object.save
-    @test_object.datastreams[dsid].should_not be_changed
+    expect(@test_object.datastreams[dsid]).not_to be_changed
     to = ActiveFedora::Base.find(@test_object.pid) 
-    to.should_not be_nil 
-    to.datastreams[dsid].should_not be_nil
-    to.datastreams[dsid].content.should == fixture('dino.jpg').read
+    expect(to).not_to be_nil 
+    expect(to.datastreams[dsid]).not_to be_nil
+    expect(to.datastreams[dsid].content).to eq(fixture('dino.jpg').read)
   end
   
   it "should be able to set the versionable attribute" do
@@ -65,26 +65,26 @@ describe ActiveFedora::Datastream do
     ds = ActiveFedora::Datastream.new(@test_object.inner_object, dsid)
     ds.content = v1
     ds.versionable = false
-    @test_object.add_datastream(ds).should be_true
+    expect(@test_object.add_datastream(ds)).to be_truthy
     @test_object.save
     to = ActiveFedora::Base.find(@test_object.pid)
     ds = to.datastreams[dsid]
-    ds.versionable.should be_false
+    expect(ds.versionable).to be_falsey
     ds.versionable = true
     to.save
     ds.content = v2
     to.save
     versions = ds.versions
-    versions.length.should == 2
+    expect(versions.length).to eq(2)
     # order of versions not guaranteed
     if versions[0].content == v2
-      versions[1].content.should == v1
-      versions[0].asOfDateTime.should be >= versions[1].asOfDateTime
+      expect(versions[1].content).to eq(v1)
+      expect(versions[0].asOfDateTime).to be >= versions[1].asOfDateTime
     else
-      versions[0].content.should == v1
-      versions[1].content.should == v2   
-      versions[1].asOfDateTime.should be >= versions[0].asOfDateTime
+      expect(versions[0].content).to eq(v1)
+      expect(versions[1].content).to eq(v2)   
+      expect(versions[1].asOfDateTime).to be >= versions[0].asOfDateTime
     end
-    ds.content.should == v2
+    expect(ds.content).to eq(v2)
   end
 end

--- a/spec/integration/datastreams_spec.rb
+++ b/spec/integration/datastreams_spec.rb
@@ -20,8 +20,8 @@ describe ActiveFedora::Datastreams do
 
     it "should work" do
       subject.save(validate: false)
-      subject.nokogiri_autocreate_on.should_not be_new
-      subject.nokogiri_autocreate_off.should be_new
+      expect(subject.nokogiri_autocreate_on).not_to be_new
+      expect(subject.nokogiri_autocreate_off).to be_new
     end
   end
 
@@ -51,21 +51,21 @@ describe ActiveFedora::Datastreams do
     end
     
     it "should create datastreams from the spec on new objects" do
-      expect(@test.without_versions.versionable).to be_false
-      expect(@test.with_versions.versionable).to be_true
+      expect(@test.without_versions.versionable).to be_falsey
+      expect(@test.with_versions.versionable).to be_truthy
       expect(@test.with_versions.dsLabel).to eql "Versioned DS"
       @test.without_versions.content= "blah blah blah"
       @test.save
-      expect(HasMetadata.find(@test.pid).without_versions.versionable).to be_false
+      expect(HasMetadata.find(@test.pid).without_versions.versionable).to be_falsey
     end
     
     it "should use ds_specs and preserve existing datastreams on migrated objects" do
       test_obj = HasMetadata.find(@base.pid, cast: false)
       expect(test_obj.datastreams["testDS"].dsLabel).to eql "Test DS"
-      expect(test_obj.datastreams["testDS"].new?).to be_false
+      expect(test_obj.datastreams["testDS"].new?).to be_falsey
       expect(test_obj.with_versions.dsLabel).to eql "Versioned DS"
-      expect(test_obj.without_versions.versionable).to be_false
-      expect(test_obj.with_versions.new?).to be_true
+      expect(test_obj.without_versions.versionable).to be_falsey
+      expect(test_obj.with_versions.new?).to be_truthy
     end
     
   end
@@ -98,34 +98,34 @@ describe ActiveFedora::Datastreams do
     end
     
     it "should create datastreams from the spec on new objects" do
-      expect(@has_file.file_ds.versionable).to be_false
+      expect(@has_file.file_ds.versionable).to be_falsey
       @has_file.file_ds.content = "blah blah blah"
-      expect(@has_file.file_ds.changed?).to be_true
-      expect(@has_file.file_ds2.changed?).to be_false # no autocreate
-      expect(@has_file.file_ds2.new?).to be_true
+      expect(@has_file.file_ds.changed?).to be_truthy
+      expect(@has_file.file_ds2.changed?).to be_falsey # no autocreate
+      expect(@has_file.file_ds2.new?).to be_truthy
       @has_file.save
-      expect(@has_file.file_ds.versionable).to be_false
+      expect(@has_file.file_ds.versionable).to be_falsey
       test_obj = HasFile.find(@has_file.pid)
-      expect(test_obj.file_ds.versionable).to be_false
-      expect(test_obj.rels_ext.changed?).to be_false
-      expect(test_obj.file_ds.changed?).to be_false
-      expect(test_obj.file_ds2.changed?).to be_false
-      expect(test_obj.file_ds2.new?).to be_true
+      expect(test_obj.file_ds.versionable).to be_falsey
+      expect(test_obj.rels_ext.changed?).to be_falsey
+      expect(test_obj.file_ds.changed?).to be_falsey
+      expect(test_obj.file_ds2.changed?).to be_falsey
+      expect(test_obj.file_ds2.new?).to be_truthy
     end
     
     it "should use ds_specs on migrated objects" do
       test_obj = HasFile.find(@base.pid, cast: false)
-      expect(test_obj.file_ds.versionable).to be_false
-      expect(test_obj.file_ds.new?).to be_true
+      expect(test_obj.file_ds.versionable).to be_falsey
+      expect(test_obj.file_ds.new?).to be_truthy
       test_obj.file_ds.content = "blah blah blah"
       test_obj.save
-      expect(test_obj.file_ds.versionable).to be_false
+      expect(test_obj.file_ds.versionable).to be_falsey
       # look it up again to check datastream profile
       test_obj = HasFile.find(@base.pid, cast: false)
-      expect(test_obj.file_ds.versionable).to be_false
+      expect(test_obj.file_ds.versionable).to be_falsey
       expect(test_obj.file_ds.dsLabel).to eql "File Datastream"
       test_obj = HasFile.find(@base2.pid, cast: false)
-      expect(test_obj.file_ds.versionable).to be_true
+      expect(test_obj.file_ds.versionable).to be_truthy
       expect(test_obj.file_ds.dsLabel).to eql "Pre-existing DS"
     end
   end
@@ -151,7 +151,7 @@ describe ActiveFedora::Datastreams do
       ds = @base.create_datastream('ActiveFedora::Datastream', 'someMetadata', ds_opts)
       @base.add_datastream(ds)
       @base.save
-      expect(@base.datastreams.keys.include?('someMetadata')).to be_true
+      expect(@base.datastreams.keys.include?('someMetadata')).to be_truthy
       test_obj = ActiveFedora::Base.find(@base.pid)
       expect(test_obj.datastreams['someMetadata'].content).to eql @ds_content
       expect(test_obj.datastreams['someMetadata'].controlGroup).to eql 'E'
@@ -164,7 +164,7 @@ describe ActiveFedora::Datastreams do
       ds = @base.create_datastream('ActiveFedora::Datastream', 'someMetadata', ds_opts)
       @base.add_datastream(ds)
       @base.save
-      expect(@base.datastreams.keys.include?('someMetadata')).to be_true
+      expect(@base.datastreams.keys.include?('someMetadata')).to be_truthy
       test_obj = ActiveFedora::Base.find(@base.pid)
       expect(test_obj.datastreams['someMetadata'].content).to eql @ds_content
       expect(test_obj.datastreams['someMetadata'].controlGroup).to eql 'M'

--- a/spec/integration/delete_all_spec.rb
+++ b/spec/integration/delete_all_spec.rb
@@ -31,8 +31,8 @@ describe ActiveFedora::Base do
   describe ".destroy_all" do
     it "should remove both and run callbacks" do 
       SpecModel::Basic.destroy_all
-      SpecModel::Basic.count.should == 0 
-      SpecModel::Basic.callback_counter.should == 2
+      expect(SpecModel::Basic.count).to eq(0) 
+      expect(SpecModel::Basic.callback_counter).to eq(2)
     end
 
     describe "when a model is missing" do
@@ -48,7 +48,7 @@ describe ActiveFedora::Base do
       it "should be able to skip a missing model" do 
         expect(ActiveFedora::Base.logger).to receive(:error).with("Although #{pid} was found in Solr, it doesn't seem to exist in Fedora. The index is out of synch.")
         SpecModel::Basic.destroy_all
-        SpecModel::Basic.count.should == 1 
+        expect(SpecModel::Basic.count).to eq(1) 
       end
     end
   end
@@ -56,8 +56,8 @@ describe ActiveFedora::Base do
   describe ".delete_all" do
     it "should remove both and not run callbacks" do 
       SpecModel::Basic.delete_all
-      SpecModel::Basic.count.should == 0
-      SpecModel::Basic.callback_counter.should == 0
+      expect(SpecModel::Basic.count).to eq(0)
+      expect(SpecModel::Basic.callback_counter).to eq(0)
     end
   end
 end

--- a/spec/integration/fedora_solr_sync_spec.rb
+++ b/spec/integration/fedora_solr_sync_spec.rb
@@ -23,6 +23,6 @@ describe "fedora_solr_sync_issues" do
   it "should not go into an infinite loop" do
     subject.inner_object.delete
     parent.reload
-    parent.things.should == []
+    expect(parent.things).to eq([])
   end
 end

--- a/spec/integration/full_featured_model_spec.rb
+++ b/spec/integration/full_featured_model_spec.rb
@@ -108,16 +108,16 @@ describe ActiveFedora::Base do
   end
   
   it "should be an instance of ActiveFedora::Base" do
-    @test_history.should be_kind_of(ActiveFedora::Base)
+    expect(@test_history).to be_kind_of(ActiveFedora::Base)
   end
   
 
   it "should create proxies to all the datastreams" do
     properties_ds = @test_history.datastreams["properties"]
     dublin_core_ds = @test_history.datastreams["dublin_core"]
-    @test_history.properties.should be properties_ds    
-    @test_history.should respond_to(:properties)
-    OralHistory.new.should respond_to(:properties)
+    expect(@test_history.properties).to be properties_ds    
+    expect(@test_history).to respond_to(:properties)
+    expect(OralHistory.new).to respond_to(:properties)
   end 
 
     
@@ -142,12 +142,12 @@ describe ActiveFedora::Base do
     @properties_sample_values.each_pair do |field, value|
       next if field == :hard_copy_availability #FIXME HYDRA-824
       next if field == :location #FIXME HYDRA-825 
-      (@solr_result[ActiveFedora::SolrService.solr_name(field, type: :string)] || @solr_result[ActiveFedora::SolrService.solr_name(field, type: :date)]).should == [::Solrizer::Extractor.format_node_value(value)] 
+      expect(@solr_result[ActiveFedora::SolrService.solr_name(field, type: :string)] || @solr_result[ActiveFedora::SolrService.solr_name(field, type: :date)]).to eq([::Solrizer::Extractor.format_node_value(value)]) 
     end
     
     @dublin_core_sample_values.each_pair do |field, value|
       next if [:format, :type].include?(field)  #format and type are methods declared on Object
-      dublin_core_ds.send("#{field.to_s}").should == [value]
+      expect(dublin_core_ds.send("#{field.to_s}")).to eq([value])
     end    
   end
   
@@ -158,19 +158,19 @@ describe ActiveFedora::Base do
     dublin_core_ds.subject = "My Subject Heading"
     dc_xml = REXML::Document.new(dublin_core_ds.to_xml)
     
-    dc_xml.root.elements["dcterms:subject"].text.should == "My Subject Heading"
+    expect(dc_xml.root.elements["dcterms:subject"].text).to eq("My Subject Heading")
     
   end
   
   it "should support #find_with_conditions" do
     solr_result = OralHistory.find_with_conditions({})
-    solr_result.should_not be_nil
+    expect(solr_result).not_to be_nil
   end
   
   describe '#new' do
     it "should support custom pids" do
       oh = OralHistory.new(:pid=>"uuid:blah-blah-blah")
-      oh.pid.should == "uuid:blah-blah-blah"
+      expect(oh.pid).to eq("uuid:blah-blah-blah")
     end
   end
   

--- a/spec/integration/has_and_belongs_to_many_associations_spec.rb
+++ b/spec/integration/has_and_belongs_to_many_associations_spec.rb
@@ -36,14 +36,14 @@ describe ActiveFedora::Base do
       end
       it "habtm should set and remove relationships bidirectionally" do
         @book.topics << @topic1
-        @book.topics.should == [@topic1]
-        @topic1.books.should == [@book]
-        @topic1.reload.books.should == [@book]
+        expect(@book.topics).to eq([@topic1])
+        expect(@topic1.books).to eq([@book])
+        expect(@topic1.reload.books).to eq([@book])
 
         @book.topics.delete(@topic1)
         #@topic1.books.delete(@book)
-        @book.topics.should == []
-        @topic1.books.should == []
+        expect(@book.topics).to eq([])
+        expect(@topic1.books).to eq([])
       end
       it "Should allow for more than 10 items" do
 
@@ -51,16 +51,16 @@ describe ActiveFedora::Base do
           @book.topics << Topic.create
         end
         @book.save
-        @book.topics.count.should == 12
+        expect(@book.topics.count).to eq(12)
         book2 = Book.find(@book.pid)
-        book2.topics.count.should == 12
+        expect(book2.topics.count).to eq(12)
       end
 
       it "Should find inherited objects along with base objects" do
         @book.topics << @topic1
         @special_book.topics << @topic1
-        @topic1.books.should == [@book, @special_book]
-        @topic1.reload.books.should == [@book, @special_book]
+        expect(@topic1.books).to eq([@book, @special_book])
+        expect(@topic1.reload.books).to eq([@book, @special_book])
       end
 
       it "Should cast found books to the correct cmodel" do
@@ -83,20 +83,20 @@ describe ActiveFedora::Base do
       end
       it "should set relationships bidirectionally" do
         @book.topics << @topic1
-        @book.topics.should == [@topic1]
-        @book.relationships(:has_topic).should == [@topic1.internal_uri]
-        @topic1.relationships(:has_topic).should == []
-        @topic1.relationships(:is_topic_of).should == [@book.internal_uri]
-        Topic.find(@topic1.pid).books.should == [@book] #Can't have saved it because @book isn't saved yet.
+        expect(@book.topics).to eq([@topic1])
+        expect(@book.relationships(:has_topic)).to eq([@topic1.internal_uri])
+        expect(@topic1.relationships(:has_topic)).to eq([])
+        expect(@topic1.relationships(:is_topic_of)).to eq([@book.internal_uri])
+        expect(Topic.find(@topic1.pid).books).to eq([@book]) #Can't have saved it because @book isn't saved yet.
       end
       it "should save new child objects" do
         @book.topics << Topic.new
-        @book.topics.first.pid.should_not be_nil
+        expect(@book.topics.first.pid).not_to be_nil
       end
       it "should clear out the old associtions" do
         @book.topics = [@topic1]
         @book.topics = [@topic2]
-        @book.topic_ids.should == [@topic2.pid]
+        expect(@book.topic_ids).to eq([@topic2.pid])
       end
       after do
         @book.delete
@@ -135,27 +135,27 @@ describe ActiveFedora::Base do
       end
 
       it "should have a collection" do
-        book.relationships(:is_member_of_collection).should == [collection.internal_uri]
-        book.collections.should == [collection]
+        expect(book.relationships(:is_member_of_collection)).to eq([collection.internal_uri])
+        expect(book.collections).to eq([collection])
       end
       it "habtm should not set foreign relationships if :inverse_of is not specified" do
-         collection.relationships(:is_member_of_collection).should == []
+         expect(collection.relationships(:is_member_of_collection)).to eq([])
       end
       it "should load the collections" do
         reloaded = Book.find(book.pid)
-        reloaded.collections.should == [collection]
+        expect(reloaded.collections).to eq([collection])
       end
 
       describe "#empty?" do
         subject { book.collections }
-        its(:empty?) { should be_false }
+        its(:empty?) { is_expected.to be_falsey }
       end
     end
 
     context "when a book isn't in a collection" do 
       describe "#empty?" do
         subject { book.collections }
-        its(:empty?) { should be_true }
+        its(:empty?) { should be_truthy }
       end
     end
   end
@@ -191,22 +191,22 @@ describe ActiveFedora::Base do
       end
 
       it "delete should cause the entries to be removed from RELS-EXT, but not destroy the original record" do
-        book.collections.should == [collection1, collection2]
+        expect(book.collections).to eq([collection1, collection2])
         book.collections.delete(collection1)
-        book.collections.should == [collection2]
+        expect(book.collections).to eq([collection2])
         book.save!
         book.reload
-        book.collections.should == [collection2]
+        expect(book.collections).to eq([collection2])
         expect {Collection.find(collection1.pid)}.to_not be_nil
       end
 
       it "destroy should cause the entries to be removed from RELS-EXT, but not destroy the original record" do
-        book.collections.should == [collection1, collection2]
+        expect(book.collections).to eq([collection1, collection2])
         book.collections.destroy(collection1)
-        book.collections.should == [collection2]
+        expect(book.collections).to eq([collection2])
         book.save!
         book.reload
-        book.collections.should == [collection2]
+        expect(book.collections).to eq([collection2])
         expect {Collection.find(collection1.pid)}.to_not be_nil
       end
     end
@@ -240,25 +240,25 @@ describe ActiveFedora::Base do
       end
 
       it "destroy should cause the before_remove and after_remove callback to be triggered" do
-        book.should_receive(:foo).with(collection)
-        book.should_receive(:bar).with(collection)
+        expect(book).to receive(:foo).with(collection)
+        expect(book).to receive(:bar).with(collection)
         book.collections.destroy(collection)
       end
 
       it "delete should cause the before_remove and after_remove callback to be triggered" do
-        book.should_receive(:foo).with(collection)
-        book.should_receive(:bar).with(collection)
+        expect(book).to receive(:foo).with(collection)
+        expect(book).to receive(:bar).with(collection)
         book.collections.delete(collection)
       end
 
       it "should not remove if an exception is thrown in before_remove" do
-        book.should_receive(:foo).with(collection).and_raise
-        book.should_not_receive(:bar)
+        expect(book).to receive(:foo).with(collection).and_raise
+        expect(book).not_to receive(:bar)
         begin
           book.collections.delete(collection)
         rescue RuntimeError
         end
-        book.collections.should == [collection]
+        expect(book.collections).to eq([collection])
       end
     end
 
@@ -287,25 +287,25 @@ describe ActiveFedora::Base do
       end
 
       it "shift should cause the before_add and after_add callback to be triggered" do
-        book.should_receive(:foo).with(collection)
-        book.should_receive(:bar).with(collection)
+        expect(book).to receive(:foo).with(collection)
+        expect(book).to receive(:bar).with(collection)
         book.collections << collection
       end
 
       it "assignment should cause the before_add and after_add callback to be triggered" do
-        book.should_receive(:foo).with(collection)
-        book.should_receive(:bar).with(collection)
+        expect(book).to receive(:foo).with(collection)
+        expect(book).to receive(:bar).with(collection)
         book.collections = [collection]
       end
 
       it "should not add if an exception is thrown in before_add" do
-        book.should_receive(:foo).with(collection).and_raise
-        book.should_not_receive(:bar)
+        expect(book).to receive(:foo).with(collection).and_raise
+        expect(book).not_to receive(:bar)
         begin
           book.collections << collection
         rescue RuntimeError
         end
-        book.collections.should == []
+        expect(book.collections).to eq([])
       end
     end
 
@@ -341,7 +341,7 @@ describe "Autosave" do
 
     it "should save dependent records" do
       component.reload
-      component.items.first.title.should == 'my title'
+      expect(component.items.first.title).to eq('my title')
     end
   end
   describe "From the has_many side" do
@@ -349,7 +349,7 @@ describe "Autosave" do
 
     it "should save dependent records" do
       item.reload
-      item.components.first.description.should == 'my description'
+      expect(item.components.first.description).to eq('my description')
     end
   end
 

--- a/spec/integration/has_many_associations_spec.rb
+++ b/spec/integration/has_many_associations_spec.rb
@@ -21,7 +21,7 @@ describe "Collection members" do
         expect(library.books).not_to be_loaded
         expect(library.books.size).to eq(0)
         expect(library.books).to be_loaded
-        expect(library.books.any?).to be_false
+        expect(library.books.any?).to be_falsey
       end
     end
   end
@@ -41,9 +41,9 @@ describe "Collection members" do
     end
 
     it "should cache the results" do
-      expect(library.books.loaded?).to be_false
+      expect(library.books.loaded?).to be_falsey
       expect(library.books).to eq [book]
-      expect(library.books.loaded?).to be_true
+      expect(library.books.loaded?).to be_truthy
     end
     it "should load from solr" do
       expect(library.books.load_from_solr.map {|r| r["id"]}).to eq([book.pid])
@@ -52,9 +52,9 @@ describe "Collection members" do
       expect(library.books.load_from_solr(rows: 0).size).to eq(0)
     end
     it "should respond to #any?" do
-      expect(library.books.any?).to be_true
-      expect(library.books.any? {|book| book.library == nil}).to be_false
-      expect(library.books.any? {|book| book.library == library}).to be_true
+      expect(library.books.any?).to be_truthy
+      expect(library.books.any? {|book| book.library == nil}).to be_falsey
+      expect(library.books.any? {|book| book.library == library}).to be_truthy
     end
   end
 end
@@ -84,7 +84,7 @@ describe "After save callbacks" do
   let(:book) { Book.new(library: library) }
   it "should have the relationship available in after_save" do
     book.save!
-    book.library_books.should include book
+    expect(book.library_books).to include book
   end
 end
 
@@ -115,8 +115,8 @@ describe "When two or more relationships share the same property" do
 
   it "Should only return relationships of the correct class" do
     @book.reload
-    @book.people.should == [@person1, @person2]
-    @book.collections.should == []
+    expect(@book.people).to eq([@person1, @person2])
+    expect(@book.collections).to eq([])
   end
 end
 
@@ -150,7 +150,7 @@ describe "When relationship is restricted to AF::Base" do
     end
     it "Should not restrict relationships " do
       @book.reload
-      @book.attachments.should == [@image, @pdf]
+      expect(@book.attachments).to eq([@image, @pdf])
     end
   end
 
@@ -168,7 +168,7 @@ describe "When relationship is restricted to AF::Base" do
     it "Should not restrict relationships " do
       email.attachment_ids = [image.id, pdf.id]
       email.reload
-      email.attachments.should == [image, pdf]
+      expect(email.attachments).to eq([image, pdf])
     end
   end
 end
@@ -194,12 +194,12 @@ describe "Deleting a dependent relationship" do
   it "should remove relationships" do
     component.item = item
     component.save!
-    item.components.should == [component]
+    expect(item.components).to eq([component])
     item.components.delete(component)
     item.reload
     component.reload
-    component.relationships(:is_part_of).should == []
-    item.components.should == []
+    expect(component.relationships(:is_part_of)).to eq([])
+    expect(item.components).to eq([])
   end
 
   it "should remove the relationships that point at that object" do
@@ -207,7 +207,7 @@ describe "Deleting a dependent relationship" do
     component.save!
     item.delete
     component.reload
-    component.relationships(:is_part_of).should == []
+    expect(component.relationships(:is_part_of)).to eq([])
   end
 
   it "should only try to delete objects that exist in the datastore (not cached objects)" do
@@ -254,7 +254,7 @@ describe "Autosave" do
 
     it "should save dependent records" do
       component.reload
-      component.item.title.should == 'my title'
+      expect(component.item.title).to eq('my title')
     end
   end
   describe "From the has_many side" do
@@ -262,7 +262,7 @@ describe "Autosave" do
 
     it "should save dependent records" do
       item.reload
-      item.components.first.description.should == 'my description'
+      expect(item.components.first.description).to eq('my description')
     end
   end
 

--- a/spec/integration/json_serialization_spec.rb
+++ b/spec/integration/json_serialization_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Objects should be serialized to JSON" do
   it "should have json results" do
-    ActiveFedora::Base.new.to_json.should == "{\"id\":null}"
+    expect(ActiveFedora::Base.new.to_json).to eq("{\"id\":null}")
   end
 
   describe "with a more interesting model" do
@@ -20,7 +20,7 @@ describe "Objects should be serialized to JSON" do
       Object.send(:remove_const, :Foo)
     end
     subject { Foo.new(foo: ["baz"], bar: 'quix') }
-    before { subject.stub(pid: 'test:123') }
+    before { allow(subject).to receive_messages(pid: 'test:123') }
     it "should have to_json" do
       json = JSON.parse(subject.to_json)
       expect(json['id']).to eq "test:123"

--- a/spec/integration/load_from_solr_spec.rb
+++ b/spec/integration/load_from_solr_spec.rb
@@ -52,7 +52,7 @@ describe "Loading from solr" do
   end
 
   it "should be able to get indexed properties without loading from fedora" do
-    RdfTest.connection_for_pid('1').should_not_receive(:datastream_dissemination)
+    expect(RdfTest.connection_for_pid('1')).not_to receive(:datastream_dissemination)
     obj = RdfTest.load_instance_from_solr original.pid
     expect(obj.title).to eq "PLAN 9 FROM OUTER SPACE"
     expect(obj.date_uploaded).to eq [Date.parse('1959-01-01')]

--- a/spec/integration/model_spec.rb
+++ b/spec/integration/model_spec.rb
@@ -29,11 +29,11 @@ describe ActiveFedora::Model do
   describe "#all" do
     it "should return an array of instances of the calling Class" do
       result = ModelIntegrationSpec::Basic.all.to_a
-      result.should be_instance_of(Array)
+      expect(result).to be_instance_of(Array)
       # this test is meaningless if the array length is zero
-      result.length.should > 0
+      expect(result.length).to be > 0
       result.each do |obj|
-        obj.class.should == ModelIntegrationSpec::Basic
+        expect(obj.class).to eq(ModelIntegrationSpec::Basic)
       end
     end
   end
@@ -41,31 +41,31 @@ describe ActiveFedora::Model do
   describe '#find' do
     describe "#find with a valid pid without cast" do
       subject { ActiveFedora::Base.find(@test_instance.pid) }
-      it { should be_instance_of ModelIntegrationSpec::Basic}
+      it { is_expected.to be_instance_of ModelIntegrationSpec::Basic}
     end
     describe "#find with a valid pid with cast of false" do
       subject { ActiveFedora::Base.find(@test_instance.pid, cast: false) }
-      it { should be_instance_of ActiveFedora::Base}
+      it { is_expected.to be_instance_of ActiveFedora::Base}
     end
     describe "#find with a valid pid without cast on a model extending Base" do
       subject { ModelIntegrationSpec::Basic.find(@test_instance.pid) }
-      it { should be_instance_of ModelIntegrationSpec::Basic}
+      it { is_expected.to be_instance_of ModelIntegrationSpec::Basic}
     end
   end
 
   describe "#load_instance_from_solr" do
     describe "with a valid pid" do
       subject { ActiveFedora::Base.load_instance_from_solr(@test_instance.pid) }
-      it { should be_instance_of ModelIntegrationSpec::Basic}
+      it { is_expected.to be_instance_of ModelIntegrationSpec::Basic}
     end
     describe "with metadata datastream spec" do
       subject { ActiveFedora::Base.load_instance_from_solr(@test_instance.pid) }
       it "should create an xml datastream" do
-        subject.datastreams['properties'].should be_kind_of ActiveFedora::SimpleDatastream
+        expect(subject.datastreams['properties']).to be_kind_of ActiveFedora::SimpleDatastream
       end
 
       it "should know the datastreams properties" do
-        subject.properties.dsSize.should == 9
+        expect(subject.properties.dsSize).to eq(9)
       end
     end
   end

--- a/spec/integration/nested_attribute_spec.rb
+++ b/spec/integration/nested_attribute_spec.rb
@@ -43,31 +43,31 @@ describe "NestedAttribute behavior" do
   end
 
   it "should have _destroy" do
-    Bar.new._destroy.should be_false
+    expect(Bar.new._destroy).to be_falsey
   end
 
   it "should update the child objects" do
     @car, @bar1, @bar2 = create_car_with_bars
 
     @car.attributes = {:bars_attributes=>[{:id=>@bar1.pid, :uno=>"bar1 uno"}, {:uno=>"newbar uno"}, {:id=>@bar2.pid, :_destroy=>'1', :uno=>'bar2 uno'}]}
-    Bar.find(@bar1.pid).uno.should == 'bar1 uno'
-    Bar.where(:id => @bar2.pid).first.should be_nil
-    Bar.where(:uno => "newbar uno").first.should_not be_nil
+    expect(Bar.find(@bar1.pid).uno).to eq('bar1 uno')
+    expect(Bar.where(:id => @bar2.pid).first).to be_nil
+    expect(Bar.where(:uno => "newbar uno").first).not_to be_nil
 
     bars = @car.bars(true)
-    bars.should include(@bar1)
-    bars.should_not include(@bar2)
+    expect(bars).to include(@bar1)
+    expect(bars).not_to include(@bar2)
   end
 
   it "should reject attributes when all blank" do
     @car, @bar1, @bar2 = create_car_with_bars(CarAllBlank)
 
-    @car.bars.count.should == 2
+    expect(@car.bars.count).to eq(2)
     @car.attributes = {:bars_attributes=>[{}, {:id=>@bar1.pid, :uno=>"bar1 uno"}]}
-    @car.bars(true).count.should == 2
+    expect(@car.bars(true).count).to eq(2)
 
     @bar1.reload
-    @bar1.uno.should == "bar1 uno"
+    expect(@bar1.uno).to eq("bar1 uno")
   end
 
   it "should reject attributes based on proc" do
@@ -76,8 +76,8 @@ describe "NestedAttribute behavior" do
     @car.attributes = {:bars_attributes=>[{}, {:id=>@bar1.pid, :uno=>"bar1 uno"}, {:id=>@bar2.pid, :dos=>"bar2 dos"}]}
     @bar1.reload
     @bar2.reload
-    @bar1.uno.should == "bar1 uno"
-    @bar2.dos.should be_nil
+    expect(@bar1.uno).to eq("bar1 uno")
+    expect(@bar2.dos).to be_nil
   end
 
   it "should reject attributes base on method name" do
@@ -86,20 +86,20 @@ describe "NestedAttribute behavior" do
     @car.attributes = {:bars_attributes=>[{}, {:id=>@bar1.pid, :uno=>"bar1 uno"}, {:id=>@bar2.pid, :dos=>"bar2 dos"}]}
     @bar1.reload
     @bar2.reload
-    @bar1.uno.should == "bar1 uno"
-    @bar2.dos.should be_nil
+    expect(@bar1.uno).to eq("bar1 uno")
+    expect(@bar2.dos).to be_nil
   end
 
   it "should throw TooManyRecords" do
     @car, @bar1, @bar2 = create_car_with_bars(CarWithLimit)
 
-    lambda {
+    expect {
       @car.attributes = {:bars_attributes=>[{}]}
-    }.should_not raise_exception
+    }.not_to raise_exception
 
-    lambda {
+    expect {
       @car.attributes = {:bars_attributes=>[{}, {}]}
-    }.should raise_exception(ActiveFedora::NestedAttributes::TooManyRecords)
+    }.to raise_exception(ActiveFedora::NestedAttributes::TooManyRecords)
   end
 
   private

--- a/spec/integration/ntriples_datastream_spec.rb
+++ b/spec/integration/ntriples_datastream_spec.rb
@@ -49,25 +49,25 @@ describe ActiveFedora::NtriplesRDFDatastream do
     foo = RdfTest.new(pid: 'test:1') #Pid needs to match the subject in the loaded file
     foo.title = 'Hamlet'
     foo.save
-    foo.title.should == 'Hamlet'
+    expect(foo.title).to eq('Hamlet')
     foo.rdf.content = File.new('spec/fixtures/mixed_rdf_descMetadata.nt').read
     foo.save
-    foo.title.should == 'Title of work'
+    expect(foo.title).to eq('Title of work')
   end
 
   it "should delegate as_json to the fields" do
     @subject = RdfTest.new(title: "Title of work")
-    @subject.rdf.title.as_json.should == ["Title of work"]
-    @subject.rdf.title.to_json.should == "\[\"Title of work\"\]"
+    expect(@subject.rdf.title.as_json).to eq(["Title of work"])
+    expect(@subject.rdf.title.to_json).to eq("\[\"Title of work\"\]")
   end
 
   it "should solrize even when the object is not new" do
     foo = RdfTest.new
-    foo.should_receive(:update_index).once
+    expect(foo).to receive(:update_index).once
     foo.title = "title1"
     foo.save
     foo = RdfTest.find(foo.pid)
-    foo.should_receive(:update_index).once
+    expect(foo).to receive(:update_index).once
     foo.title = "The Work2"
     foo.save  
   end
@@ -75,36 +75,36 @@ describe ActiveFedora::NtriplesRDFDatastream do
   describe "serializing" do
     it "should handle dates" do
       subject.date_uploaded = [Date.parse('2012-11-02')]
-      subject.date_uploaded.first.should be_kind_of Date
+      expect(subject.date_uploaded.first).to be_kind_of Date
       solr_document = subject.to_solr
-      solr_document[ActiveFedora::SolrService.solr_name('rdf__date_uploaded', type: :date)].should == ['2012-11-02T00:00:00Z']
+      expect(solr_document[ActiveFedora::SolrService.solr_name('rdf__date_uploaded', type: :date)]).to eq(['2012-11-02T00:00:00Z'])
     end
     it "should handle integers" do
       subject.filesize = 12345 
-      subject.filesize.should be_kind_of Fixnum
+      expect(subject.filesize).to be_kind_of Fixnum
       solr_document = subject.to_solr
-      solr_document[ActiveFedora::SolrService.solr_name('rdf__filesize', :stored_sortable, type: :integer)].should == '12345'
+      expect(solr_document[ActiveFedora::SolrService.solr_name('rdf__filesize', :stored_sortable, type: :integer)]).to eq('12345')
     end
   end
 
   it "should produce a solr document" do
     @subject = RdfTest.new(title: "War and Peace")
     solr_document = @subject.to_solr
-    solr_document[ActiveFedora::SolrService.solr_name('rdf__title', :facetable)].should == ["War and Peace"]
-    solr_document[ActiveFedora::SolrService.solr_name('rdf__title', type: :string)].should == ["War and Peace"]
+    expect(solr_document[ActiveFedora::SolrService.solr_name('rdf__title', :facetable)]).to eq(["War and Peace"])
+    expect(solr_document[ActiveFedora::SolrService.solr_name('rdf__title', type: :string)]).to eq(["War and Peace"])
   end
 
   it "should set and recall values" do
     @subject.title = 'War and Peace'
-    @subject.rdf.should be_changed
+    expect(@subject.rdf).to be_changed
     @subject.based_near = ["Moscow, Russia"]
     @subject.related_url = ["http://en.wikipedia.org/wiki/War_and_Peace"]
     @subject.part = ["this is a part"]
     @subject.save
-    @subject.title.should == 'War and Peace'
-    @subject.based_near.should == ["Moscow, Russia"]
-    @subject.related_url.should == ["http://en.wikipedia.org/wiki/War_and_Peace"]
-    @subject.part.should == ["this is a part"]    
+    expect(@subject.title).to eq('War and Peace')
+    expect(@subject.based_near).to eq(["Moscow, Russia"])
+    expect(@subject.related_url).to eq(["http://en.wikipedia.org/wiki/War_and_Peace"])
+    expect(@subject.part).to eq(["this is a part"])    
   end
   it "should set, persist, and recall values" do
     @subject.title = 'War and Peace'
@@ -114,24 +114,24 @@ describe ActiveFedora::NtriplesRDFDatastream do
     @subject.save
 
     loaded = RdfTest.find(@subject.pid)
-    loaded.title.should == 'War and Peace'
-    loaded.based_near.should == ['Moscow, Russia']
-    loaded.related_url.should == ['http://en.wikipedia.org/wiki/War_and_Peace']
-    loaded.part.should == ['this is a part']
+    expect(loaded.title).to eq('War and Peace')
+    expect(loaded.based_near).to eq(['Moscow, Russia'])
+    expect(loaded.related_url).to eq(['http://en.wikipedia.org/wiki/War_and_Peace'])
+    expect(loaded.part).to eq(['this is a part'])
   end
   it "should set multiple values" do
     @subject.part = ["part 1", "part 2"]
     @subject.save
 
     loaded = RdfTest.find(@subject.pid)
-    loaded.part.should == ['part 1', 'part 2']
+    expect(loaded.part).to eq(['part 1', 'part 2'])
   end
   it "should append values" do
     @subject.part = ["thing 1"]
     @subject.save
 
     @subject.part << "thing 2"
-    @subject.part.should == ["thing 1", "thing 2"]
+    expect(@subject.part).to eq(["thing 1", "thing 2"])
   end
 
   it "should be able to save a blank document" do
@@ -144,7 +144,7 @@ describe ActiveFedora::NtriplesRDFDatastream do
 <http://oregondigital.org/ns/62> <http://purl.org/dc/terms/spatial> "Benton County (Ore.)" .
 '
     @subject.rdf.content = ntrip
-    @subject.rdf.graph.dump(:ntriples).should == ntrip
+    expect(@subject.rdf.graph.dump(:ntriples)).to eq(ntrip)
   end
 
   describe "using rdf_subject" do
@@ -165,7 +165,7 @@ describe ActiveFedora::NtriplesRDFDatastream do
       @subject.rdf.dctype = "Frog"
       @subject.save!
       @subject.reload
-      @subject.rdf.graph.dump(:ntriples).should == "<http://oregondigital.org/ns/99> <http://purl.org/dc/terms/type> \"Frog\" .\n"
+      expect(@subject.rdf.graph.dump(:ntriples)).to eq("<http://oregondigital.org/ns/99> <http://purl.org/dc/terms/type> \"Frog\" .\n")
       @subject.rdf.dctype == ['Frog']
 
     end
@@ -178,32 +178,32 @@ describe ActiveFedora::NtriplesRDFDatastream do
     @subject.related_url = ["http://psu.edu/"]
     @subject.related_url << "http://projecthydra.org/"
 
-    @subject.title.should == "Hamlet"
-    @subject.related_url.should include("http://psu.edu/")
-    @subject.related_url.should include("http://projecthydra.org/")
+    expect(@subject.title).to eq("Hamlet")
+    expect(@subject.related_url).to include("http://psu.edu/")
+    expect(@subject.related_url).to include("http://projecthydra.org/")
 
     @subject.title = "" #empty string can be meaningful, don't assume delete.
-    @subject.title.should == ''
+    expect(@subject.title).to eq('')
 
     @subject.title = nil
     @subject.related_url.delete("http://projecthydra.org/")
 
-    @subject.title.should be_nil
-    @subject.related_url.should == ["http://psu.edu/"]
+    expect(@subject.title).to be_nil
+    expect(@subject.related_url).to eq(["http://psu.edu/"])
   end
   it "should delete multiple values at once" do
     @subject.part = ["MacBeth"]
     @subject.part << "Hamlet"
     @subject.part << "Romeo & Juliet"
-    @subject.part.first.should == "MacBeth"
+    expect(@subject.part.first).to eq("MacBeth")
     @subject.part.delete("MacBeth", "Romeo & Juliet")
-    @subject.part.should == ["Hamlet"]
-    @subject.part.first.should == "Hamlet"
+    expect(@subject.part).to eq(["Hamlet"])
+    expect(@subject.part.first).to eq("Hamlet")
   end
   it "should ignore values to be deleted that do not exist" do
     @subject.part = ["title1", "title2", "title3"]
     @subject.part.delete("title2", "title4", "title6")
-    @subject.part.should == ["title1", "title3"]
+    expect(@subject.part).to eq(["title1", "title3"])
   end
   describe "term proxy methods" do
     before(:each) do
@@ -224,25 +224,25 @@ describe ActiveFedora::NtriplesRDFDatastream do
     end
 
     it "should support the count method to determine # of values" do
-      @subject.title.count.should == 3
+      expect(@subject.title.count).to eq(3)
     end
     it "should iterate over multiple values" do
-      @subject.title.should respond_to(:each)
+      expect(@subject.title).to respond_to(:each)
     end
     it "should get the first value" do
-      @subject.title.first.should == "title1"
+      expect(@subject.title.first).to eq("title1")
     end
     it "should evaluate equality predictably" do
-      @subject.title.should == ["title1", "title2", "title3"]
+      expect(@subject.title).to eq(["title1", "title2", "title3"])
     end
     it "should support the empty? method" do
-      @subject.title.should respond_to(:empty?)
-      @subject.title.empty?.should be_false
+      expect(@subject.title).to respond_to(:empty?)
+      expect(@subject.title.empty?).to be_falsey
       @subject.title.delete("title1", "title2", "title3")
-      @subject.title.empty?.should be_true
+      expect(@subject.title.empty?).to be_truthy
     end
     it "should support the is_a? method" do
-      @subject.title.is_a?(Array).should == true
+      expect(@subject.title.is_a?(Array)).to eq(true)
     end
   end
 end

--- a/spec/integration/om_datastream_spec.rb
+++ b/spec/integration/om_datastream_spec.rb
@@ -26,28 +26,28 @@ describe ActiveFedora::OmDatastream do
     end
 
     it "should report being inline" do
-      @obj.descMetadata.should be_inline
+      expect(@obj.descMetadata).to be_inline
     end
 
     it "should not be changed when no fields have been set" do
-      @obj.descMetadata.should_not be_changed
+      expect(@obj.descMetadata).not_to be_changed
     end
     it "should be changed when a field has been set" do
       @obj.descMetadata.title = 'Foobar'
-      @obj.descMetadata.should be_changed
+      expect(@obj.descMetadata).to be_changed
     end
     describe "#changed?" do
       it "should not be changed if the new xml matches the old xml" do
         @obj.descMetadata.content = @obj.descMetadata.content
-        @obj.descMetadata.should_not be_changed
+        expect(@obj.descMetadata).not_to be_changed
       end
 
       it "should not be changed if there are minor differences in whitespace" do
         @obj.descMetadata.content = "<a><b>1</b></a>"
         @obj.save
-        @obj.descMetadata.should_not be_changed
+        expect(@obj.descMetadata).not_to be_changed
         @obj.descMetadata.content = "<a>\n<b>1</b>\n</a>"
-        @obj.descMetadata.should_not be_changed
+        expect(@obj.descMetadata).not_to be_changed
       end
     end
   end
@@ -75,21 +75,21 @@ describe ActiveFedora::OmDatastream do
     end
 
     it "should not report being inline" do
-      @obj.descMetadata.should be_managed
+      expect(@obj.descMetadata).to be_managed
     end
 
     describe "#changed?" do
       it "should not be changed if the new xml matches the old xml" do
         @obj.descMetadata.content = @obj.descMetadata.content
-        @obj.descMetadata.should_not be_changed
+        expect(@obj.descMetadata).not_to be_changed
       end
 
       it "should be changed if there are minor differences in whitespace" do
         @obj.descMetadata.content = "<a><b>1</b></a>"
         @obj.save
-        @obj.descMetadata.should_not be_changed
+        expect(@obj.descMetadata).not_to be_changed
         @obj.descMetadata.content = "<a>\n<b>1</b>\n</a>"
-        @obj.descMetadata.should be_changed
+        expect(@obj.descMetadata).to be_changed
       end
     end
 
@@ -109,31 +109,31 @@ describe ActiveFedora::OmDatastream do
       end
 
       it "should return the same values whether getting from solr or Fedora" do
-        @solr_obj.datastreams["descMetadata"].term_values(:name,:role,:text).should == ["Creator","Contributor","Funder","Host"]
-        @solr_obj.datastreams["descMetadata"].term_values({:name=>0},:role,:text).should == ["Creator"]
-        @solr_obj.datastreams["descMetadata"].term_values({:name=>1},:role,:text).should == ["Contributor"]
-        @solr_obj.datastreams["descMetadata"].term_values({:name=>0},{:role=>0},:text).should == ["Creator"]
-        @solr_obj.datastreams["descMetadata"].term_values({:name=>1},{:role=>0},:text).should == ["Contributor"]
-        @solr_obj.datastreams["descMetadata"].term_values({:name=>1},{:role=>1},:text).should == []
+        expect(@solr_obj.datastreams["descMetadata"].term_values(:name,:role,:text)).to eq(["Creator","Contributor","Funder","Host"])
+        expect(@solr_obj.datastreams["descMetadata"].term_values({:name=>0},:role,:text)).to eq(["Creator"])
+        expect(@solr_obj.datastreams["descMetadata"].term_values({:name=>1},:role,:text)).to eq(["Contributor"])
+        expect(@solr_obj.datastreams["descMetadata"].term_values({:name=>0},{:role=>0},:text)).to eq(["Creator"])
+        expect(@solr_obj.datastreams["descMetadata"].term_values({:name=>1},{:role=>0},:text)).to eq(["Contributor"])
+        expect(@solr_obj.datastreams["descMetadata"].term_values({:name=>1},{:role=>1},:text)).to eq([])
         ar = @solr_obj.datastreams["descMetadata"].term_values(:name,{:role=>0},:text)
-        ar.length.should == 4
-        ar.include?("Creator").should == true
-        ar.include?("Contributor").should == true
-        ar.include?("Funder").should == true
-        ar.include?("Host").should == true
+        expect(ar.length).to eq(4)
+        expect(ar.include?("Creator")).to eq(true)
+        expect(ar.include?("Contributor")).to eq(true)
+        expect(ar.include?("Funder")).to eq(true)
+        expect(ar.include?("Host")).to eq(true)
 
-        @obj.datastreams["descMetadata"].term_values(:name,:role,:text).should == ["Creator","Contributor","Funder","Host"]
-        @obj.datastreams["descMetadata"].term_values({:name=>0},:role,:text).should == ["Creator"]
-        @obj.datastreams["descMetadata"].term_values({:name=>1},:role,:text).should == ["Contributor"]
-        @obj.datastreams["descMetadata"].term_values({:name=>0},{:role=>0},:text).should == ["Creator"]
-        @obj.datastreams["descMetadata"].term_values({:name=>1},{:role=>0},:text).should == ["Contributor"]
-        @obj.datastreams["descMetadata"].term_values({:name=>1},{:role=>1},:text).should == []
+        expect(@obj.datastreams["descMetadata"].term_values(:name,:role,:text)).to eq(["Creator","Contributor","Funder","Host"])
+        expect(@obj.datastreams["descMetadata"].term_values({:name=>0},:role,:text)).to eq(["Creator"])
+        expect(@obj.datastreams["descMetadata"].term_values({:name=>1},:role,:text)).to eq(["Contributor"])
+        expect(@obj.datastreams["descMetadata"].term_values({:name=>0},{:role=>0},:text)).to eq(["Creator"])
+        expect(@obj.datastreams["descMetadata"].term_values({:name=>1},{:role=>0},:text)).to eq(["Contributor"])
+        expect(@obj.datastreams["descMetadata"].term_values({:name=>1},{:role=>1},:text)).to eq([])
         ar = @obj.datastreams["descMetadata"].term_values(:name,{:role=>0},:text)
-        ar.length.should == 4
-        ar.include?("Creator").should == true
-        ar.include?("Contributor").should == true
-        ar.include?("Funder").should == true
-        ar.include?("Host").should == true
+        expect(ar.length).to eq(4)
+        expect(ar.include?("Creator")).to eq(true)
+        expect(ar.include?("Contributor")).to eq(true)
+        expect(ar.include?("Funder")).to eq(true)
+        expect(ar.include?("Host")).to eq(true)
       end
     end
     
@@ -146,10 +146,10 @@ describe ActiveFedora::OmDatastream do
 
       it "should not be dirty after .update_values is saved" do
         @obj.datastreams["descMetadata"].update_values([{:name=>0},{:role=>0},:text] =>"Funder")
-        @obj.datastreams["descMetadata"].should be_changed
+        expect(@obj.datastreams["descMetadata"]).to be_changed
         @obj.save
-        @obj.datastreams["descMetadata"].should_not be_changed
-        @obj.datastreams["descMetadata"].term_values({:name=>0},{:role=>0},:text).should == ["Funder"]
+        expect(@obj.datastreams["descMetadata"]).not_to be_changed
+        expect(@obj.datastreams["descMetadata"].term_values({:name=>0},{:role=>0},:text)).to eq(["Funder"])
       end    
     end
 
@@ -161,7 +161,7 @@ describe ActiveFedora::OmDatastream do
         @obj.reload
       end
       it "should solrize terms with :type=>'date' to *_dt solr terms" do
-        @obj.to_solr[ActiveFedora::SolrService.solr_name('desc_metadata__journal_issue_publication_date', type: :date)].should == ['2012-11-02T00:00:00Z']
+        expect(@obj.to_solr[ActiveFedora::SolrService.solr_name('desc_metadata__journal_issue_publication_date', type: :date)]).to eq(['2012-11-02T00:00:00Z'])
       end
     end
   end

--- a/spec/integration/persistence_spec.rb
+++ b/spec/integration/persistence_spec.rb
@@ -16,7 +16,7 @@ describe "persisting objects" do
 
   describe "#create!" do
     it "should validate" do
-      lambda { MockAFBaseRelationship.create!}.should raise_error ActiveFedora::RecordInvalid, "Validation failed: Name can't be blank"
+      expect { MockAFBaseRelationship.create!}.to raise_error ActiveFedora::RecordInvalid, "Validation failed: Name can't be blank"
     end
   end
 end

--- a/spec/integration/rdf_nested_attributes_spec.rb
+++ b/spec/integration/rdf_nested_attributes_spec.rb
@@ -100,14 +100,14 @@ describe "Nesting attribute behavior of RDFDatastream" do
         subject { ComplexRDFDatastream::PersonalName.new(RDF::Graph.new) }
         it "should accept a hash" do
           subject.elementList_attributes =  [{ topicElement_attributes: {'0' => { elementValue:"Quantum Behavior" }, '1' => { elementValue:"Wave Function" }}}]
-          subject.elementList.first[0].elementValue.should == ["Quantum Behavior"]
-          subject.elementList.first[1].elementValue.should == ["Wave Function"]
+          expect(subject.elementList.first[0].elementValue).to eq(["Quantum Behavior"])
+          expect(subject.elementList.first[1].elementValue).to eq(["Wave Function"])
 
         end
         it "should accept an array" do
           subject.elementList_attributes =  [{ topicElement_attributes: [{ elementValue:"Quantum Behavior" }, { elementValue:"Wave Function" }]}]
-          subject.elementList.first[0].elementValue.should == ["Quantum Behavior"]
-          subject.elementList.first[1].elementValue.should == ["Wave Function"]
+          expect(subject.elementList.first[0].elementValue).to eq(["Quantum Behavior"])
+          expect(subject.elementList.first[1].elementValue).to eq(["Wave Function"])
         end
       end
 
@@ -118,10 +118,10 @@ describe "Nesting attribute behavior of RDFDatastream" do
         end
 
         it 'should have attributes' do
-          subject.topic[0].elementList.first[0].elementValue.should == ["Cosmology"]
-          subject.topic[1].elementList.first[0].elementValue.should == ["Quantum Behavior"]
-          subject.personalName.first.elementList.first.fullNameElement.should == ["Jefferson, Thomas"]
-          subject.personalName.first.elementList.first.dateNameElement.should == ["1743-1826"]
+          expect(subject.topic[0].elementList.first[0].elementValue).to eq(["Cosmology"])
+          expect(subject.topic[1].elementList.first[0].elementValue).to eq(["Quantum Behavior"])
+          expect(subject.personalName.first.elementList.first.fullNameElement).to eq(["Jefferson, Thomas"])
+          expect(subject.personalName.first.elementList.first.dateNameElement).to eq(["1743-1826"])
         end
         
         it 'should build nodes with ids' do
@@ -171,7 +171,7 @@ describe "Nesting attribute behavior of RDFDatastream" do
       it "should update nested objects" do
         subject.parts_attributes= [{id: replace_object_id, label: "Universal Joint"}, {label:"Oil Pump"}, {id: remove_object_id, _destroy: '1', label: "bar1 uno"}]
 
-        subject.parts.map{|p| p.label.first}.should == ['Alternator', 'Universal Joint', 'Transmission', 'Oil Pump']
+        expect(subject.parts.map{|p| p.label.first}).to eq(['Alternator', 'Universal Joint', 'Transmission', 'Oil Pump'])
 
       end
       it "create a new object when the id is provided" do

--- a/spec/integration/relation_delegation_spec.rb
+++ b/spec/integration/relation_delegation_spec.rb
@@ -38,27 +38,27 @@ describe ActiveFedora::Model do
     subject { ModelIntegrationSpec::Basic.where(bar: 'Peanuts') }
 
     it "should map" do
-      subject.map(&:id).should == [instance2.id, instance3.id]
+      expect(subject.map(&:id)).to eq([instance2.id, instance3.id])
     end
 
     it "should collect" do
-      subject.collect(&:id).should == [instance2.id, instance3.id]
+      expect(subject.collect(&:id)).to eq([instance2.id, instance3.id])
     end
 
     it "should have each" do
       t = double
-      t.should_receive(:foo).twice
+      expect(t).to receive(:foo).twice
       subject.each { t.foo }
     end
 
     it "should have all?" do
-      expect(subject.all? { |t| t.foo == ['Alpha']}).to be_false
-      expect(subject.all? { |t| t.bar == ['Peanuts']}).to be_true
+      expect(subject.all? { |t| t.foo == ['Alpha']}).to be_falsey
+      expect(subject.all? { |t| t.bar == ['Peanuts']}).to be_truthy
     end
 
     it "should have include?" do
-      expect(subject.include?(instance1)).to be_false
-      expect(subject.include?(instance2)).to be_true
+      expect(subject.include?(instance1)).to be_falsey
+      expect(subject.include?(instance2)).to be_truthy
     end
   end
 end

--- a/spec/integration/relation_spec.rb
+++ b/spec/integration/relation_spec.rb
@@ -14,7 +14,7 @@ describe ActiveFedora::Base do
   end
 
   subject { Library.all } 
-  its(:class) {should eq ActiveFedora::Relation }
+  its(:class) {is_expected.to eq ActiveFedora::Relation }
 
   before :all do
     Library.create
@@ -32,7 +32,7 @@ describe ActiveFedora::Base do
       expect(subject).to be_loaded
     end
     it "shouldn't reload" do
-      ActiveFedora::Relation.any_instance.should_not_receive :find_each
+      expect_any_instance_of(ActiveFedora::Relation).not_to receive :find_each
       subject[0]
     end
   end

--- a/spec/integration/rels_ext_datastream_spec.rb
+++ b/spec/integration/rels_ext_datastream_spec.rb
@@ -60,7 +60,7 @@ describe ActiveFedora::RelsExtDatastream do
       rexml1 = REXML::Document.new(@test_datastream.to_rels_ext())
       @test_datastream.serialize!
       rexml2 = REXML::Document.new(@test_object.datastreams["RELS-EXT"].content)
-      rexml1.root.elements["rdf:Description"].inspect.should eql(rexml2.root.elements["rdf:Description"].inspect)
+      expect(rexml1.root.elements["rdf:Description"].inspect).to eql(rexml2.root.elements["rdf:Description"].inspect)
     end
   
   end
@@ -72,11 +72,11 @@ describe ActiveFedora::RelsExtDatastream do
     end
     @test_object.save
     # make sure that _something_ was actually added to the object's relationships hash
-    @test_object.ids_for_outbound(:is_member_of).size.should == 1
+    expect(@test_object.ids_for_outbound(:is_member_of).size).to eq(1)
     new_rels = ActiveFedora::Base.find(@test_object.pid).relationships
     # This stopped working, need to push an issue into the rdf library. (when dumping ntriples, the order of assertions changed)
     #new_rels.should == @test_object.relationships
-    new_rels.dump(:rdfxml).should == @test_object.relationships.dump(:rdfxml)
+    expect(new_rels.dump(:rdfxml)).to eq(@test_object.relationships.dump(:rdfxml))
   end
 
 end

--- a/spec/integration/scoped_query_spec.rb
+++ b/spec/integration/scoped_query_spec.rb
@@ -39,18 +39,18 @@ describe "scoped queries" do
     describe ".all" do
       it "should return an array of instances of the calling Class" do
         result = ModelIntegrationSpec::Basic.all.to_a
-        result.should be_instance_of(Array)
+        expect(result).to be_instance_of(Array)
         # this test is meaningless if the array length is zero
-        result.length.should > 0
+        expect(result.length).to be > 0
         result.each do |obj|
-          obj.class.should == ModelIntegrationSpec::Basic
+          expect(obj.class).to eq(ModelIntegrationSpec::Basic)
         end
       end
     end
 
     describe ".first" do
       it "should return one instance of the calling class" do
-        ModelIntegrationSpec::Basic.first.should == test_instance
+        expect(ModelIntegrationSpec::Basic.first).to eq(test_instance)
       end
     end
   end
@@ -67,33 +67,33 @@ describe "scoped queries" do
         test_instance3.delete
       end
       it "should query" do
-        ModelIntegrationSpec::Basic.where(ActiveFedora::SolrService.solr_name('foo', type: :string)=> 'Beta').should == [test_instance1]
-        ModelIntegrationSpec::Basic.where('foo' => 'Beta').should == [test_instance1]
+        expect(ModelIntegrationSpec::Basic.where(ActiveFedora::SolrService.solr_name('foo', type: :string)=> 'Beta')).to eq([test_instance1])
+        expect(ModelIntegrationSpec::Basic.where('foo' => 'Beta')).to eq([test_instance1])
       end
       it "should order" do
-        ModelIntegrationSpec::Basic.order(ActiveFedora::SolrService.solr_name('foo', :sortable) + ' asc').should == [test_instance2, test_instance1, test_instance3]
+        expect(ModelIntegrationSpec::Basic.order(ActiveFedora::SolrService.solr_name('foo', :sortable) + ' asc')).to eq([test_instance2, test_instance1, test_instance3])
       end
       it "should limit" do
-        ModelIntegrationSpec::Basic.limit(1).should == [test_instance1]
+        expect(ModelIntegrationSpec::Basic.limit(1)).to eq([test_instance1])
       end
       it "should offset" do
-        ModelIntegrationSpec::Basic.offset(1).should == [test_instance2, test_instance3]
+        expect(ModelIntegrationSpec::Basic.offset(1)).to eq([test_instance2, test_instance3])
       end
 
       it "should chain queries" do
-        ModelIntegrationSpec::Basic.where(ActiveFedora::SolrService.solr_name('bar', type: :string) => 'Peanuts').order(ActiveFedora::SolrService.solr_name('foo', :sortable) + ' asc').limit(1).should == [test_instance2]
+        expect(ModelIntegrationSpec::Basic.where(ActiveFedora::SolrService.solr_name('bar', type: :string) => 'Peanuts').order(ActiveFedora::SolrService.solr_name('foo', :sortable) + ' asc').limit(1)).to eq([test_instance2])
       end
 
       it "should wrap string conditions with parentheses" do
-        ModelIntegrationSpec::Basic.where("foo:bar OR bar:baz").where_values.should == ["(foo:bar OR bar:baz)"]
+        expect(ModelIntegrationSpec::Basic.where("foo:bar OR bar:baz").where_values).to eq(["(foo:bar OR bar:baz)"])
       end
 
       it "should chain where queries" do
-        ModelIntegrationSpec::Basic.where(ActiveFedora::SolrService.solr_name('bar', type: :string) => 'Peanuts').where("#{ActiveFedora::SolrService.solr_name('foo', type: :string)}:bar").where_values.should == ["#{ActiveFedora::SolrService.solr_name('bar', type: :string)}:Peanuts", "(#{ActiveFedora::SolrService.solr_name('foo', type: :string)}:bar)"]
+        expect(ModelIntegrationSpec::Basic.where(ActiveFedora::SolrService.solr_name('bar', type: :string) => 'Peanuts').where("#{ActiveFedora::SolrService.solr_name('foo', type: :string)}:bar").where_values).to eq(["#{ActiveFedora::SolrService.solr_name('bar', type: :string)}:Peanuts", "(#{ActiveFedora::SolrService.solr_name('foo', type: :string)}:bar)"])
       end
 
       it "should chain count" do
-        ModelIntegrationSpec::Basic.where(ActiveFedora::SolrService.solr_name('bar', type: :string) => 'Peanuts').count.should == 2 
+        expect(ModelIntegrationSpec::Basic.where(ActiveFedora::SolrService.solr_name('bar', type: :string) => 'Peanuts').count).to eq(2) 
       end
 
       it "calling first should not affect the relation's ability to get all results later" do
@@ -125,7 +125,7 @@ describe "scoped queries" do
       end
       it "should log an error" do
         expect(ActiveFedora::Base.logger).to receive(:error).with("Although #{pid} was found in Solr, it doesn't seem to exist in Fedora. The index is out of synch.")
-        ModelIntegrationSpec::Basic.all.should == [test_instance1, test_instance3]
+        expect(ModelIntegrationSpec::Basic.all).to eq([test_instance1, test_instance3])
       end
     end
   end

--- a/spec/integration/solr_service_spec.rb
+++ b/spec/integration/solr_service_spec.rb
@@ -39,9 +39,9 @@ describe ActiveFedora::SolrService do
       query = "id\:#{RSolr.solr_escape(@test_object.pid)} OR id\:#{RSolr.solr_escape(@foo_object.pid)}"
       solr_result = ActiveFedora::SolrService.query(query)
       result = ActiveFedora::SolrService.reify_solr_results(solr_result)
-      result.length.should == 2
+      expect(result.length).to eq(2)
       result.each do |r|
-        (r.class == ActiveFedora::Base || r.class == FooObject).should be_true
+        expect(r.class == ActiveFedora::Base || r.class == FooObject).to be_truthy
       end
     end
     
@@ -49,21 +49,21 @@ describe ActiveFedora::SolrService do
       query = "id\:#{RSolr.solr_escape(@test_object.pid)} OR id\:#{RSolr.solr_escape(@foo_object.pid)}"
       solr_result = ActiveFedora::SolrService.query(query)
       result = ActiveFedora::SolrService.reify_solr_results(solr_result,{:load_from_solr=>true})
-      result.length.should == 2
+      expect(result.length).to eq(2)
       result.each do |r|
-        r.inner_object.should be_a(ActiveFedora::SolrDigitalObject)
-        [ActiveFedora::Base, FooObject].should include(r.class)
-        ['test_object','foo_object'].should include(r.label)
-        @test_object.inner_object.profile.should == @profiles['test']
-        @foo_object.inner_object.profile.should == @profiles['foo']
-        @foo_object.datastreams['descMetadata'].profile.should == @profiles['foo_descMetadata']
-        @foo_object.datastreams['descMetadata'].content.should be_equivalent_to(@foo_content)
+        expect(r.inner_object).to be_a(ActiveFedora::SolrDigitalObject)
+        expect([ActiveFedora::Base, FooObject]).to include(r.class)
+        expect(['test_object','foo_object']).to include(r.label)
+        expect(@test_object.inner_object.profile).to eq(@profiles['test'])
+        expect(@foo_object.inner_object.profile).to eq(@profiles['foo'])
+        expect(@foo_object.datastreams['descMetadata'].profile).to eq(@profiles['foo_descMetadata'])
+        expect(@foo_object.datastreams['descMetadata'].content).to be_equivalent_to(@foo_content)
       end
     end
     
     it 'should instantiate all datastreams in the solr doc, even ones undeclared by the class' do
       obj = ActiveFedora::Base.load_instance_from_solr @foo_object.pid 
-      obj.datastreams.keys.should include('descMetadata')
+      expect(obj.datastreams.keys).to include('descMetadata')
     end
     
     it 'should #reify a lightweight object as a new instance' do
@@ -72,10 +72,10 @@ describe ActiveFedora::SolrService do
       result = ActiveFedora::SolrService.reify_solr_results(solr_result,{:load_from_solr=>true})
       solr_foo = result.first
       real_foo = solr_foo.reify
-      solr_foo.inner_object.should be_a(ActiveFedora::SolrDigitalObject)
-      real_foo.inner_object.should be_a(ActiveFedora::DigitalObject)
-      solr_foo.label.should == 'foo_object'
-      real_foo.label.should == 'foo_object'
+      expect(solr_foo.inner_object).to be_a(ActiveFedora::SolrDigitalObject)
+      expect(real_foo.inner_object).to be_a(ActiveFedora::DigitalObject)
+      expect(solr_foo.label).to eq('foo_object')
+      expect(real_foo.label).to eq('foo_object')
     end
     
     it 'should #reify! a lightweight object within the same instance' do
@@ -83,10 +83,10 @@ describe ActiveFedora::SolrService do
       solr_result = ActiveFedora::SolrService.query(query)
       result = ActiveFedora::SolrService.reify_solr_results(solr_result,{:load_from_solr=>true})
       solr_foo = result.first
-      solr_foo.inner_object.should be_a(ActiveFedora::SolrDigitalObject)
+      expect(solr_foo.inner_object).to be_a(ActiveFedora::SolrDigitalObject)
       solr_foo.reify!
-      solr_foo.inner_object.should be_a(ActiveFedora::DigitalObject)
-      solr_foo.label.should == 'foo_object'
+      expect(solr_foo.inner_object).to be_a(ActiveFedora::DigitalObject)
+      expect(solr_foo.label).to eq('foo_object')
     end
     
     it 'should raise an exception when attempting to reify a first-class object' do
@@ -94,17 +94,17 @@ describe ActiveFedora::SolrService do
       solr_result = ActiveFedora::SolrService.query(query)
       result = ActiveFedora::SolrService.reify_solr_results(solr_result,{:load_from_solr=>true})
       solr_foo = result.first
-      lambda {solr_foo.reify}.should_not raise_exception
-      lambda {solr_foo.reify!}.should_not raise_exception
-      lambda {solr_foo.reify!}.should raise_exception(/already a full/)
-      lambda {solr_foo.reify}.should raise_exception(/already a full/)
+      expect {solr_foo.reify}.not_to raise_exception
+      expect {solr_foo.reify!}.not_to raise_exception
+      expect {solr_foo.reify!}.to raise_exception(/already a full/)
+      expect {solr_foo.reify}.to raise_exception(/already a full/)
     end
   
     it 'should call load_instance_from_solr if :load_from_solr option passed in' do
       query = "id\:#{RSolr.solr_escape(@test_object.pid)} OR id\:#{RSolr.solr_escape(@foo_object.pid)}"
       solr_result = ActiveFedora::SolrService.query(query)
-      ActiveFedora::Base.should_receive(:load_instance_from_solr).once
-      FooObject.should_receive(:load_instance_from_solr).once
+      expect(ActiveFedora::Base).to receive(:load_instance_from_solr).once
+      expect(FooObject).to receive(:load_instance_from_solr).once
       result = ActiveFedora::SolrService.reify_solr_results(solr_result,{:load_from_solr=>true})
     end
     

--- a/spec/support/mock_fedora.rb
+++ b/spec/support/mock_fedora.rb
@@ -2,34 +2,34 @@ def mock_client
   return @mock_client if @mock_client
   @mock_client = double("client")
   @getter = double("getter")
-  @getter.stub(:get).and_return('')
-  @mock_client.stub(:[]).with("describe?xml=true").and_return('')
+  allow(@getter).to receive(:get).and_return('')
+  allow(@mock_client).to receive(:[]).with("describe?xml=true").and_return('')
   @mock_client 
 end
   
 def stub_get(pid, datastreams=nil, record_exists=false)
   pid.gsub!(/:/, '%3A')
   if record_exists
-    mock_client.stub(:[]).with("objects/#{pid}?format=xml").and_return(double('get getter', :get=>'foobar'))
+    allow(mock_client).to receive(:[]).with("objects/#{pid}?format=xml").and_return(double('get getter', :get=>'foobar'))
   else
-    mock_client.stub(:[]).with("objects/#{pid}?format=xml").and_raise(RestClient::ResourceNotFound)
+    allow(mock_client).to receive(:[]).with("objects/#{pid}?format=xml").and_raise(RestClient::ResourceNotFound)
   end
-  mock_client.stub(:[]).with("objects/#{pid}/datastreams?format=xml").and_return(@getter)
+  allow(mock_client).to receive(:[]).with("objects/#{pid}/datastreams?format=xml").and_return(@getter)
   datastreams ||= ['someData', 'withText', 'withText2', 'RELS-EXT']
   datastreams.each do |dsid|
-    mock_client.stub(:[]).with("objects/#{pid}/datastreams/#{dsid}?format=xml").and_return(@getter)
+    allow(mock_client).to receive(:[]).with("objects/#{pid}/datastreams/#{dsid}?format=xml").and_return(@getter)
   end
 end
 
 def stub_ingest(pid=nil)
   n = pid ? pid.gsub(/:/, '%3A') : nil
-  mock_client.should_receive(:[]).with("objects/#{n || 'new'}").and_return(double("ingester", :post=>pid))
+  expect(mock_client).to receive(:[]).with("objects/#{n || 'new'}").and_return(double("ingester", :post=>pid))
 end
 
 def stub_add_ds(pid, dsids)
   pid.gsub!(/:/, '%3A')
   dsids.each do |dsid|
-    client = mock_client.stub(:[]).with do |params|
+    client = allow(mock_client).to receive(:[]).with do |params|
       /objects\/#{pid}\/datastreams\/#{dsid}/.match(params)
     end
     client.and_return(double("ds_adder", :post=>pid, :get=>''))
@@ -39,7 +39,7 @@ end
 def stub_get_content(pid, dsids)
   pid.gsub!(/:/, '%3A')
   dsids.each do |dsid|
-    mock_client.stub(:[]).with { |params| /objects\/#{pid}\/datastreams\/#{dsid}\/content/.match(params)}.and_return(double("content_accessor", :post=>pid, :get=>''))
+    allow(mock_client).to receive(:[]).with { |params| /objects\/#{pid}\/datastreams\/#{dsid}\/content/.match(params)}.and_return(double("content_accessor", :post=>pid, :get=>''))
   end
 end
 

--- a/spec/unit/active_fedora_spec.rb
+++ b/spec/unit/active_fedora_spec.rb
@@ -14,36 +14,36 @@ describe ActiveFedora do
   describe "initialization methods" do
     describe "environment" do
       it "should use config_options[:environment] if set" do
-        ActiveFedora.stub(:config_options => {:environment=>"ballyhoo"})
-        ActiveFedora.environment.should eql("ballyhoo")
+        allow(ActiveFedora).to receive_messages(:config_options => {:environment=>"ballyhoo"})
+        expect(ActiveFedora.environment).to eql("ballyhoo")
       end
 
       it "should use Rails.env if no config_options and Rails.env is set" do
         stub_rails(:env => "bedbugs")
-        ActiveFedora.stub(:config_options => {})
-        ActiveFedora.environment.should eql("bedbugs")
+        allow(ActiveFedora).to receive_messages(:config_options => {})
+        expect(ActiveFedora.environment).to eql("bedbugs")
         unstub_rails
       end
 
       it "should use ENV['environment'] if neither config_options nor Rails.env are set" do
         ENV['environment'] = "wichita"
-        ActiveFedora.stub(:config_options => {})
-        ActiveFedora.environment.should eql("wichita")
+        allow(ActiveFedora).to receive_messages(:config_options => {})
+        expect(ActiveFedora.environment).to eql("wichita")
         ENV['environment']='test'
       end
 
       it "should use ENV['RAILS_ENV'] and log a warning if none of the above are set" do
         ENV['environment']=nil
         ENV['RAILS_ENV'] = "rails_env"
-        lambda {ActiveFedora.environment}.should raise_error(RuntimeError, "You're depending on RAILS_ENV for setting your environment. Please use ENV['environment'] for non-rails environment setting: 'rake foo:bar environment=test'")
+        expect {ActiveFedora.environment}.to raise_error(RuntimeError, "You're depending on RAILS_ENV for setting your environment. Please use ENV['environment'] for non-rails environment setting: 'rake foo:bar environment=test'")
         ENV['environment']='test'
       end
 
       it "should be development if none of the above are present" do
         ENV['environment']=nil
         ENV['RAILS_ENV'] = nil
-        ActiveFedora.stub(:config_options => {})
-        ActiveFedora.environment.should == 'development'
+        allow(ActiveFedora).to receive_messages(:config_options => {})
+        expect(ActiveFedora.environment).to eq('development')
         ENV['environment']="test"
       end
     end
@@ -59,7 +59,7 @@ describe ActiveFedora do
     describe "outside of rails" do
        it "should load the passed config if explicit config passed in as a string" do
         ActiveFedora.init(:fedora_config_path=>'./spec/fixtures/rails_root/config/fedora.yml', :environment => 'test')
-        ActiveFedora.config.credentials.should == {:url=> "http://testhost.com:8983/fedora", :user=>'fedoraAdmin', :password=>'fedoraAdmin'}
+        expect(ActiveFedora.config.credentials).to eq({:url=> "http://testhost.com:8983/fedora", :user=>'fedoraAdmin', :password=>'fedoraAdmin'})
       end
     end
 
@@ -79,22 +79,22 @@ describe ActiveFedora do
             solr_config_path = File.expand_path(File.join(File.dirname(__FILE__),"../fixtures/rails_root/config/solr.yml"))
             pred_config_path = File.expand_path(File.join(File.dirname(__FILE__),"../fixtures/rails_root/config/predicate_mappings.yml"))
             
-            File.stub(:open).with(fedora_config_path).and_return(fedora_config)
-            File.stub(:open).with(solr_config_path).and_return(solr_config)
-            ActiveFedora::SolrService.stub(:load_mappings) #For the solrizer solr_mappings.yml
+            allow(File).to receive(:open).with(fedora_config_path).and_return(fedora_config)
+            allow(File).to receive(:open).with(solr_config_path).and_return(solr_config)
+            allow(ActiveFedora::SolrService).to receive(:load_mappings) #For the solrizer solr_mappings.yml
 
             ActiveFedora.init(:fedora_config_path=>fedora_config_path,:solr_config_path=>solr_config_path)
-            ActiveFedora.solr.class.should == ActiveFedora::SolrService
+            expect(ActiveFedora.solr.class).to eq(ActiveFedora::SolrService)
           end
         end
 
         describe "with no explicit config path" do
           it "should look for the file in the path defined at Rails.root" do
-            ActiveFedora::SolrService.stub(:load_mappings) #necessary or else it will load the solrizer config and it breaks other tests in the suite.
+            allow(ActiveFedora::SolrService).to receive(:load_mappings) #necessary or else it will load the solrizer config and it breaks other tests in the suite.
             
             stub_rails(:root=>File.join(File.dirname(__FILE__),"../fixtures/rails_root"))
             ActiveFedora.init()
-            ActiveFedora.config.credentials[:url].should == "http://testhost.com:8983/fedora"
+            expect(ActiveFedora.config.credentials[:url]).to eq("http://testhost.com:8983/fedora")
           end
         end
       end
@@ -111,13 +111,13 @@ describe ActiveFedora do
       end
     end
     it "should return class constants based on strings" do
-      ActiveFedora.class_from_string("Om").should == Om
-      ActiveFedora.class_from_string("ActiveFedora::RDF::Indexing").should == ActiveFedora::RDF::Indexing
-      ActiveFedora.class_from_string("Indexing", ActiveFedora::RDF).should == ActiveFedora::RDF::Indexing
+      expect(ActiveFedora.class_from_string("Om")).to eq(Om)
+      expect(ActiveFedora.class_from_string("ActiveFedora::RDF::Indexing")).to eq(ActiveFedora::RDF::Indexing)
+      expect(ActiveFedora.class_from_string("Indexing", ActiveFedora::RDF)).to eq(ActiveFedora::RDF::Indexing)
     end
 
     it "should find sibling classes" do
-      ActiveFedora.class_from_string("SiblingClass", ParentClass::OtherSiblingClass).should == ParentClass::SiblingClass
+      expect(ActiveFedora.class_from_string("SiblingClass", ParentClass::OtherSiblingClass)).to eq(ParentClass::SiblingClass)
     end
 
     it "should raise a NameError if the class isn't found" do

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -69,7 +69,7 @@ describe ActiveFedora::Base do
         expect(subject.inspect).to eq "#<BarHistory2 pid: nil, cow: \"\", fubar: [], pig: nil, horse: [], duck: [\"\"], animal_id: nil>"
       end
       describe "with a pid" do
-        before { subject.stub(pid: 'test:123') }
+        before { allow(subject).to receive_messages(pid: 'test:123') }
         it "should show a pid" do
           expect(subject.inspect).to eq "#<BarHistory2 pid: \"test:123\", cow: \"\", fubar: [], pig: nil, horse: [], duck: [\"\"], animal_id: nil>"
         end
@@ -108,58 +108,58 @@ describe ActiveFedora::Base do
     end
 
     it "should reveal the unique properties" do
-      BarHistory2.unique?(:horse).should be false
-      BarHistory2.unique?(:pig).should be true
-      BarHistory2.unique?(:cow).should be true
+      expect(BarHistory2.unique?(:horse)).to be false
+      expect(BarHistory2.unique?(:pig)).to be true
+      expect(BarHistory2.unique?(:cow)).to be true
     end
 
     it "should save a delegated property uniquely" do
       subject.fubar = ["Quack"]
-      subject.fubar.should == ["Quack"]
-      subject.withText.get_values(:fubar).first.should == 'Quack'
+      expect(subject.fubar).to eq(["Quack"])
+      expect(subject.withText.get_values(:fubar).first).to eq('Quack')
       subject.cow = "Low"
-      subject.cow.should == "Low"
-      subject.xmlish.term_values(:cow).first.should == 'Low'
+      expect(subject.cow).to eq("Low")
+      expect(subject.xmlish.term_values(:cow).first).to eq('Low')
 
       subject.pig = "Oink"
-      subject.pig.should == "Oink"
+      expect(subject.pig).to eq("Oink")
     end
 
     it "should allow passing parameters to the delegate accessor" do
       subject.fubar = ["one", "two"]
-      subject.fubar(1).should == ['two']
+      expect(subject.fubar(1)).to eq(['two'])
     end
 
     it "should return an array if marked as multiple" do
       subject.horse=["neigh", "whinny"]
-      subject.horse.should == ["neigh", "whinny"]
+      expect(subject.horse).to eq(["neigh", "whinny"])
     end
 
     it "should be able to delegate deeply into the terminology" do
       subject.duck = ["Quack", "Peep"]
-      subject.duck.should == ["Quack", "Peep"]
+      expect(subject.duck).to eq(["Quack", "Peep"])
     end
 
     it "should be able to track change status" do
-      subject.fubar_changed?.should be false
+      expect(subject.fubar_changed?).to be false
       subject.fubar = ["Meow"]
-      subject.fubar_changed?.should be true
+      expect(subject.fubar_changed?).to be true
     end
 
     describe "array getters and setters" do
       it "should accept symbol keys" do
         subject[:duck] = ["Cluck", "Gobble"]
-        subject[:duck].should == ["Cluck", "Gobble"]
+        expect(subject[:duck]).to eq(["Cluck", "Gobble"])
       end
 
       it "should accept string keys" do
         subject['duck'] = ["Cluck", "Gobble"]
-        subject['duck'].should == ["Cluck", "Gobble"]
+        expect(subject['duck']).to eq(["Cluck", "Gobble"])
       end
 
       it "should accept field names with _id that are not associations" do
         subject['animal_id'] = "lemur"
-        subject['animal_id'].should == "lemur"
+        expect(subject['animal_id']).to eq("lemur")
       end
 
       it "should raise an error on the reader when the field isn't delegated" do
@@ -206,13 +206,13 @@ describe ActiveFedora::Base do
 
     it "should be able to delegate deeply into the terminology" do
       subject.donkey = ["Bray", "Hee-haw"]
-      subject.donkey.should == ["Bray", "Hee-haw"]
+      expect(subject.donkey).to eq(["Bray", "Hee-haw"])
     end
 
     it "should be able to track change status" do
-      subject.cow_changed?.should be false
+      expect(subject.cow_changed?).to be false
       subject.cow = ["Moo"]
-      subject.cow_changed?.should be true
+      expect(subject.cow_changed?).to be true
     end 
   end
 
@@ -247,9 +247,9 @@ describe ActiveFedora::Base do
 
     describe "with a multivalued field" do
       it "should be able to track change status" do
-        subject.title_changed?.should be false
+        expect(subject.title_changed?).to be false
         subject.title = ["Title1", "Title2"]
-        subject.title_changed?.should be true
+        expect(subject.title_changed?).to be true
       end
       it "should not accept a single literal value" do
         expect { subject.title = "Title1" }.to raise_error
@@ -261,9 +261,9 @@ describe ActiveFedora::Base do
     end
     describe "with a single-valued field" do
       it "should be able to track change status" do
-        subject.description_changed?.should be false
+        expect(subject.description_changed?).to be false
         subject.description = "A brief description"
-        subject.description_changed?.should be true
+        expect(subject.description_changed?).to be true
       end
       it "should not accept an array of literal values" do
         expect { subject.description = ["A brief description", "A longer description"] }.to raise_error

--- a/spec/unit/base_active_model_spec.rb
+++ b/spec/unit/base_active_model_spec.rb
@@ -37,18 +37,18 @@ describe ActiveFedora::Base do
     describe "attributes=" do
       it "should set attributes" do
         @n.attributes = {:fubar=>"baz", :duck=>"Quack"}
-        @n.fubar.should == "baz"
-        @n.withText.get_values(:fubar).first.should == 'baz'
-        @n.duck.should == "Quack"
-        @n.xmlish.term_values(:duck).first.should == 'Quack'
+        expect(@n.fubar).to eq("baz")
+        expect(@n.withText.get_values(:fubar).first).to eq('baz')
+        expect(@n.duck).to eq("Quack")
+        expect(@n.xmlish.term_values(:duck).first).to eq('Quack')
       end
     end
     describe "update_attributes" do
       it "should set attributes and save " do
         @n.update_attributes(:fubar=>"baz", :duck=>"Quack")
         @q = BarHistory.find(@n.pid)
-        @q.fubar.should == "baz"
-        @q.duck.should == "Quack"
+        expect(@q.fubar).to eq("baz")
+        expect(@q.duck).to eq("Quack")
       end
       after do
         @n.delete

--- a/spec/unit/base_cma_spec.rb
+++ b/spec/unit/base_cma_spec.rb
@@ -9,8 +9,8 @@ describe ActiveFedora::Base do
   describe '.save' do
 
     it "should add hasModel relationship that points to the CModel if @new_object" do
-      @test_object.stub(:update_index)
-      @test_object.should_receive(:refresh)
+      allow(@test_object).to receive(:update_index)
+      expect(@test_object).to receive(:refresh)
       @test_object.save
     end
   end

--- a/spec/unit/base_datastream_management_spec.rb
+++ b/spec/unit/base_datastream_management_spec.rb
@@ -9,25 +9,25 @@ describe ActiveFedora::Base do
   describe '.add_datastream' do
     it "should not call Datastream.save" do
       ds = ActiveFedora::Datastream.new(@test_object.inner_object, 'ds_to_add')
-      ds.should_receive(:save).never
+      expect(ds).to receive(:save).never
       @test_object.add_datastream(ds)
     end
     it "should add the datastream to the datastreams_in_memory array" do
       ds = ActiveFedora::Datastream.new(@test_object.inner_object, 'ds_to_add')
-      @test_object.datastreams.should_not have_key(ds.dsid)
+      expect(@test_object.datastreams).not_to have_key(ds.dsid)
       @test_object.add_datastream(ds)
-      @test_object.datastreams.should have_key(ds.dsid)
+      expect(@test_object.datastreams).to have_key(ds.dsid)
     end
     it "should auto-assign dsids using auto-incremented integers if dsid is nil or an empty string" do 
       ds = ActiveFedora::Datastream.new(@test_object.inner_object, nil)
-      ds.dsid.should == 'DS1'
-      @test_object.add_datastream(ds).should == 'DS1'
+      expect(ds.dsid).to eq('DS1')
+      expect(@test_object.add_datastream(ds)).to eq('DS1')
       ds_emptystringid = ActiveFedora::Datastream.new(@test_object.inner_object, '')
-      @test_object.add_datastream(ds_emptystringid).should == 'DS2'
+      expect(@test_object.add_datastream(ds_emptystringid)).to eq('DS2')
     end
     it "should accept a prefix option and apply it to automatically assigned dsids" do
       ds = ActiveFedora::Datastream.new(@test_object.inner_object, nil, :prefix=> "FOO")
-      ds.dsid.should == 'FOO1'
+      expect(ds.dsid).to eq('FOO1')
     end
   end
 end

--- a/spec/unit/base_extra_spec.rb
+++ b/spec/unit/base_extra_spec.rb
@@ -9,12 +9,12 @@ describe ActiveFedora::Base do
   describe ".update_index" do
     before do
       mock_conn = double("SolrConnection")
-      mock_conn.should_receive(:add) do |_, opts|
-        opts.should == {:params=>{:softCommit=>true}}
+      expect(mock_conn).to receive(:add) do |_, opts|
+        expect(opts).to eq({:params=>{:softCommit=>true}})
       end
       mock_ss = double("SolrService")
-      mock_ss.stub(:conn).and_return(mock_conn)
-      ActiveFedora::SolrService.stub(:instance).and_return(mock_ss)
+      allow(mock_ss).to receive(:conn).and_return(mock_conn)
+      allow(ActiveFedora::SolrService).to receive(:instance).and_return(mock_ss)
     end
     
     it "should call .to_solr on all SimpleDatastreams AND RelsExtDatastreams and pass the resulting document to solr" do
@@ -24,11 +24,11 @@ describe ActiveFedora::Base do
       mock3 = double("RELS-EXT", :to_solr => {})
       
       mock_datastreams = {:ds1 => mock1, :ds2 => mock2, :rels_ext => mock3}
-      mock1.should_receive(:solrize_profile).and_return({})
-      mock2.should_receive(:solrize_profile).and_return({})
-      mock3.should_receive(:solrize_profile).and_return({})
-      @test_object.should_receive(:datastreams).twice.and_return(mock_datastreams)
-      @test_object.should_receive(:solrize_relationships)
+      expect(mock1).to receive(:solrize_profile).and_return({})
+      expect(mock2).to receive(:solrize_profile).and_return({})
+      expect(mock3).to receive(:solrize_profile).and_return({})
+      expect(@test_object).to receive(:datastreams).twice.and_return(mock_datastreams)
+      expect(@test_object).to receive(:solrize_relationships)
       @test_object.update_index
     end
 
@@ -39,11 +39,11 @@ describe ActiveFedora::Base do
       mock3 = double("RELS-EXT", :to_solr => {})
       
       mock_datastreams = {:ds1 => mock1, :ds2 => mock2, :rels_ext => mock3}
-      mock1.should_receive(:solrize_profile).and_return({})
-      mock2.should_receive(:solrize_profile).and_return({})
-      mock3.should_receive(:solrize_profile).and_return({})
-      @test_object.should_receive(:datastreams).twice.and_return(mock_datastreams)
-      @test_object.should_receive(:solrize_relationships)
+      expect(mock1).to receive(:solrize_profile).and_return({})
+      expect(mock2).to receive(:solrize_profile).and_return({})
+      expect(mock3).to receive(:solrize_profile).and_return({})
+      expect(@test_object).to receive(:datastreams).twice.and_return(mock_datastreams)
+      expect(@test_object).to receive(:solrize_relationships)
       @test_object.update_index
     end
 
@@ -59,12 +59,12 @@ describe ActiveFedora::Base do
     end
     
     it "should delete object from repository and index" do
-      @test_object.inner_object.stub(:delete)
+      allow(@test_object.inner_object).to receive(:delete)
       mock_conn = double("SolrConnection")
-      mock_conn.should_receive(:delete_by_id).with(nil, {:params=>{"softCommit"=>true}}) 
+      expect(mock_conn).to receive(:delete_by_id).with(nil, {:params=>{"softCommit"=>true}}) 
       mock_ss = double("SolrService")
-      mock_ss.stub(:conn).and_return(mock_conn)
-      ActiveFedora::SolrService.stub(:instance).and_return(mock_ss)
+      allow(mock_ss).to receive(:conn).and_return(mock_conn)
+      allow(ActiveFedora::SolrService).to receive(:instance).and_return(mock_ss)
       @test_object.delete
     end
 
@@ -87,13 +87,13 @@ describe ActiveFedora::Base do
   
     context "with the namespace declared in the model" do
       before do
-        subject.stub(:pid_namespace).and_return("test-cModel")
+        allow(subject).to receive(:pid_namespace).and_return("test-cModel")
       end
       its(:to_class_uri) {should == 'info:fedora/test-cModel:SpecModel_CamelCased' }
     end
     context "with the suffix declared in the model" do
       before do
-        subject.stub(:pid_suffix).and_return("-TEST-SUFFIX")
+        allow(subject).to receive(:pid_suffix).and_return("-TEST-SUFFIX")
       end
       its(:to_class_uri) {should == 'info:fedora/afmodel:SpecModel_CamelCased-TEST-SUFFIX' }
     end

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -6,80 +6,80 @@ describe ActiveFedora::Base do
 
   describe 'descendants' do
     it "should record the decendants" do
-      ActiveFedora::Base.descendants.should include(ModsArticle, SpecialThing)
+      expect(ActiveFedora::Base.descendants).to include(ModsArticle, SpecialThing)
     end
   end
 
   describe "sharding" do
     it "should have a shard_index" do
-      ActiveFedora::Base.shard_index(@this_pid).should == 0
+      expect(ActiveFedora::Base.shard_index(@this_pid)).to eq(0)
     end
 
     context "When the repository is NOT sharded" do
       subject {ActiveFedora::Base.connection_for_pid('test:bar')}
       before(:each) do
-        ActiveFedora.config.stub(:sharded?).and_return(false)
+        allow(ActiveFedora.config).to receive(:sharded?).and_return(false)
         ActiveFedora::Base.fedora_connection = {}
-        ActiveFedora.config.stub(:credentials).and_return(:url=>'myfedora')
-        Rubydora::Fc3Service.any_instance.stub(:repository_profile)
+        allow(ActiveFedora.config).to receive(:credentials).and_return(:url=>'myfedora')
+        allow_any_instance_of(Rubydora::Fc3Service).to receive(:repository_profile)
       end
-      it { should be_kind_of Rubydora::Repository}
+      it { is_expected.to be_kind_of Rubydora::Repository}
       it "should be the standard connection" do
-        subject.client.url.should == 'myfedora'
+        expect(subject.client.url).to eq('myfedora')
       end
       describe "assign_pid" do
         it "should use fedora to generate pids" do
           # TODO: This juggling of Fedora credentials & establishing connections should be handled by an establish_fedora_connection method,
           # possibly wrap it all into a fedora_connection method - MZ 06-05-2012
           stubfedora = double("Fedora")
-          stubfedora.should_receive(:connection).and_return(double("Connection", :mint =>"sample:newpid"))
+          expect(stubfedora).to receive(:connection).and_return(double("Connection", :mint =>"sample:newpid"))
           # Should use ActiveFedora.config.credentials as a single hash rather than an array of shards
-          ActiveFedora::RubydoraConnection.should_receive(:new).with(ActiveFedora.config.credentials).and_return(stubfedora)
+          expect(ActiveFedora::RubydoraConnection).to receive(:new).with(ActiveFedora.config.credentials).and_return(stubfedora)
           ActiveFedora::Base.assign_pid(ActiveFedora::Base.new.inner_object)
         end
       end
       describe "shard_index" do
         it "should always return zero (the first and only connection)" do
-          ActiveFedora::Base.shard_index('test:bar').should == 0
+          expect(ActiveFedora::Base.shard_index('test:bar')).to eq(0)
         end
       end
     end
     context "When the repository is sharded" do
       before :each do
-        ActiveFedora.config.stub(:sharded?).and_return(true)
+        allow(ActiveFedora.config).to receive(:sharded?).and_return(true)
         ActiveFedora::Base.fedora_connection = {}
-        ActiveFedora.config.stub(:credentials).and_return([{:url=>'shard1'}, {:url=>'shard2'} ])
+        allow(ActiveFedora.config).to receive(:credentials).and_return([{:url=>'shard1'}, {:url=>'shard2'} ])
       end
       describe "assign_pid" do
         it "should always use the first shard to generate pids" do
           stubhard1 = double("Shard")
           stubhard2 = double("Shard")
-          stubhard1.should_receive(:connection).and_return(double("Connection", :mint =>"sample:newpid"))
-          stubhard2.should_receive(:connection).never
+          expect(stubhard1).to receive(:connection).and_return(double("Connection", :mint =>"sample:newpid"))
+          expect(stubhard2).to receive(:connection).never
           ActiveFedora::Base.fedora_connection = {0 => stubhard1, 1 => stubhard2}
           ActiveFedora::Base.assign_pid(ActiveFedora::Base.new.inner_object)
         end
       end
       describe "shard_index" do
         it "should use modulo of md5 of the pid to distribute objects across shards" do
-          ActiveFedora::Base.shard_index('test:bar').should == 0
-          ActiveFedora::Base.shard_index('test:nanana').should == 1
+          expect(ActiveFedora::Base.shard_index('test:bar')).to eq(0)
+          expect(ActiveFedora::Base.shard_index('test:nanana')).to eq(1)
         end
       end
       describe "the repository" do
         before do
-          Rubydora::Fc3Service.any_instance.stub(:repository_profile)
+          allow_any_instance_of(Rubydora::Fc3Service).to receive(:repository_profile)
         end
         describe "for test:bar" do
           subject {ActiveFedora::Base.connection_for_pid('test:bar')}
           it "should be shard1" do
-            subject.client.url.should == 'shard1'
+            expect(subject.client.url).to eq('shard1')
           end
         end
         describe "for test:baz" do
           subject {ActiveFedora::Base.connection_for_pid('test:nanana')}
           it "should be shard1" do
-            subject.client.url.should == 'shard2'
+            expect(subject.client.url).to eq('shard2')
           end
         end
       end
@@ -89,29 +89,29 @@ describe ActiveFedora::Base do
 
   describe "reindex_everything" do
     it "should call update_index on every object except for the fedora-system objects" do
-       Rubydora::Repository.any_instance.should_receive(:search).
+       expect_any_instance_of(Rubydora::Repository).to receive(:search).
             and_yield(double(pid:'XXX')).and_yield(double(pid:'YYY')).and_yield(double(pid:'ZZZ')).
             and_yield(double(pid:'fedora-system:ServiceDeployment-3.0')).
             and_yield(double(pid:'fedora-system:ServiceDefinition-3.0')).
             and_yield(double(pid:'fedora-system:FedoraObject-3.0'))
 
        mock_update = double(:mock_obj)
-       mock_update.should_receive(:update_index).exactly(3).times
-       ActiveFedora::Base.should_receive(:find).with('XXX').and_return(mock_update)
-       ActiveFedora::Base.should_receive(:find).with('YYY').and_return(mock_update)
-       ActiveFedora::Base.should_receive(:find).with('ZZZ').and_return(mock_update)
+       expect(mock_update).to receive(:update_index).exactly(3).times
+       expect(ActiveFedora::Base).to receive(:find).with('XXX').and_return(mock_update)
+       expect(ActiveFedora::Base).to receive(:find).with('YYY').and_return(mock_update)
+       expect(ActiveFedora::Base).to receive(:find).with('ZZZ').and_return(mock_update)
        ActiveFedora::Base.reindex_everything
     end
 
     it "should accept a query param for the search" do
        query_string = "pid~*"
-       Rubydora::Repository.any_instance.should_receive(:search).with(query_string).
+       expect_any_instance_of(Rubydora::Repository).to receive(:search).with(query_string).
             and_yield(double(pid:'XXX')).and_yield(double(pid:'YYY')).and_yield(double(pid:'ZZZ'))
        mock_update = double(:mock_obj)
-       mock_update.should_receive(:update_index).exactly(3).times
-       ActiveFedora::Base.should_receive(:find).with('XXX').and_return(mock_update)
-       ActiveFedora::Base.should_receive(:find).with('YYY').and_return(mock_update)
-       ActiveFedora::Base.should_receive(:find).with('ZZZ').and_return(mock_update)
+       expect(mock_update).to receive(:update_index).exactly(3).times
+       expect(ActiveFedora::Base).to receive(:find).with('XXX').and_return(mock_update)
+       expect(ActiveFedora::Base).to receive(:find).with('YYY').and_return(mock_update)
+       expect(ActiveFedora::Base).to receive(:find).with('ZZZ').and_return(mock_update)
        ActiveFedora::Base.reindex_everything(query_string)
     end
   end
@@ -154,15 +154,15 @@ describe ActiveFedora::Base do
     before(:each) do
       @this_pid = increment_pid.to_s
       stub_get(@this_pid)
-      Rubydora::Repository.any_instance.stub(:client).and_return(@mock_client)
-      ActiveFedora::Base.stub(:assign_pid).and_return(@this_pid)
+      allow_any_instance_of(Rubydora::Repository).to receive(:client).and_return(@mock_client)
+      allow(ActiveFedora::Base).to receive(:assign_pid).and_return(@this_pid)
 
       @test_object = ActiveFedora::Base.new
     end
 
     after(:each) do
       begin
-      ActiveFedora::SolrService.stub(:instance)
+      allow(ActiveFedora::SolrService).to receive(:instance)
       #@test_object.delete
       rescue
       end
@@ -172,60 +172,60 @@ describe ActiveFedora::Base do
     describe '#new' do
       it "should create an inner object" do
         # for doing AFObject.new(params[:foo]) when nothing is in params[:foo]
-        Rubydora::DigitalObject.any_instance.should_receive(:save).never
+        expect_any_instance_of(Rubydora::DigitalObject).to receive(:save).never
         result = ActiveFedora::Base.new(nil)
-        result.inner_object.should be_kind_of(ActiveFedora::UnsavedDigitalObject)
+        expect(result.inner_object).to be_kind_of(ActiveFedora::UnsavedDigitalObject)
       end
 
       it "should not save or get an pid on init" do
-        Rubydora::DigitalObject.any_instance.should_receive(:save).never
-        ActiveFedora::Base.should_receive(:assign_pid).never
+        expect_any_instance_of(Rubydora::DigitalObject).to receive(:save).never
+        expect(ActiveFedora::Base).to receive(:assign_pid).never
         f = FooHistory.new
       end
 
       it "should be able to create with a custom pid" do
         f = FooHistory.new(:pid=>'numbnuts:1')
-        f.pid.should == 'numbnuts:1'
+        expect(f.pid).to eq('numbnuts:1')
       end
     end
 
     describe ".datastream_class_for_name" do
       it "should return the specifed class" do
-        FooAdaptation.datastream_class_for_name('someData').should == ActiveFedora::OmDatastream
+        expect(FooAdaptation.datastream_class_for_name('someData')).to eq(ActiveFedora::OmDatastream)
       end
       it "should return the specifed class" do
-        FooAdaptation.datastream_class_for_name('content').should == ActiveFedora::Datastream
+        expect(FooAdaptation.datastream_class_for_name('content')).to eq(ActiveFedora::Datastream)
       end
     end
 
     describe ".internal_uri" do
       it "should return pid as fedors uri" do
-        @test_object.internal_uri.should eql("info:fedora/#{@test_object.pid}")
+        expect(@test_object.internal_uri).to eql("info:fedora/#{@test_object.pid}")
       end
     end
 
     ### Methods for ActiveModel::Conversions
     it "should have to_param once it's saved" do
-      @test_object.to_param.should be_nil
-      @test_object.inner_object.stub(new_record?: false, pid: 'foo:123')
-      @test_object.to_param.should == 'foo:123'
+      expect(@test_object.to_param).to be_nil
+      allow(@test_object.inner_object).to receive_messages(new_record?: false, pid: 'foo:123')
+      expect(@test_object.to_param).to eq('foo:123')
     end
 
     it "should have to_key once it's saved" do
-      @test_object.to_key.should be_nil
-      @test_object.inner_object.stub(new_record?: false, pid: 'foo:123')
-      @test_object.to_key.should == ['foo:123']
+      expect(@test_object.to_key).to be_nil
+      allow(@test_object.inner_object).to receive_messages(new_record?: false, pid: 'foo:123')
+      expect(@test_object.to_key).to eq(['foo:123'])
     end
 
     it "should have to_model when it's saved" do
-      @test_object.to_model.should be @test_object
+      expect(@test_object.to_model).to be @test_object
     end
     ### end ActiveModel::Conversions
 
     ### Methods for ActiveModel::Naming
     it "Should know the model_name" do
-      FooHistory.model_name.should == 'FooHistory'
-      FooHistory.model_name.human.should == 'Foo history'
+      expect(FooHistory.model_name).to eq('FooHistory')
+      expect(FooHistory.model_name.human).to eq('Foo history')
     end
     ### End ActiveModel::Naming
 
@@ -233,7 +233,7 @@ describe ActiveFedora::Base do
     describe ".datastreams" do
       let(:test_history) { FooHistory.new }
       it "should create accessors for datastreams declared with has_metadata" do
-        test_history.withText.should == test_history.datastreams['withText']
+        expect(test_history.withText).to eq(test_history.datastreams['withText'])
       end
       describe "dynamic accessors" do
         before do
@@ -243,56 +243,56 @@ describe ActiveFedora::Base do
         describe "when the datastream is named with dash" do
           let(:ds) {double('datastream', :dsid=>'eac-cpf')}
           it "should convert dashes to underscores" do
-            test_history.eac_cpf.should == ds
+            expect(test_history.eac_cpf).to eq(ds)
           end
         end
         describe "when the datastream is named with underscore" do
           let (:ds) { double('datastream', :dsid=>'foo_bar') }
           it "should preserve the underscore" do
-            test_history.foo_bar.should == ds
+            expect(test_history.foo_bar).to eq(ds)
           end
         end
       end
     end
 
     it 'should provide #find' do
-      ActiveFedora::Base.should respond_to(:find)
+      expect(ActiveFedora::Base).to respond_to(:find)
     end
 
     it "should provide .create_date" do
-      @test_object.should respond_to(:create_date)
+      expect(@test_object).to respond_to(:create_date)
     end
 
     it "should provide .modified_date" do
-      @test_object.should respond_to(:modified_date)
+      expect(@test_object).to respond_to(:modified_date)
     end
 
     it 'should respond to .rels_ext' do
-      @test_object.should respond_to(:rels_ext)
+      expect(@test_object).to respond_to(:rels_ext)
     end
 
     describe '.rels_ext' do
 
       it 'should return the RelsExtDatastream object from the datastreams array' do
-        @test_object.stub(:datastreams => {"RELS-EXT" => "foo"})
-        @test_object.rels_ext.should == "foo"
+        allow(@test_object).to receive_messages(:datastreams => {"RELS-EXT" => "foo"})
+        expect(@test_object.rels_ext).to eq("foo")
       end
     end
 
     it 'should provide #add_relationship' do
-      @test_object.should respond_to(:add_relationship)
+      expect(@test_object).to respond_to(:add_relationship)
     end
 
     describe '#add_relationship' do
       it 'should call #add_relationship on the rels_ext datastream' do
         @test_object.add_relationship("predicate", "info:fedora/object")
         pred = ActiveFedora::Predicates.vocabularies["info:fedora/fedora-system:def/relations-external#"]["predicate"]
-        @test_object.relationships.should have_statement(RDF::Statement.new(RDF::URI.new(@test_object.internal_uri), pred, RDF::URI.new("info:fedora/object")))
+        expect(@test_object.relationships).to have_statement(RDF::Statement.new(RDF::URI.new(@test_object.internal_uri), pred, RDF::URI.new("info:fedora/object")))
       end
 
       it "should update the RELS-EXT datastream and set the datastream as dirty when relationships are added" do
         mock_ds = double("Rels-Ext")
-        mock_ds.stub(:content_will_change!)
+        allow(mock_ds).to receive(:content_will_change!)
         @test_object.datastreams["RELS-EXT"] = mock_ds
         @test_object.add_relationship(:is_member_of, "info:fedora/demo:5")
         @test_object.add_relationship(:is_member_of, "info:fedora/demo:10")
@@ -300,54 +300,54 @@ describe ActiveFedora::Base do
 
       it 'should add a relationship to an object only if it does not exist already' do
         next_pid = increment_pid.to_s
-        ActiveFedora::Base.stub(:assign_pid).and_return(next_pid)
+        allow(ActiveFedora::Base).to receive(:assign_pid).and_return(next_pid)
         stub_get(next_pid)
 
         @test_object3 = ActiveFedora::Base.new
         @test_object.add_relationship(:has_part,@test_object3)
-        @test_object.ids_for_outbound(:has_part).should == [@test_object3.pid]
+        expect(@test_object.ids_for_outbound(:has_part)).to eq([@test_object3.pid])
         #try adding again and make sure not there twice
         @test_object.add_relationship(:has_part,@test_object3)
-        @test_object.ids_for_outbound(:has_part).should == [@test_object3.pid]
+        expect(@test_object.ids_for_outbound(:has_part)).to eq([@test_object3.pid])
       end
 
       it 'should add literal relationships if requested' do
         @test_object.add_relationship(:conforms_to,"AnInterface",true)
-        @test_object.ids_for_outbound(:conforms_to).should == ["AnInterface"]
+        expect(@test_object.ids_for_outbound(:conforms_to)).to eq(["AnInterface"])
       end
     end
 
     it 'should provide #remove_relationship' do
-      @test_object.should respond_to(:remove_relationship)
+      expect(@test_object).to respond_to(:remove_relationship)
     end
 
     describe '#remove_relationship' do
       it 'should remove a relationship from the relationships hash' do
         @test_object3 = ActiveFedora::Base.new()
-        @test_object3.stub(:pid=>'7')
+        allow(@test_object3).to receive_messages(:pid=>'7')
         @test_object4 = ActiveFedora::Base.new()
-        @test_object4.stub(:pid=>'8')
+        allow(@test_object4).to receive_messages(:pid=>'8')
         @test_object.add_relationship(:has_part,@test_object3)
         @test_object.add_relationship(:has_part,@test_object4)
         #check both are there
-        @test_object.ids_for_outbound(:has_part).should == [@test_object3.pid,@test_object4.pid]
+        expect(@test_object.ids_for_outbound(:has_part)).to eq([@test_object3.pid,@test_object4.pid])
         @test_object.remove_relationship(:has_part,@test_object3)
         #check only one item removed
-        @test_object.ids_for_outbound(:has_part).should == [@test_object4.pid]
+        expect(@test_object.ids_for_outbound(:has_part)).to eq([@test_object4.pid])
         @test_object.remove_relationship(:has_part,@test_object4)
         #check last item removed and predicate removed since now emtpy
-        @test_object.relationships.size.should == 0
+        expect(@test_object.relationships.size).to eq(0)
       end
     end
 
     it 'should provide #relationships' do
-      @test_object.should respond_to(:relationships)
+      expect(@test_object).to respond_to(:relationships)
     end
 
     describe '#relationships' do
       it 'should return a graph' do
-        @test_object.relationships.kind_of?(RDF::Graph).should be_true
-        @test_object.relationships.size.should == 0
+        expect(@test_object.relationships.kind_of?(RDF::Graph)).to be_truthy
+        expect(@test_object.relationships.size).to eq(0)
       end
     end
 
@@ -356,26 +356,26 @@ describe ActiveFedora::Base do
         stub_get(@this_pid)
         stub_add_ds(@this_pid, ['RELS-EXT'])
         @test_object.assert_content_model
-        @test_object.relationships(:has_model).should == ["info:fedora/afmodel:ActiveFedora_Base"]
+        expect(@test_object.relationships(:has_model)).to eq(["info:fedora/afmodel:ActiveFedora_Base"])
 
       end
     end
 
     describe '.save' do
       it "should create a new record" do
-        @test_object.stub(:new_record? => true)
-        @test_object.should_receive(:assign_pid)
-        @test_object.should_receive(:serialize_datastreams)
-        @test_object.inner_object.should_receive(:save)
-        @test_object.should_receive(:update_index)
+        allow(@test_object).to receive_messages(:new_record? => true)
+        expect(@test_object).to receive(:assign_pid)
+        expect(@test_object).to receive(:serialize_datastreams)
+        expect(@test_object.inner_object).to receive(:save)
+        expect(@test_object).to receive(:update_index)
         @test_object.save
       end
 
       it "should update an existing record" do
-        @test_object.stub(:new_record? => false)
-        @test_object.should_receive(:serialize_datastreams)
-        @test_object.inner_object.should_receive(:save)
-        @test_object.should_receive(:update_index)
+        allow(@test_object).to receive_messages(:new_record? => false)
+        expect(@test_object).to receive(:serialize_datastreams)
+        expect(@test_object.inner_object).to receive(:save)
+        expect(@test_object).to receive(:update_index)
         @test_object.save
       end
     end
@@ -383,8 +383,8 @@ describe ActiveFedora::Base do
     describe "#create" do
       it "should build a new record and save it" do
         obj = double()
-        obj.should_receive(:save)
-        FooHistory.should_receive(:new).and_return(obj)
+        expect(obj).to receive(:save)
+        expect(FooHistory).to receive(:new).and_return(obj)
         @hist = FooHistory.create(:fubar=>'ta', :swank=>'da')
       end
 
@@ -393,7 +393,7 @@ describe ActiveFedora::Base do
     describe ".adapt_to" do
       it "should return an adapted object of the requested type" do
         @test_object = FooHistory.new()
-        @test_object.adapt_to(FooAdaptation).class.should == FooAdaptation
+        expect(@test_object.adapt_to(FooAdaptation).class).to eq(FooAdaptation)
       end
       it "should not make an additional call to fedora to create the adapted object" do
         @test_object = FooHistory.new()
@@ -403,25 +403,25 @@ describe ActiveFedora::Base do
         @test_object = FooHistory.new()
         @test_object.add_file_datastream("XXX", :dsid=>'MY_DSID')
         adapted = @test_object.adapt_to(FooAdaptation)
-        adapted.datastreams.keys.should include 'MY_DSID'
-        adapted.datastreams['MY_DSID'].content.should == "XXX"
-        adapted.datastreams['MY_DSID'].changed?.should be_true
+        expect(adapted.datastreams.keys).to include 'MY_DSID'
+        expect(adapted.datastreams['MY_DSID'].content).to eq("XXX")
+        expect(adapted.datastreams['MY_DSID'].changed?).to be_truthy
       end
       it "should propagate modified datastreams to the adapted object" do
         @test_object = FooHistory.new()
         orig_ds = @test_object.datastreams['someData']
         orig_ds.content="<YYY/>"
         adapted = @test_object.adapt_to(FooAdaptation)
-        adapted.datastreams.keys.should include 'someData'
-        adapted.datastreams['someData'].should == orig_ds
-        adapted.datastreams['someData'].content.strip.should == "<YYY/>"
-        adapted.datastreams['someData'].changed?.should be_true
+        expect(adapted.datastreams.keys).to include 'someData'
+        expect(adapted.datastreams['someData']).to eq(orig_ds)
+        expect(adapted.datastreams['someData'].content.strip).to eq("<YYY/>")
+        expect(adapted.datastreams['someData'].changed?).to be_truthy
       end
       it "should use the datastream definitions from the adapted object" do
         @test_object = FooHistory.new()
         adapted = @test_object.adapt_to(FooAdaptation)
-        adapted.datastreams.keys.should include 'someData'
-        adapted.datastreams['someData'].class.should == ActiveFedora::OmDatastream
+        expect(adapted.datastreams.keys).to include 'someData'
+        expect(adapted.datastreams['someData'].class).to eq(ActiveFedora::OmDatastream)
       end
     end
 
@@ -429,16 +429,16 @@ describe ActiveFedora::Base do
       subject { FooHistory.new }
 
       it "should raise an exception if the object class is not equal to or a subclass of any known model" do
-        ActiveFedora::ContentModel.should_receive(:known_models_for).with(subject).and_return([FooAdaptation])
+        expect(ActiveFedora::ContentModel).to receive(:known_models_for).with(subject).and_return([FooAdaptation])
         expect { subject.adapt_to_cmodel }.to raise_error(ActiveFedora::ModelNotAsserted)
       end
       it "should cast to an inherited model over a random one" do
-        ActiveFedora::ContentModel.should_receive(:known_models_for).with(subject).and_return([FooAdaptation, FooInherited])
-        subject.adapt_to_cmodel.should be_kind_of FooInherited
+        expect(ActiveFedora::ContentModel).to receive(:known_models_for).with(subject).and_return([FooAdaptation, FooInherited])
+        expect(subject.adapt_to_cmodel).to be_kind_of FooInherited
       end
       it "should not cast when a cmodel is same as the class" do
-        ActiveFedora::ContentModel.should_receive(:known_models_for).with(subject).and_return([FooHistory])
-        subject.adapt_to_cmodel.should === subject
+        expect(ActiveFedora::ContentModel).to receive(:known_models_for).with(subject).and_return([FooHistory])
+        expect(subject.adapt_to_cmodel).to be === subject
       end
     end
 
@@ -446,36 +446,36 @@ describe ActiveFedora::Base do
       subject { ActiveFedora::Base.new }
 
       it "should cast to the first cmodel if ActiveFedora::Base (or no specified cmodel)" do
-        ActiveFedora::ContentModel.should_receive(:known_models_for).with(subject).and_return([FooAdaptation, FooHistory])
-        subject.adapt_to_cmodel.should be_kind_of FooAdaptation
+        expect(ActiveFedora::ContentModel).to receive(:known_models_for).with(subject).and_return([FooAdaptation, FooHistory])
+        expect(subject.adapt_to_cmodel).to be_kind_of FooAdaptation
       end
     end
 
 
     describe ".to_solr" do
       it "should provide .to_solr" do
-        @test_object.should respond_to(:to_solr)
+        expect(@test_object).to respond_to(:to_solr)
       end
 
       it "should add pid, system_create_date, system_modified_date and object_state from object attributes" do
-        @test_object.should_receive(:create_date).and_return("2012-03-04T03:12:02Z")
-        @test_object.should_receive(:modified_date).and_return("2012-03-07T03:12:02Z")
-        @test_object.stub(pid: 'changeme:123')
+        expect(@test_object).to receive(:create_date).and_return("2012-03-04T03:12:02Z")
+        expect(@test_object).to receive(:modified_date).and_return("2012-03-07T03:12:02Z")
+        allow(@test_object).to receive_messages(pid: 'changeme:123')
         @test_object.state = "D"
         solr_doc = @test_object.to_solr
-        solr_doc[ActiveFedora::SolrService.solr_name("system_create", :stored_sortable, type: :date)].should eql("2012-03-04T03:12:02Z")
-        solr_doc[ActiveFedora::SolrService.solr_name("system_modified", :stored_sortable, type: :date)].should eql("2012-03-07T03:12:02Z")
-        solr_doc[ActiveFedora::SolrService.solr_name("object_state", :stored_sortable)].should eql("D")
-        solr_doc[:id].should eql("changeme:123")
+        expect(solr_doc[ActiveFedora::SolrService.solr_name("system_create", :stored_sortable, type: :date)]).to eql("2012-03-04T03:12:02Z")
+        expect(solr_doc[ActiveFedora::SolrService.solr_name("system_modified", :stored_sortable, type: :date)]).to eql("2012-03-07T03:12:02Z")
+        expect(solr_doc[ActiveFedora::SolrService.solr_name("object_state", :stored_sortable)]).to eql("D")
+        expect(solr_doc[:id]).to eql("changeme:123")
       end
 
       it "should omit base metadata and RELS-EXT if :model_only==true" do
         @test_object.add_relationship(:has_part, "foo", true)
         solr_doc = @test_object.to_solr(Hash.new, :model_only => true)
-        solr_doc[ActiveFedora::SolrService.solr_name("system_create", type: :date)].should be_nil
-        solr_doc[ActiveFedora::SolrService.solr_name("system_modified", type: :date)].should be_nil
-        solr_doc["id"].should be_nil
-        solr_doc[ActiveFedora::SolrService.solr_name("has_part", :symbol)].should be_nil
+        expect(solr_doc[ActiveFedora::SolrService.solr_name("system_create", type: :date)]).to be_nil
+        expect(solr_doc[ActiveFedora::SolrService.solr_name("system_modified", type: :date)]).to be_nil
+        expect(solr_doc["id"]).to be_nil
+        expect(solr_doc[ActiveFedora::SolrService.solr_name("has_part", :symbol)]).to be_nil
       end
 
       it "should add self.class as the :active_fedora_model" do
@@ -483,35 +483,35 @@ describe ActiveFedora::Base do
         stub_get_content(@this_pid, ['RELS-EXT', 'someData', 'withText2', 'withText'])
         @test_history = FooHistory.new()
         solr_doc = @test_history.to_solr
-        solr_doc[ActiveFedora::SolrService.solr_name("active_fedora_model", :stored_sortable)].should eql("FooHistory")
+        expect(solr_doc[ActiveFedora::SolrService.solr_name("active_fedora_model", :stored_sortable)]).to eql("FooHistory")
       end
 
       it "should call .to_solr on all SimpleDatastreams and OmDatastreams, passing the resulting document to solr" do
         mock1 = double("ds1", :to_solr => {})
         mock2 = double("ds2", :to_solr => {})
         ngds = double("ngds", :to_solr => {})
-        ngds.should_receive(:solrize_profile)
-        mock1.should_receive(:solrize_profile)
-        mock2.should_receive(:solrize_profile)
+        expect(ngds).to receive(:solrize_profile)
+        expect(mock1).to receive(:solrize_profile)
+        expect(mock2).to receive(:solrize_profile)
 
-        @test_object.should_receive(:datastreams).twice.and_return({:ds1 => mock1, :ds2 => mock2, :ngds => ngds})
-        @test_object.should_receive(:solrize_relationships)
+        expect(@test_object).to receive(:datastreams).twice.and_return({:ds1 => mock1, :ds2 => mock2, :ngds => ngds})
+        expect(@test_object).to receive(:solrize_relationships)
         @test_object.to_solr
       end
       it "should call .to_solr on all RDFDatastreams, passing the resulting document to solr" do
         mock = double("ds1", :to_solr => {})
-        mock.should_receive(:solrize_profile)
+        expect(mock).to receive(:solrize_profile)
 
-        @test_object.should_receive(:datastreams).twice.and_return({:ds1 => mock})
-        @test_object.should_receive(:solrize_relationships)
+        expect(@test_object).to receive(:datastreams).twice.and_return({:ds1 => mock})
+        expect(@test_object).to receive(:solrize_relationships)
         @test_object.to_solr
       end
 
       it "should call .to_solr on the relationships rels-ext is dirty" do
         @test_object.add_relationship(:has_collection_member, "info:fedora/test:member")
         rels_ext = @test_object.rels_ext
-        rels_ext.should be_changed
-        @test_object.should_receive(:solrize_relationships)
+        expect(rels_ext).to be_changed
+        expect(@test_object).to receive(:solrize_relationships)
         @test_object.to_solr
       end
 
@@ -519,16 +519,16 @@ describe ActiveFedora::Base do
 
     describe ".label" do
       it "should return the label of the inner object" do
-        @test_object.inner_object.should_receive(:label).and_return("foo label")
-        @test_object.label.should == "foo label"
+        expect(@test_object.inner_object).to receive(:label).and_return("foo label")
+        expect(@test_object.label).to eq("foo label")
       end
     end
 
     describe ".label=" do
       it "should set the label of the inner object" do
-        @test_object.label.should_not == "foo label"
+        expect(@test_object.label).not_to eq("foo label")
         @test_object.label = "foo label"
-        @test_object.label.should == "foo label"
+        expect(@test_object.label).to eq("foo label")
       end
     end
     describe "update_attributes" do
@@ -536,9 +536,9 @@ describe ActiveFedora::Base do
         m = FooHistory.new
         att= {"fubar"=> '1234', "baz" =>'stuff'}
 
-        m.should_receive(:fubar=).with('1234')
-        m.should_receive(:baz=).with('stuff')
-        m.should_receive(:save)
+        expect(m).to receive(:fubar=).with('1234')
+        expect(m).to receive(:baz=).with('stuff')
+        expect(m).to receive(:save)
         m.update_attributes(att)
       end
     end
@@ -548,9 +548,9 @@ describe ActiveFedora::Base do
         m = FooHistory.new
         att= {"fubar"=> '1234', "baz" =>'stuff'}
 
-        m.should_receive(:fubar=).with('1234')
-        m.should_receive(:baz=).with('stuff')
-        m.should_receive(:save)
+        expect(m).to receive(:fubar=).with('1234')
+        expect(m).to receive(:baz=).with('stuff')
+        expect(m).to receive(:save)
         m.update(att)
       end
     end
@@ -564,12 +564,12 @@ describe ActiveFedora::Base do
         graph.insert RDF::Statement.new(subject, ActiveFedora::Predicates.find_graph_predicate(:has_part),  RDF::URI.new('info:fedora/demo:12'))
         graph.insert RDF::Statement.new(subject, ActiveFedora::Predicates.find_graph_predicate(:conforms_to),  "AnInterface")
 
-        @test_object.should_receive(:relationships).and_return(graph)
+        expect(@test_object).to receive(:relationships).and_return(graph)
         solr_doc = @test_object.solrize_relationships
-        solr_doc[ActiveFedora::SolrService.solr_name("is_member_of", :symbol)].should == "info:fedora/demo:10"
-        solr_doc[ActiveFedora::SolrService.solr_name("is_part_of", :symbol)].should == "info:fedora/demo:11"
-        solr_doc[ActiveFedora::SolrService.solr_name("has_part", :symbol)].should == "info:fedora/demo:12"
-        solr_doc[ActiveFedora::SolrService.solr_name("conforms_to", :symbol)].should == "AnInterface"
+        expect(solr_doc[ActiveFedora::SolrService.solr_name("is_member_of", :symbol)]).to eq("info:fedora/demo:10")
+        expect(solr_doc[ActiveFedora::SolrService.solr_name("is_part_of", :symbol)]).to eq("info:fedora/demo:11")
+        expect(solr_doc[ActiveFedora::SolrService.solr_name("has_part", :symbol)]).to eq("info:fedora/demo:12")
+        expect(solr_doc[ActiveFedora::SolrService.solr_name("conforms_to", :symbol)]).to eq("AnInterface")
       end
     end
   end

--- a/spec/unit/builder/has_and_belongs_to_many_spec.rb
+++ b/spec/unit/builder/has_and_belongs_to_many_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe ActiveFedora::Associations::Builder::HasAndBelongsToMany do
   describe "valid_options" do
     subject { ActiveFedora::Associations::Builder::HasAndBelongsToMany.valid_options }
-    it { should eq [:class_name, :property, :before_add, :after_add, :before_remove, :after_remove, 
+    it { is_expected.to eq [:class_name, :property, :before_add, :after_add, :before_remove, :after_remove, 
                     :inverse_of, :solr_page_size, :autosave] }
   end
 end

--- a/spec/unit/callback_spec.rb
+++ b/spec/unit/callback_spec.rb
@@ -30,22 +30,22 @@ describe ActiveFedora::Base do
   end
 
   it "Should have after_initialize, before_save,after_save, before_create, after_create, after_update, before_update, before_destroy" do
-    CallbackStub.any_instance.should_receive(:a_init)
-    CallbackStub.any_instance.should_receive :b_create
-    CallbackStub.any_instance.should_receive :a_create
-    CallbackStub.any_instance.should_receive(:b_save)
-    CallbackStub.any_instance.should_receive(:a_save)
+    expect_any_instance_of(CallbackStub).to receive(:a_init)
+    expect_any_instance_of(CallbackStub).to receive :b_create
+    expect_any_instance_of(CallbackStub).to receive :a_create
+    expect_any_instance_of(CallbackStub).to receive(:b_save)
+    expect_any_instance_of(CallbackStub).to receive(:a_save)
     cb = CallbackStub.new :pid => 'test:123'
     cb.save
 end
  it "Should have after_initialize, before_save,after_save, before_create, after_create, after_update, before_update, before_destroy" do
-    CallbackStub.any_instance.should_receive(:a_init)
-    CallbackStub.any_instance.should_receive(:b_save)
-    CallbackStub.any_instance.should_receive(:a_save)
-    CallbackStub.any_instance.should_receive(:a_find)
-    CallbackStub.any_instance.should_receive(:b_update)
-    CallbackStub.any_instance.should_receive(:a_update)
-    CallbackStub.any_instance.should_receive(:do_stuff)
+    expect_any_instance_of(CallbackStub).to receive(:a_init)
+    expect_any_instance_of(CallbackStub).to receive(:b_save)
+    expect_any_instance_of(CallbackStub).to receive(:a_save)
+    expect_any_instance_of(CallbackStub).to receive(:a_find)
+    expect_any_instance_of(CallbackStub).to receive(:b_update)
+    expect_any_instance_of(CallbackStub).to receive(:a_update)
+    expect_any_instance_of(CallbackStub).to receive(:do_stuff)
 
     cb2 = CallbackStub.find('test:123')
     cb2.save

--- a/spec/unit/code_configurator_spec.rb
+++ b/spec/unit/code_configurator_spec.rb
@@ -38,14 +38,14 @@ describe ActiveFedora::FileConfigurator do
   end
 
   it "should initialize from code" do
-    Psych.should_receive(:load).never
-    File.should_receive(:exists?).never
-    File.should_receive(:read).never
-    File.should_receive(:open).never
+    expect(Psych).to receive(:load).never
+    expect(File).to receive(:exists?).never
+    expect(File).to receive(:read).never
+    expect(File).to receive(:open).never
     ActiveFedora.init(@config_params)
-    ActiveFedora.fedora_config.credentials.should == @config_params[:fedora_config]
-    ActiveFedora.solr_config.should == @config_params[:solr_config]
-    ActiveFedora::Predicates.predicate_mappings['info:fedora/fedora-system:def/relations-external#'].length.should == 1
+    expect(ActiveFedora.fedora_config.credentials).to eq(@config_params[:fedora_config])
+    expect(ActiveFedora.solr_config).to eq(@config_params[:solr_config])
+    expect(ActiveFedora::Predicates.predicate_mappings['info:fedora/fedora-system:def/relations-external#'].length).to eq(1)
   end
   
 end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -5,7 +5,7 @@ describe ActiveFedora::Config do
     conf = Psych.load(File.read('spec/fixtures/rails_root/config/fedora.yml'))['test']
     subject { ActiveFedora::Config.new(conf) }
     its(:credentials) { should == {:url => 'http://testhost.com:8983/fedora', :user=> 'fedoraAdmin', :password=> 'fedoraAdmin'}}
-    it { should_not be_sharded }
+    it { is_expected.not_to be_sharded }
   end
   describe "with several fedora shards" do
     conf = Psych.load(File.read('spec/fixtures/sharded_fedora.yml'))['test']
@@ -13,7 +13,7 @@ describe ActiveFedora::Config do
     its(:credentials) { should == [{:url => 'http://127.0.0.1:8983/fedora1', :user=> 'fedoraAdmin', :password=> 'fedoraAdmin'},
                               {:url => 'http://127.0.0.1:8983/fedora2', :user=> 'fedoraAdmin', :password=> 'fedoraAdmin'},
                               {:url => 'http://127.0.0.1:8983/fedora3', :user=> 'fedoraAdmin', :password=> 'fedoraAdmin'}]}
-    it { should be_sharded }
+    it { is_expected.to be_sharded }
   end
 
 end

--- a/spec/unit/content_model_spec.rb
+++ b/spec/unit/content_model_spec.rb
@@ -21,19 +21,19 @@ describe ActiveFedora::ContentModel do
   describe '.best_model_for' do
     it 'should be nil if no relationships' do
       mock_object = BaseModel.new
-      mock_object.should_receive(:relationships).with(:has_model).and_return([])
+      expect(mock_object).to receive(:relationships).with(:has_model).and_return([])
       expect(ActiveFedora::ContentModel.best_model_for(mock_object)).to be_nil
     end
 
     it 'should be based on inheritance hierarchy' do
       mock_object = ActiveFedora::Base.new
-      mock_object.should_receive(:relationships).with(:has_model).and_return(["info:fedora/fedora-system:ServiceDefinition-3.0", 'info:fedora/afmodel:SampleModel', 'info:fedora/afmodel:BaseModel'])
+      expect(mock_object).to receive(:relationships).with(:has_model).and_return(["info:fedora/fedora-system:ServiceDefinition-3.0", 'info:fedora/afmodel:SampleModel', 'info:fedora/afmodel:BaseModel'])
       expect(ActiveFedora::ContentModel.best_model_for(mock_object)).to eq SampleModel
     end
 
     it 'should find the deepest descendant of the on inheritance hierarchy' do
       mock_object = BaseModel.new
-      mock_object.should_receive(:relationships).with(:has_model).and_return(["info:fedora/fedora-system:ServiceDefinition-3.0", 'info:fedora/afmodel:SampleModel', 'info:fedora/afmodel:BaseModel'])
+      expect(mock_object).to receive(:relationships).with(:has_model).and_return(["info:fedora/fedora-system:ServiceDefinition-3.0", 'info:fedora/afmodel:SampleModel', 'info:fedora/afmodel:BaseModel'])
       expect(ActiveFedora::ContentModel.best_model_for(mock_object)).to eq SampleModel
     end
   end
@@ -41,46 +41,46 @@ describe ActiveFedora::ContentModel do
   describe "models_asserted_by" do
     it "should return an array of all of the content models asserted by the given object" do
       mock_object = double("ActiveFedora Object")
-      mock_object.should_receive(:relationships).with(:has_model).and_return(["info:fedora/fedora-system:ServiceDefinition-3.0", "info:fedora/afmodel:SampleModel", "info:fedora/afmodel:NonDefinedModel"])
-      ActiveFedora::ContentModel.models_asserted_by(mock_object).should == ["info:fedora/fedora-system:ServiceDefinition-3.0", "info:fedora/afmodel:SampleModel", "info:fedora/afmodel:NonDefinedModel"]
+      expect(mock_object).to receive(:relationships).with(:has_model).and_return(["info:fedora/fedora-system:ServiceDefinition-3.0", "info:fedora/afmodel:SampleModel", "info:fedora/afmodel:NonDefinedModel"])
+      expect(ActiveFedora::ContentModel.models_asserted_by(mock_object)).to eq(["info:fedora/fedora-system:ServiceDefinition-3.0", "info:fedora/afmodel:SampleModel", "info:fedora/afmodel:NonDefinedModel"])
     end
     it "should return an empty array if the object doesn't have a RELS-EXT datastream" do
       mock_object = double("ActiveFedora Object")
-      mock_object.should_receive(:relationships).with(:has_model).and_return([])
-      ActiveFedora::ContentModel.models_asserted_by(mock_object).should == []
+      expect(mock_object).to receive(:relationships).with(:has_model).and_return([])
+      expect(ActiveFedora::ContentModel.models_asserted_by(mock_object)).to eq([])
     end
   end
   
   describe "known_models_asserted_by" do
     it "should figure out the applicable models to load" do
       mock_object = double("ActiveFedora Object")
-      mock_object.should_receive(:relationships).with(:has_model).and_return(["info:fedora/fedora-system:ServiceDefinition-3.0", "info:fedora/afmodel:SampleModel", "info:fedora/afmodel:NonDefinedModel"])
-      ActiveFedora::ContentModel.known_models_for(mock_object).should == [SampleModel]
+      expect(mock_object).to receive(:relationships).with(:has_model).and_return(["info:fedora/fedora-system:ServiceDefinition-3.0", "info:fedora/afmodel:SampleModel", "info:fedora/afmodel:NonDefinedModel"])
+      expect(ActiveFedora::ContentModel.known_models_for(mock_object)).to eq([SampleModel])
     end
     it "should support namespaced models" do
       pending "This is harder than it looks."
       mock_object = double("ActiveFedora Object")
-      mock_object.should_receive(:relationships).with(:has_model).and_return(["info:fedora/afmodel:Sample_NamespacedModel"])
-      ActiveFedora::ContentModel.known_models_for(mock_object).should == [Sample::NamespacedModel]
+      expect(mock_object).to receive(:relationships).with(:has_model).and_return(["info:fedora/afmodel:Sample_NamespacedModel"])
+      expect(ActiveFedora::ContentModel.known_models_for(mock_object)).to eq([Sample::NamespacedModel])
     end
     it "should default to using ActiveFedora::Base as the model" do
       mock_object = double("ActiveFedora Object")
-      mock_object.should_receive(:relationships).with(:has_model).and_return(["info:fedora/afmodel:NonDefinedModel"])
-      ActiveFedora::ContentModel.known_models_for(mock_object).should == [ActiveFedora::Base]
+      expect(mock_object).to receive(:relationships).with(:has_model).and_return(["info:fedora/afmodel:NonDefinedModel"])
+      expect(ActiveFedora::ContentModel.known_models_for(mock_object)).to eq([ActiveFedora::Base])
     end
     it "should still work even if the object doesn't have a RELS-EXT datastream" do
       mock_object = double("ActiveFedora Object")
-      mock_object.should_receive(:relationships).with(:has_model).and_return([])
-      ActiveFedora::ContentModel.known_models_for(mock_object).should == [ActiveFedora::Base]
+      expect(mock_object).to receive(:relationships).with(:has_model).and_return([])
+      expect(ActiveFedora::ContentModel.known_models_for(mock_object)).to eq([ActiveFedora::Base])
     end
   end
   
   describe "uri_to_model_class" do
     it "should return an ActiveFedora Model class corresponding to the given uri if a valid model can be found" do
-      ActiveFedora::ContentModel.uri_to_model_class("info:fedora/afmodel:SampleModel").should == SampleModel
-      ActiveFedora::ContentModel.uri_to_model_class("info:fedora/afmodel:NonDefinedModel").should == false
-      ActiveFedora::ContentModel.uri_to_model_class("info:fedora/afmodel:String").should == false
-      ActiveFedora::ContentModel.uri_to_model_class("info:fedora/hydra-cModel:genericContent").should == GenericContent
+      expect(ActiveFedora::ContentModel.uri_to_model_class("info:fedora/afmodel:SampleModel")).to eq(SampleModel)
+      expect(ActiveFedora::ContentModel.uri_to_model_class("info:fedora/afmodel:NonDefinedModel")).to eq(false)
+      expect(ActiveFedora::ContentModel.uri_to_model_class("info:fedora/afmodel:String")).to eq(false)
+      expect(ActiveFedora::ContentModel.uri_to_model_class("info:fedora/hydra-cModel:genericContent")).to eq(GenericContent)
     end
   end
 

--- a/spec/unit/core_spec.rb
+++ b/spec/unit/core_spec.rb
@@ -68,7 +68,7 @@ describe ActiveFedora::Base do
     it "should access associations" do
       f = Book.find(subject.id)
       f.freeze
-      f.library_id.should_not be_nil
+      expect(f.library_id).not_to be_nil
 
     end
   end

--- a/spec/unit/datastream_collections_spec.rb
+++ b/spec/unit/datastream_collections_spec.rb
@@ -15,24 +15,24 @@ describe ActiveFedora::DatastreamCollections do
     it 'should cache a definition of named datastream and create helper methods to add/remove/access them' do
       @test_object2 = MockHasDatastream.new
       #prefix should default to name in caps if not specified in has_datastream call
-      @test_object2.named_datastreams_desc.should == {"thumbnail"=>{:name=>"thumbnail",:prefix => "THUMB", 
+      expect(@test_object2.named_datastreams_desc).to eq({"thumbnail"=>{:name=>"thumbnail",:prefix => "THUMB", 
                                                                     :type=>"ActiveFedora::Datastream", :mimeType=>"image/jpeg", 
                                                                     :controlGroup=>'M'},
                                                       "EAD"=>       {:name=>"EAD", :prefix=>"EAD",
                                                                     :type=>"ActiveFedora::Datastream", :mimeType=>"application/xml", 
                                                                     :controlGroup=>'M' },
                                                       "external"=>  {:name=>"external", :prefix=>"EXTERNAL",
-                                                                    :type=>"ActiveFedora::Datastream", :controlGroup=>'E' }}
-      @test_object2.should respond_to(:thumbnail_append)
-      @test_object2.should respond_to(:thumbnail_file_append)
-      @test_object2.should respond_to(:thumbnail)
-      @test_object2.should respond_to(:thumbnail_ids)
-      @test_object2.should respond_to(:ead_append)
-      @test_object2.should respond_to(:ead_file_append)
-      @test_object2.should respond_to(:EAD)
-      @test_object2.should respond_to(:EAD_ids)
-      @test_object2.should respond_to(:external)
-      @test_object2.should respond_to(:external_ids)
+                                                                    :type=>"ActiveFedora::Datastream", :controlGroup=>'E' }})
+      expect(@test_object2).to respond_to(:thumbnail_append)
+      expect(@test_object2).to respond_to(:thumbnail_file_append)
+      expect(@test_object2).to respond_to(:thumbnail)
+      expect(@test_object2).to respond_to(:thumbnail_ids)
+      expect(@test_object2).to respond_to(:ead_append)
+      expect(@test_object2).to respond_to(:ead_file_append)
+      expect(@test_object2).to respond_to(:EAD)
+      expect(@test_object2).to respond_to(:EAD_ids)
+      expect(@test_object2).to respond_to(:external)
+      expect(@test_object2).to respond_to(:external_ids)
     end
   end
   describe '#datastream_names' do
@@ -46,7 +46,7 @@ describe ActiveFedora::DatastreamCollections do
     
     it 'should return a set of datastream names defined by has_datastream' do
       @test_object2 = MockDatastreamNames.new
-      @test_object2.datastream_names.should include("thumbnail","EAD")
+      expect(@test_object2.datastream_names).to include("thumbnail","EAD")
     end
   end
   
@@ -65,8 +65,8 @@ describe ActiveFedora::DatastreamCollections do
       @test_object2 = MockAddNamedDatastream.new
       @f = File.new(File.join( File.dirname(__FILE__), "../fixtures/minivan.jpg"))
       @f2 = File.new(File.join( File.dirname(__FILE__), "../fixtures/dino.jpg" ))
-      @f.stub(:content_type).and_return("image/jpeg")
-      @f2.stub(:original_filename).and_return("dino.jpg")
+      allow(@f).to receive(:content_type).and_return("image/jpeg")
+      allow(@f2).to receive(:original_filename).and_return("dino.jpg")
     end
       
     it 'cannot add a datastream with name that does not exist' do
@@ -93,16 +93,16 @@ describe ActiveFedora::DatastreamCollections do
 
     it "should use the given label for the dsLabel" do
       @test_object2.add_named_datastream("high",{:content_type=>"image/jpeg",:blob=>@f2, :label=>"my_image"})
-      @test_object2.high.first.dsLabel.should == "my_image"
+      expect(@test_object2.high.first.dsLabel).to eq("my_image")
     end
 
     it "should fallback on using the file name" do
       @test_object2.add_named_datastream("high",{:content_type=>"image/jpeg",:blob=>@f2})
-      @test_object2.high.first.dsLabel.should == "dino.jpg"
+      expect(@test_object2.high.first.dsLabel).to eq("dino.jpg")
     end 
 
     it "should check the file for a content type" do
-      @f.should_receive(:content_type).and_return("image/jpeg")
+      expect(@f).to receive(:content_type).and_return("image/jpeg")
       @test_object2.add_named_datastream("thumbnail",{:file=>@f})
     end
 
@@ -111,7 +111,7 @@ describe ActiveFedora::DatastreamCollections do
     end
 
     it "should encsure mimetype and content type match" do
-      @f.stub(:content_type).and_return("image/tiff")
+      allow(@f).to receive(:content_type).and_return("image/tiff")
       expect { @test_object2.add_named_datastream("thumbnail",{:file=>f}) }.to raise_error
     end
       
@@ -119,12 +119,12 @@ describe ActiveFedora::DatastreamCollections do
       #check for if any mime type allowed
       @test_object2.add_named_datastream("anymime",{:file=>@f})
       #check datastream created is of type ActiveFedora::Datastream
-      @test_object2.anymime.first.class.should == ActiveFedora::Datastream
+      expect(@test_object2.anymime.first.class).to eq(ActiveFedora::Datastream)
     end
 
     it "should cgecj that a dsid forms to the prefix" do
       #if dsid supplied check that conforms to prefix
-      @f.stub(:content_type).and_return("image/jpeg")
+      allow(@f).to receive(:content_type).and_return("image/jpeg")
       expect { @test_object2.add_named_datastream("thumbnail",{:file=>@f,:dsid=>"DS1"}) }.to raise_error
     end
 
@@ -134,7 +134,7 @@ describe ActiveFedora::DatastreamCollections do
       #@test_object2.high.first.attributes[:prefix].should == "HIGH"
       @test_object2.high.first.dsid.match(/HIGH[0-9]/)
       #check datastreams added with other right properties
-      @test_object2.high.first.controlGroup.should == "M"
+      expect(@test_object2.high.first.controlGroup).to eq("M")
     end
 
     it "should work with external datastreams" do
@@ -142,7 +142,7 @@ describe ActiveFedora::DatastreamCollections do
       #check external datastream
       @test_object2.add_named_datastream("external",{:dsLocation=>"http://myreasource.com"})
       #check dslocation goes to dslabel
-      @test_object2.external.first.dsLabel.should == "http://myreasource.com"
+      expect(@test_object2.external.first.dsLabel).to eq("http://myreasource.com")
       #check datastreams added to fedora (may want to stub this at first)
     end
   end
@@ -162,15 +162,15 @@ describe ActiveFedora::DatastreamCollections do
       @test_object2 = MockAddNamedFileDatastream.new
       f = File.new(File.join( File.dirname(__FILE__), "../fixtures/minivan.jpg"))
       #these normally supplied in multi-part post request
-      f.stub(:original_filename).and_return("minivan.jpg")
-      f.stub(:content_type).and_return("image/jpeg")
+      allow(f).to receive(:original_filename).and_return("minivan.jpg")
+      allow(f).to receive(:content_type).and_return("image/jpeg")
       @test_object2.add_named_file_datastream("thumbnail",f)
       thumb = @test_object2.thumbnail.first
-      thumb.class.should == MockDS
-      thumb.mimeType.should == "image/jpeg"
-      thumb.dsid.should == "THUMB1"
-      thumb.controlGroup.should == "M"
-      thumb.dsLabel.should == "minivan.jpg"
+      expect(thumb.class).to eq(MockDS)
+      expect(thumb.mimeType).to eq("image/jpeg")
+      expect(thumb.dsid).to eq("THUMB1")
+      expect(thumb.controlGroup).to eq("M")
+      expect(thumb.dsLabel).to eq("minivan.jpg")
       #thumb.name.should == "thumbnail"
         # :prefix=>"THUMB", :content_type=>"image/jpeg", :dsid=>"THUMB1", :dsID=>"THUMB1", 
         # :pid=>@test_object2.pid, :mimeType=>"image/jpeg", :controlGroup=>"M", :dsLabel=>"minivan.jpg", :name=>"thumbnail"}
@@ -190,10 +190,10 @@ describe ActiveFedora::DatastreamCollections do
       @test_object2 = MockUpdateNamedDatastream.new
       f = File.new(File.join( File.dirname(__FILE__), "../fixtures/minivan.jpg"))
       f2 = File.new(File.join( File.dirname(__FILE__), "../fixtures/dino.jpg" ))
-      f.stub(:content_type).and_return("image/jpeg")
-      f.stub(:original_filename).and_return("minivan.jpg")
-      f2.stub(:content_type).and_return("image/jpeg")
-      f2.stub(:original_filename).and_return("dino.jpg")
+      allow(f).to receive(:content_type).and_return("image/jpeg")
+      allow(f).to receive(:original_filename).and_return("minivan.jpg")
+      allow(f2).to receive(:content_type).and_return("image/jpeg")
+      allow(f2).to receive(:original_filename).and_return("dino.jpg")
       #check raise exception if dsid not supplied
       @test_object2.add_named_datastream("thumbnail",{:file=>f})
       had_exception = false
@@ -212,15 +212,15 @@ describe ActiveFedora::DatastreamCollections do
       end
       raise "Failed to raise exception if dsid does not exist" unless had_exception  
       #check datastream is updated in place without new dsid  
-      @test_object2.thumbnail.size.should == 1
+      expect(@test_object2.thumbnail.size).to eq(1)
       @test_object2.thumbnail_ids == ["THUMB1"]
       thumb1 = @test_object2.thumbnail.first
-      thumb1.dsid.should == 'THUMB1'
-      thumb1.pid.should == @test_object2.pid
-      thumb1.dsLabel.should == 'minivan.jpg'
+      expect(thumb1.dsid).to eq('THUMB1')
+      expect(thumb1.pid).to eq(@test_object2.pid)
+      expect(thumb1.dsLabel).to eq('minivan.jpg')
       f.rewind
       @test_object2.update_named_datastream("thumbnail",{:file=>f2,:dsid=>"THUMB1"})
-      @test_object2.thumbnail.size.should == 1
+      expect(@test_object2.thumbnail.size).to eq(1)
       @test_object2.thumbnail_ids == ["THUMB1"]
       # @test_object2.thumbnail.first.attributes.should == {:type=>"ActiveFedora::Datastream",
       #                                                     :content_type=>"image/jpeg", 
@@ -229,9 +229,9 @@ describe ActiveFedora::DatastreamCollections do
       #                                                     :pid=>@test_object2.pid, :dsID=>"THUMB1", 
       #                                                     :name=>"thumbnail", :dsLabel=>"dino.jpg"}
       thumb1 = @test_object2.thumbnail.first
-      thumb1.dsid.should == 'THUMB1'
-      thumb1.pid.should == @test_object2.pid
-      thumb1.dsLabel.should == 'dino.jpg'
+      expect(thumb1.dsid).to eq('THUMB1')
+      expect(thumb1.pid).to eq(@test_object2.pid)
+      expect(thumb1.dsLabel).to eq('dino.jpg')
     end
   end
   describe '#named_datastreams_desc' do
@@ -245,9 +245,9 @@ describe ActiveFedora::DatastreamCollections do
     
     it 'should intialize a value to an empty hash and then not modify afterward' do
       @test_object2 = MockNamedDatastreamsDesc.new
-      @test_object2.named_datastreams_desc.should == {"thumbnail"=>{:name=>"thumbnail",:prefix => "THUMB", 
+      expect(@test_object2.named_datastreams_desc).to eq({"thumbnail"=>{:name=>"thumbnail",:prefix => "THUMB", 
                                                                     :type=>"ActiveFedora::Datastream", :mimeType=>"image/jpeg", 
-                                                                    :controlGroup=>'M'}}
+                                                                    :controlGroup=>'M'}})
     end
   end
 
@@ -261,8 +261,8 @@ describe ActiveFedora::DatastreamCollections do
     
     it 'should return true if a named datastream exists in model' do
       @test_object2 = MockIsNamedDatastream.new
-      @test_object2.is_named_datastream?("thumbnail").should == true
-      @test_object2.is_named_datastream?("thumb").should == false
+      expect(@test_object2.is_named_datastream?("thumbnail")).to eq(true)
+      expect(@test_object2.is_named_datastream?("thumb")).to eq(false)
     end
   end
   
@@ -280,33 +280,33 @@ describe ActiveFedora::DatastreamCollections do
     it 'should return a hash of datastream names to arrays of datastreams' do
       @test_object2 = MockNamedDatastreams.new
       f = File.new(File.join( File.dirname(__FILE__), "../fixtures/minivan.jpg" ))
-      f.stub(:content_type).and_return("image/jpeg")
-      f.stub(:original_filename).and_return("minivan.jpg")
+      allow(f).to receive(:content_type).and_return("image/jpeg")
+      allow(f).to receive(:original_filename).and_return("minivan.jpg")
       f2 = File.new(File.join( File.dirname(__FILE__), "../fixtures/dino.jpg" ))
-      f2.stub(:content_type).and_return("image/jpeg")
-      f2.stub(:original_filename).and_return("dino.jpg")
+      allow(f2).to receive(:content_type).and_return("image/jpeg")
+      allow(f2).to receive(:original_filename).and_return("dino.jpg")
       @test_object2.thumbnail_file_append(f)
       @test_object2.high_file_append(f2)
       @test_object2.external_append({:dsLocation=>"http://myresource.com"})
       datastreams = @test_object2.named_datastreams
-      datastreams.keys.include?("thumbnail").should == true
-      datastreams.keys.include?("external").should == true
-      datastreams.keys.include?("high").should == true
-      datastreams.keys.size.should == 3
-      datastreams["thumbnail"].size.should == 1
-      datastreams["thumbnail"].first.dsid.should == 'THUMB1'
-      datastreams["thumbnail"].first.dsLabel.should == 'minivan.jpg'
-      datastreams["thumbnail"].first.controlGroup.should == "M"
+      expect(datastreams.keys.include?("thumbnail")).to eq(true)
+      expect(datastreams.keys.include?("external")).to eq(true)
+      expect(datastreams.keys.include?("high")).to eq(true)
+      expect(datastreams.keys.size).to eq(3)
+      expect(datastreams["thumbnail"].size).to eq(1)
+      expect(datastreams["thumbnail"].first.dsid).to eq('THUMB1')
+      expect(datastreams["thumbnail"].first.dsLabel).to eq('minivan.jpg')
+      expect(datastreams["thumbnail"].first.controlGroup).to eq("M")
 
-      datastreams["external"].size.should == 1
-      datastreams["external"].first.dsid.should == "EXTERNAL1"
-      datastreams["external"].first.dsLocation.should == "http://myresource.com"
-      datastreams["external"].first.controlGroup.should == "E"
+      expect(datastreams["external"].size).to eq(1)
+      expect(datastreams["external"].first.dsid).to eq("EXTERNAL1")
+      expect(datastreams["external"].first.dsLocation).to eq("http://myresource.com")
+      expect(datastreams["external"].first.controlGroup).to eq("E")
 
-      datastreams["high"].size.should == 1
-      datastreams["high"].first.dsLabel.should == 'dino.jpg'
-      datastreams["high"].first.controlGroup.should == "M"
-      datastreams["high"].first.dsid.should == "HIGH1"
+      expect(datastreams["high"].size).to eq(1)
+      expect(datastreams["high"].first.dsLabel).to eq('dino.jpg')
+      expect(datastreams["high"].first.controlGroup).to eq("M")
+      expect(datastreams["high"].first.dsid).to eq("HIGH1")
     end
   end
   
@@ -325,15 +325,15 @@ describe ActiveFedora::DatastreamCollections do
     it 'should provide a hash of datastreams names to array of datastream ids' do
       @test_object2 = MockNamedDatastreamsIds.new
       f = File.new(File.join( File.dirname(__FILE__), "../fixtures/minivan.jpg" ))
-      f.stub(:content_type).and_return("image/jpeg")
-      f.stub(:original_filename).and_return("minivan.jpg")
+      allow(f).to receive(:content_type).and_return("image/jpeg")
+      allow(f).to receive(:original_filename).and_return("minivan.jpg")
       f2 = File.new(File.join( File.dirname(__FILE__), "../fixtures/dino.jpg" ))
-      f2.stub(:content_type).and_return("image/jpeg")
-      f2.stub(:original_filename).and_return("dino.jpg")
+      allow(f2).to receive(:content_type).and_return("image/jpeg")
+      allow(f2).to receive(:original_filename).and_return("dino.jpg")
       @test_object2.thumbnail_file_append(f)
       @test_object2.high_file_append(f2)
       @test_object2.external_append({:dsLocation=>"http://myresource.com"})
-      @test_object2.named_datastreams_ids.should == {"thumbnail"=>["THUMB1"],"high"=>["HIGH1"],"external"=>["EXTERNAL1"]}
+      expect(@test_object2.named_datastreams_ids).to eq({"thumbnail"=>["THUMB1"],"high"=>["HIGH1"],"external"=>["EXTERNAL1"]})
     end
   end
   
@@ -349,32 +349,32 @@ describe ActiveFedora::DatastreamCollections do
     
     it 'should create helper methods to get named datastreams or dsids' do
       @test_object2 = MockCreateNamedDatastreamFinder.new
-      @test_object2.should respond_to(:thumbnail)
-      @test_object2.should respond_to(:thumbnail_ids)  
-      @test_object2.should respond_to(:high)
-      @test_object2.should respond_to(:high_ids)
+      expect(@test_object2).to respond_to(:thumbnail)
+      expect(@test_object2).to respond_to(:thumbnail_ids)  
+      expect(@test_object2).to respond_to(:high)
+      expect(@test_object2).to respond_to(:high_ids)
       f = File.new(File.join( File.dirname(__FILE__), "../fixtures/minivan.jpg"))
       f2 = File.new(File.join( File.dirname(__FILE__), "../fixtures/dino.jpg" ))
-      f2.stub(:original_filename).and_return("dino.jpg")
-      f.stub(:content_type).and_return("image/jpeg")
+      allow(f2).to receive(:original_filename).and_return("dino.jpg")
+      allow(f).to receive(:content_type).and_return("image/jpeg")
       @test_object2.add_named_datastream("thumbnail",{:content_type=>"image/jpeg",:blob=>f, :label=>"testDS"})
       @test_object2.add_named_datastream("high",{:content_type=>"image/jpeg",:blob=>f2})
       @test_object2.add_named_datastream("high",{:content_type=>"image/jpeg",:blob=>f2})
       t2_thumb1 = @test_object2.thumbnail.first
-      t2_thumb1.mimeType.should == "image/jpeg"
-      t2_thumb1.controlGroup.should == "M"
-      t2_thumb1.dsLabel.should == "testDS"
-      t2_thumb1.pid.should == @test_object2.pid 
-      t2_thumb1.dsid.should == "THUMB1"
+      expect(t2_thumb1.mimeType).to eq("image/jpeg")
+      expect(t2_thumb1.controlGroup).to eq("M")
+      expect(t2_thumb1.dsLabel).to eq("testDS")
+      expect(t2_thumb1.pid).to eq(@test_object2.pid) 
+      expect(t2_thumb1.dsid).to eq("THUMB1")
       # :type=>"ActiveFedora::Datastream", 
       # :prefix=>"THUMB", :content_type=>"image/jpeg", :dsid=>"THUMB1", :dsID=>"THUMB1", 
       # :pid=>@test_object2.pid, :mimeType=>"image/jpeg", :controlGroup=>"M", :dsLabel=>"testDS", :name=>"thumbnail", :label=>"testDS"}
-      @test_object2.thumbnail_ids.should == ["THUMB1"]
+      expect(@test_object2.thumbnail_ids).to eq(["THUMB1"])
       @test_object2.high_ids.include?("HIGH1") == true
       @test_object2.high_ids.include?("HIGH2") == true
-      @test_object2.high_ids.size.should == 2
+      expect(@test_object2.high_ids.size).to eq(2)
       #just check returning datastream object at this point
-      @test_object2.high.first.class.should == ActiveFedora::Datastream
+      expect(@test_object2.high.first.class).to eq(ActiveFedora::Datastream)
     end
   end
     
@@ -391,29 +391,29 @@ describe ActiveFedora::DatastreamCollections do
     it 'should create append method for each has_datastream entry' do
       @test_object2 = MockCreateNamedDatastreamUpdateMethods.new
       @test_object3 = MockCreateNamedDatastreamUpdateMethods.new
-      @test_object2.should respond_to(:thumbnail_append)
-      @test_object2.should respond_to(:ead_append)
+      expect(@test_object2).to respond_to(:thumbnail_append)
+      expect(@test_object2).to respond_to(:ead_append)
       f = File.new(File.join( File.dirname(__FILE__), "../fixtures/minivan.jpg"))
-      f.stub(:content_type).and_return("image/jpeg")
-      f.stub(:original_filename).and_return("minivan.jpg")
+      allow(f).to receive(:content_type).and_return("image/jpeg")
+      allow(f).to receive(:original_filename).and_return("minivan.jpg")
       @test_object2.thumbnail_file_append(f)
       t2_thumb1 = @test_object2.thumbnail.first
-      t2_thumb1.mimeType.should == "image/jpeg"
-      t2_thumb1.dsLabel.should == "minivan.jpg"
-      t2_thumb1.pid.should == @test_object2.pid 
-      t2_thumb1.dsid.should == "THUMB1"
+      expect(t2_thumb1.mimeType).to eq("image/jpeg")
+      expect(t2_thumb1.dsLabel).to eq("minivan.jpg")
+      expect(t2_thumb1.pid).to eq(@test_object2.pid) 
+      expect(t2_thumb1.dsid).to eq("THUMB1")
       @test_object3.thumbnail_append({:file=>f})
       t3_thumb1 = @test_object3.thumbnail.first
-      t3_thumb1.mimeType.should == "image/jpeg"
-      t3_thumb1.dsLabel.should == "minivan.jpg"
-      t3_thumb1.pid.should == @test_object3.pid 
-      t3_thumb1.dsid.should == "THUMB1"
+      expect(t3_thumb1.mimeType).to eq("image/jpeg")
+      expect(t3_thumb1.dsLabel).to eq("minivan.jpg")
+      expect(t3_thumb1.pid).to eq(@test_object3.pid) 
+      expect(t3_thumb1.dsid).to eq("THUMB1")
       @test_object3.external_append({:dsLocation=>"http://myresource.com"})
       t3_external1 = @test_object3.external.first
-      t3_external1.dsLabel.should == "http://myresource.com"
-      t3_external1.dsLocation.should == "http://myresource.com"
-      t3_external1.pid.should == @test_object3.pid 
-      t3_external1.dsid.should == "EXTERNAL1"
+      expect(t3_external1.dsLabel).to eq("http://myresource.com")
+      expect(t3_external1.dsLocation).to eq("http://myresource.com")
+      expect(t3_external1.pid).to eq(@test_object3.pid) 
+      expect(t3_external1.dsid).to eq("EXTERNAL1")
       t3_external1.controlGroup == 'E'
     end
   end

--- a/spec/unit/datastream_spec.rb
+++ b/spec/unit/datastream_spec.rb
@@ -8,37 +8,37 @@ describe ActiveFedora::Datastream do
     @test_datastream.content = "hi there"
   end
 
-  its(:metadata?) { should be_false}
+  its(:metadata?) { should be_falsey}
 
   it "should escape dots in  to_param" do
-    @test_datastream.stub(:dsid).and_return('foo.bar')
-    @test_datastream.to_param.should == 'foo%2ebar'
+    allow(@test_datastream).to receive(:dsid).and_return('foo.bar')
+    expect(@test_datastream.to_param).to eq('foo%2ebar')
   end
   
   it "should be inspectable" do
-    @test_datastream.inspect.should match /#<ActiveFedora::Datastream @pid=\"\" @dsid=\"abcd\" @controlGroup=\"M\" changed=\"true\" @mimeType=\"\" >/
+    expect(@test_datastream.inspect).to match /#<ActiveFedora::Datastream @pid=\"\" @dsid=\"abcd\" @controlGroup=\"M\" changed=\"true\" @mimeType=\"\" >/
   end
 
   it "should have mimeType accessors" do
     ds1 = ActiveFedora::Datastream.new
     ds1.mimeType = "text/foo"
-    ds1.mimeType.should == "text/foo"
+    expect(ds1.mimeType).to eq("text/foo")
     ds2 = ActiveFedora::Datastream.new
     ds2.mimeType = "text/bar"
-    ds2.mimeType.should == "text/bar"
+    expect(ds2.mimeType).to eq("text/bar")
   end
 
   describe "#generate_dsid" do
     subject {ActiveFedora::Datastream.new(@test_object.inner_object) }
     let(:digital_object) { double(datastreams: {})}
     it "should create an autoincrementing dsid" do
-      subject.send(:generate_dsid, digital_object, 'FOO').should == 'FOO1'
+      expect(subject.send(:generate_dsid, digital_object, 'FOO')).to eq('FOO1')
     end
 
     describe "when some datastreams exist" do
       let(:digital_object) { double(datastreams: {'FOO56' => double})}
       it "should start from the highest existing dsid" do
-        subject.send(:generate_dsid, digital_object, 'FOO').should == 'FOO57'
+        expect(subject.send(:generate_dsid, digital_object, 'FOO')).to eq('FOO57')
       end
     end
   end
@@ -71,13 +71,13 @@ describe ActiveFedora::Datastream do
       EOS
 
       mock_repo = Rubydora::Repository.new
-      @test_object.inner_object.stub(:repository).and_return(mock_repo)
-      mock_repo.api.should_receive(:datastream).with(:dsid => 'abcd', :pid => @test_object.pid).and_return(ds_profile)
-      @test_datastream.size.should == 9999
+      allow(@test_object.inner_object).to receive(:repository).and_return(mock_repo)
+      expect(mock_repo.api).to receive(:datastream).with(:dsid => 'abcd', :pid => @test_object.pid).and_return(ds_profile)
+      expect(@test_datastream.size).to eq(9999)
     end
 
     it "should default to an empty string if ds has not been saved" do
-      @test_datastream.size.should be_nil
+      expect(@test_datastream.size).to be_nil
     end
   end
 end

--- a/spec/unit/datastreams_spec.rb
+++ b/spec/unit/datastreams_spec.rb
@@ -12,15 +12,15 @@ describe ActiveFedora::Datastreams do
     end
 
     it "should have a ds_specs entry" do
-      FooHistory.ds_specs.should have_key('dsid')
+      expect(FooHistory.ds_specs).to have_key('dsid')
     end
 
     it "should have reasonable defaults" do
-      FooHistory.ds_specs['dsid'].should include(:autocreate => false)
+      expect(FooHistory.ds_specs['dsid']).to include(:autocreate => false)
     end
 
     it "should let you override defaults" do
-      FooHistory.ds_specs['complex_ds'].should include(:versionable => true, :autocreate => true, :type => 'Z', :label => 'My Label', :control_group => 'Z')
+      expect(FooHistory.ds_specs['complex_ds']).to include(:versionable => true, :autocreate => true, :type => 'Z', :label => 'My Label', :control_group => 'Z')
     end
 
     it "should raise an error if you don't give a type" do
@@ -43,8 +43,8 @@ describe ActiveFedora::Datastreams do
     end
 
     it "should have reasonable defaults" do
-      FooHistory.ds_specs['dsid'].should include(:type => ActiveFedora::Datastream, :label => 'File Datastream', :control_group => 'M')
-      FooHistory.ds_specs['another'].should include(:type => ActiveFedora::Datastream, :label => 'File Datastream', :control_group => 'M')
+      expect(FooHistory.ds_specs['dsid']).to include(:type => ActiveFedora::Datastream, :label => 'File Datastream', :control_group => 'M')
+      expect(FooHistory.ds_specs['another']).to include(:type => ActiveFedora::Datastream, :label => 'File Datastream', :control_group => 'M')
     end
   end
 
@@ -53,9 +53,9 @@ describe ActiveFedora::Datastreams do
       m1 = double()
       m2 = double()
 
-      m1.should_receive(:serialize!)
-      m2.should_receive(:serialize!)
-       subject.stub(:datastreams => { :m1 => m1, :m2 => m2})
+      expect(m1).to receive(:serialize!)
+      expect(m2).to receive(:serialize!)
+       allow(subject).to receive_messages(:datastreams => { :m1 => m1, :m2 => m2})
        subject.serialize_datastreams
     end
   end
@@ -65,62 +65,62 @@ describe ActiveFedora::Datastreams do
       
       mock_specs = {'e' => { :disseminator => 'xyz' }}
       mock_ds = double(:controlGroup => 'E')
-      ActiveFedora::Base.stub(:ds_specs => mock_specs)
-      ActiveFedora.stub(:config_for_environment => { :url => 'http://localhost'})
-      subject.stub(:pid => 'test:1', :datastreams => {'e' => mock_ds})
-      mock_ds.should_receive(:dsLocation=).with("http://localhost/objects/test:1/methods/xyz")
+      allow(ActiveFedora::Base).to receive_messages(:ds_specs => mock_specs)
+      allow(ActiveFedora).to receive_messages(:config_for_environment => { :url => 'http://localhost'})
+      allow(subject).to receive_messages(:pid => 'test:1', :datastreams => {'e' => mock_ds})
+      expect(mock_ds).to receive(:dsLocation=).with("http://localhost/objects/test:1/methods/xyz")
       subject.add_disseminator_location_to_datastreams
     end
   end
 
   describe ".name_for_dsid" do
     it "should use the name" do
-      ActiveFedora::Base.send(:name_for_dsid, 'abc').should == 'abc'
+      expect(ActiveFedora::Base.send(:name_for_dsid, 'abc')).to eq('abc')
     end
 
     it "should use the name" do
-      ActiveFedora::Base.send(:name_for_dsid, 'ARCHIVAL_XML').should == 'ARCHIVAL_XML'
+      expect(ActiveFedora::Base.send(:name_for_dsid, 'ARCHIVAL_XML')).to eq('ARCHIVAL_XML')
     end
 
     it "should use the name" do
-      ActiveFedora::Base.send(:name_for_dsid, 'descMetadata').should == 'descMetadata'
+      expect(ActiveFedora::Base.send(:name_for_dsid, 'descMetadata')).to eq('descMetadata')
     end
 
     it "should hash-erize underscores" do
-      ActiveFedora::Base.send(:name_for_dsid, 'a-b').should == 'a_b'
+      expect(ActiveFedora::Base.send(:name_for_dsid, 'a-b')).to eq('a_b')
     end
   end
  
   describe "#datastreams" do
     it "should return the datastream hash proxy" do
-      subject.stub(:load_datastreams)
-      subject.datastreams.should be_a_kind_of(ActiveFedora::DatastreamHash)
+      allow(subject).to receive(:load_datastreams)
+      expect(subject.datastreams).to be_a_kind_of(ActiveFedora::DatastreamHash)
     end
     
     it "should round-trip to/from YAML" do
-      YAML.load(subject.datastreams.to_yaml).inspect.should == subject.datastreams.inspect
+      expect(YAML.load(subject.datastreams.to_yaml).inspect).to eq(subject.datastreams.inspect)
     end
   end
 
   describe "#configure_datastream" do
     it "should look up the ds_spec" do
       mock_dsspec = { :type => nil }
-      subject.stub(:ds_specs => {'abc' => mock_dsspec})
+      allow(subject).to receive_messages(:ds_specs => {'abc' => mock_dsspec})
       subject.configure_datastream(double(:dsid => 'abc'))
     end
 
     it "should be ok if there is no ds spec" do
       mock_dsspec = double()
-      subject.stub(:ds_specs => {})
+      allow(subject).to receive_messages(:ds_specs => {})
       subject.configure_datastream(double(:dsid => 'abc'))
     end
 
     it "should configure RelsExtDatastream" do
       mock_dsspec = { :type => ActiveFedora::RelsExtDatastream }
-      subject.stub(:ds_specs => {'abc' => mock_dsspec})
+      allow(subject).to receive_messages(:ds_specs => {'abc' => mock_dsspec})
 
       ds = double(:dsid => 'abc')
-      ds.should_receive(:model=).with(subject)
+      expect(ds).to receive(:model=).with(subject)
 
       subject.configure_datastream(ds)
     end
@@ -129,7 +129,7 @@ describe ActiveFedora::Datastreams do
       ds = double(:dsid => 'abc')
       @count = 0
       mock_dsspec = { :block => lambda { |x| @count += 1 } }
-      subject.stub(:ds_specs => {'abc' => mock_dsspec})
+      allow(subject).to receive_messages(:ds_specs => {'abc' => mock_dsspec})
 
 
       expect {
@@ -140,7 +140,7 @@ describe ActiveFedora::Datastreams do
 
   describe "#datastream_from_spec" do
     it "should fetch the rubydora datastream" do
-      subject.inner_object.should_receive(:datastream_object_for).with('dsid', {}, {})
+      expect(subject.inner_object).to receive(:datastream_object_for).with('dsid', {}, {})
       subject.datastream_from_spec({}, 'dsid')
     end
   end
@@ -149,12 +149,12 @@ describe ActiveFedora::Datastreams do
     it "should add the datastream to the object" do
       ds = double(:dsid => 'Abc')
       subject.add_datastream(ds)
-      subject.datastreams['Abc'].should == ds
+      expect(subject.datastreams['Abc']).to eq(ds)
     end
 
     it "should mint a dsid" do
       ds = ActiveFedora::Datastream.new(subject.inner_object)
-      subject.add_datastream(ds).should == 'DS1'
+      expect(subject.add_datastream(ds)).to eq('DS1')
     end
   end
 
@@ -165,24 +165,24 @@ describe ActiveFedora::Datastreams do
       ds3 = double(:metadata? => true)
       relsextds = ActiveFedora::RelsExtDatastream.new
       file_ds = double(:metadata? => false)
-      subject.stub(:datastreams => {:a => ds1, :b => ds2, :c => ds3, :d => relsextds, :e => file_ds})
-      subject.metadata_streams.should include(ds1, ds2, ds3)
-      subject.metadata_streams.should_not include(relsextds)
-      subject.metadata_streams.should_not include(file_ds)
+      allow(subject).to receive_messages(:datastreams => {:a => ds1, :b => ds2, :c => ds3, :d => relsextds, :e => file_ds})
+      expect(subject.metadata_streams).to include(ds1, ds2, ds3)
+      expect(subject.metadata_streams).not_to include(relsextds)
+      expect(subject.metadata_streams).not_to include(file_ds)
     end
   end
 
   describe "#relsext" do
     it "should be the RELS-EXT datastream" do
       m = double
-      subject.stub(:datastreams => { 'RELS-EXT' => m})
-      subject.rels_ext.should == m
+      allow(subject).to receive_messages(:datastreams => { 'RELS-EXT' => m})
+      expect(subject.rels_ext).to eq(m)
     end
 
     it "should make one up otherwise" do
-      subject.stub(:datastreams => {})
+      allow(subject).to receive_messages(:datastreams => {})
 
-      subject.rels_ext.should be_a_kind_of(ActiveFedora::RelsExtDatastream)
+      expect(subject.rels_ext).to be_a_kind_of(ActiveFedora::RelsExtDatastream)
     end
   end
 
@@ -193,7 +193,7 @@ describe ActiveFedora::Datastreams do
   describe "#create_datastream" do
     it "should mint a DSID" do
       ds = subject.create_datastream(ActiveFedora::Datastream, nil, {})
-      ds.dsid.should == 'DS1'
+      expect(ds.dsid).to eq('DS1')
     end
 
     it "should raise an argument error if the supplied dsid is nonsense" do
@@ -203,19 +203,19 @@ describe ActiveFedora::Datastreams do
     it "should try to get a mime type from the blob" do
       mock_file = double(:content_type => 'x-application/asdf')
       ds = subject.create_datastream(ActiveFedora::Datastream, nil, {:blob => mock_file})
-      ds.mimeType.should == 'x-application/asdf'
+      expect(ds.mimeType).to eq('x-application/asdf')
     end
 
     it "should provide a default mime type" do
       mock_file = double()
       ds = subject.create_datastream(ActiveFedora::Datastream, nil, {:blob => mock_file})
-      ds.mimeType.should == 'application/octet-stream'
+      expect(ds.mimeType).to eq('application/octet-stream')
     end
 
     it "should use the filename as a default label" do
       mock_file = double(:path => '/asdf/fdsa')
       ds = subject.create_datastream(ActiveFedora::Datastream, nil, {:blob => mock_file})
-      ds.dsLabel.should == 'fdsa'
+      expect(ds.dsLabel).to eq('fdsa')
     end
 
     it "should not set content for controlGroup 'E'" do

--- a/spec/unit/file_configurator_spec.rb
+++ b/spec/unit/file_configurator_spec.rb
@@ -23,7 +23,7 @@ describe ActiveFedora::FileConfigurator do
       subject.reset!
     end
     it "should be an empty hash" do
-      subject.config_options.should == {}
+      expect(subject.config_options).to eq({})
     end
   end
 
@@ -32,7 +32,7 @@ describe ActiveFedora::FileConfigurator do
       subject.reset!
     end
     it "should trigger configuration to load" do
-      subject.should_receive(:load_fedora_config)
+      expect(subject).to receive(:load_fedora_config)
       subject.fedora_config
     end 
   end
@@ -41,7 +41,7 @@ describe ActiveFedora::FileConfigurator do
       subject.reset!
     end
     it "should trigger configuration to load" do
-      subject.should_receive(:load_solr_config)
+      expect(subject).to receive(:load_solr_config)
       subject.solr_config
     end 
   end
@@ -49,13 +49,13 @@ describe ActiveFedora::FileConfigurator do
   describe "#reset!" do
     before { subject.reset! }
     it "should clear @fedora_config" do
-      subject.instance_variable_get(:@fedora_config).should == {} 
+      expect(subject.instance_variable_get(:@fedora_config)).to eq({}) 
     end
     it "should clear @solr_config" do
-      subject.instance_variable_get(:@solr_config).should == {} 
+      expect(subject.instance_variable_get(:@solr_config)).to eq({}) 
     end
     it "should clear @config_options" do
-      subject.instance_variable_get(:@config_options).should == {}
+      expect(subject.instance_variable_get(:@config_options)).to eq({})
     end
   end
 
@@ -63,87 +63,87 @@ describe ActiveFedora::FileConfigurator do
     
     describe "get_config_path(:fedora)" do
       it "should use the config_options[:config_path] if it exists" do
-        subject.should_receive(:config_options).and_return({:fedora_config_path => "/path/to/fedora.yml"})
-        File.should_receive(:file?).with("/path/to/fedora.yml").and_return(true)
-        subject.get_config_path(:fedora).should eql("/path/to/fedora.yml")
+        expect(subject).to receive(:config_options).and_return({:fedora_config_path => "/path/to/fedora.yml"})
+        expect(File).to receive(:file?).with("/path/to/fedora.yml").and_return(true)
+        expect(subject.get_config_path(:fedora)).to eql("/path/to/fedora.yml")
       end
 
       it "should look in Rails.root/config/fedora.yml if it exists and no fedora_config_path passed in" do
-        subject.should_receive(:config_options).and_return({})
+        expect(subject).to receive(:config_options).and_return({})
         stub_rails(:root => "/rails/root")
-        File.should_receive(:file?).with("/rails/root/config/fedora.yml").and_return(true)
-        subject.get_config_path(:fedora).should eql("/rails/root/config/fedora.yml")
+        expect(File).to receive(:file?).with("/rails/root/config/fedora.yml").and_return(true)
+        expect(subject.get_config_path(:fedora)).to eql("/rails/root/config/fedora.yml")
         unstub_rails
       end
 
       it "should look in ./config/fedora.yml if neither rails.root nor :fedora_config_path are set" do
-        subject.should_receive(:config_options).and_return({})
-        Dir.stub(:getwd => "/current/working/directory")
-        File.should_receive(:file?).with("/current/working/directory/config/fedora.yml").and_return(true)
-        subject.get_config_path(:fedora).should eql("/current/working/directory/config/fedora.yml")
+        expect(subject).to receive(:config_options).and_return({})
+        allow(Dir).to receive_messages(:getwd => "/current/working/directory")
+        expect(File).to receive(:file?).with("/current/working/directory/config/fedora.yml").and_return(true)
+        expect(subject.get_config_path(:fedora)).to eql("/current/working/directory/config/fedora.yml")
       end
 
       it "should return default fedora.yml that ships with active-fedora if none of the above" do
-        subject.should_receive(:config_options).and_return({})
-        Dir.should_receive(:getwd).and_return("/current/working/directory")
-        File.should_receive(:file?).with("/current/working/directory/config/fedora.yml").and_return(false)
-        File.should_receive(:file?).with(File.expand_path(File.join(File.dirname("__FILE__"),'config','fedora.yml'))).and_return(true)
+        expect(subject).to receive(:config_options).and_return({})
+        expect(Dir).to receive(:getwd).and_return("/current/working/directory")
+        expect(File).to receive(:file?).with("/current/working/directory/config/fedora.yml").and_return(false)
+        expect(File).to receive(:file?).with(File.expand_path(File.join(File.dirname("__FILE__"),'config','fedora.yml'))).and_return(true)
         expect(ActiveFedora::Base.logger).to receive(:warn).with("Using the default fedora.yml that comes with active-fedora.  If you want to override this, pass the path to fedora.yml to ActiveFedora - ie. ActiveFedora.init(:fedora_config_path => '/path/to/fedora.yml') - or set Rails.root and put fedora.yml into \#{Rails.root}/config.")
-        subject.get_config_path(:fedora).should eql(File.expand_path(File.join(File.dirname("__FILE__"),'config','fedora.yml')))
+        expect(subject.get_config_path(:fedora)).to eql(File.expand_path(File.join(File.dirname("__FILE__"),'config','fedora.yml')))
       end
     end
 
     describe "get_config_path(:predicate_mappings)" do
       it "should use the config_options[:config_path] if it exists" do
-        subject.should_receive(:config_options).and_return({:predicate_mappings_config_path => "/path/to/predicate_mappings.yml"})
-        File.should_receive(:file?).with("/path/to/predicate_mappings.yml").and_return(true)
-        subject.get_config_path(:predicate_mappings).should eql("/path/to/predicate_mappings.yml")
+        expect(subject).to receive(:config_options).and_return({:predicate_mappings_config_path => "/path/to/predicate_mappings.yml"})
+        expect(File).to receive(:file?).with("/path/to/predicate_mappings.yml").and_return(true)
+        expect(subject.get_config_path(:predicate_mappings)).to eql("/path/to/predicate_mappings.yml")
       end
 
       it "should look in Rails.root/config/predicate_mappings.yml if it exists and no predicate_mappings_config_path passed in" do
-        subject.should_receive(:config_options).and_return({})
+        expect(subject).to receive(:config_options).and_return({})
         stub_rails(:root => "/rails/root")
-        File.should_receive(:file?).with("/rails/root/config/predicate_mappings.yml").and_return(true)
-        subject.get_config_path(:predicate_mappings).should eql("/rails/root/config/predicate_mappings.yml")
+        expect(File).to receive(:file?).with("/rails/root/config/predicate_mappings.yml").and_return(true)
+        expect(subject.get_config_path(:predicate_mappings)).to eql("/rails/root/config/predicate_mappings.yml")
         unstub_rails
       end
 
       it "should look in ./config/predicate_mappings.yml if neither rails.root nor :predicate_mappings_config_path are set" do
-        subject.should_receive(:config_options).and_return({})
-        Dir.stub(:getwd => "/current/working/directory")
-        File.should_receive(:file?).with("/current/working/directory/config/predicate_mappings.yml").and_return(true)
-        subject.get_config_path(:predicate_mappings).should eql("/current/working/directory/config/predicate_mappings.yml")
+        expect(subject).to receive(:config_options).and_return({})
+        allow(Dir).to receive_messages(:getwd => "/current/working/directory")
+        expect(File).to receive(:file?).with("/current/working/directory/config/predicate_mappings.yml").and_return(true)
+        expect(subject.get_config_path(:predicate_mappings)).to eql("/current/working/directory/config/predicate_mappings.yml")
       end
 
       it "should return default predicate_mappings.yml that ships with active-fedora if none of the above" do
-        subject.should_receive(:config_options).and_return({})
-        Dir.should_receive(:getwd).and_return("/current/working/directory")
-        File.should_receive(:file?).with("/current/working/directory/config/predicate_mappings.yml").and_return(false)
-        File.should_receive(:file?).with(File.expand_path(File.join(File.dirname("__FILE__"),'config','predicate_mappings.yml'))).and_return(true)
+        expect(subject).to receive(:config_options).and_return({})
+        expect(Dir).to receive(:getwd).and_return("/current/working/directory")
+        expect(File).to receive(:file?).with("/current/working/directory/config/predicate_mappings.yml").and_return(false)
+        expect(File).to receive(:file?).with(File.expand_path(File.join(File.dirname("__FILE__"),'config','predicate_mappings.yml'))).and_return(true)
         expect(ActiveFedora::Base.logger).to receive(:warn).with("Using the default predicate_mappings.yml that comes with active-fedora.  If you want to override this, pass the path to predicate_mappings.yml to ActiveFedora - ie. ActiveFedora.init(:predicate_mappings_config_path => '/path/to/predicate_mappings.yml') - or set Rails.root and put predicate_mappings.yml into \#{Rails.root}/config.")
-        subject.get_config_path(:predicate_mappings).should eql(File.expand_path(File.join(File.dirname("__FILE__"),'config','predicate_mappings.yml')))
+        expect(subject.get_config_path(:predicate_mappings)).to eql(File.expand_path(File.join(File.dirname("__FILE__"),'config','predicate_mappings.yml')))
       end
     end
 
     describe "get_config_path(:solr)" do
       it "should return the solr_config_path if set in config_options hash" do
-        subject.stub(:config_options => {:solr_config_path => "/path/to/solr.yml"})
-        File.should_receive(:file?).with("/path/to/solr.yml").and_return(true)
-        subject.get_config_path(:solr).should eql("/path/to/solr.yml")
+        allow(subject).to receive_messages(:config_options => {:solr_config_path => "/path/to/solr.yml"})
+        expect(File).to receive(:file?).with("/path/to/solr.yml").and_return(true)
+        expect(subject.get_config_path(:solr)).to eql("/path/to/solr.yml")
       end
       
       it "should return the solr.yml file in the same directory as the fedora.yml if it exists" do
-        subject.should_receive(:path).and_return("/path/to/fedora/config/fedora.yml")
-        File.should_receive(:file?).with("/path/to/fedora/config/solr.yml").and_return(true)
-        subject.get_config_path(:solr).should eql("/path/to/fedora/config/solr.yml")
+        expect(subject).to receive(:path).and_return("/path/to/fedora/config/fedora.yml")
+        expect(File).to receive(:file?).with("/path/to/fedora/config/solr.yml").and_return(true)
+        expect(subject.get_config_path(:solr)).to eql("/path/to/fedora/config/solr.yml")
       end
       
       context "no solr.yml in same directory as fedora.yml and fedora.yml does not contain solr url" do
 
         before :each do
-          subject.stub(:config_options => {})
-          subject.should_receive(:path).and_return("/path/to/fedora/config/fedora.yml")
-          File.should_receive(:file?).with("/path/to/fedora/config/solr.yml").and_return(false)
+          allow(subject).to receive_messages(:config_options => {})
+          expect(subject).to receive(:path).and_return("/path/to/fedora/config/fedora.yml")
+          expect(File).to receive(:file?).with("/path/to/fedora/config/solr.yml").and_return(false)
         end
         after :each do
           unstub_rails
@@ -151,22 +151,22 @@ describe ActiveFedora::FileConfigurator do
 
         it "should not raise an error if there is not a solr.yml in the same directory as the fedora.yml and the fedora.yml has a solr url defined and look in rails.root" do
           stub_rails(:root=>"/rails/root")
-          File.should_receive(:file?).with("/rails/root/config/solr.yml").and_return(true)
-          subject.get_config_path(:solr).should eql("/rails/root/config/solr.yml")
+          expect(File).to receive(:file?).with("/rails/root/config/solr.yml").and_return(true)
+          expect(subject.get_config_path(:solr)).to eql("/rails/root/config/solr.yml")
         end
 
         it "should look in ./config/solr.yml if no rails root" do
-          Dir.stub(:getwd => "/current/working/directory")
-          File.should_receive(:file?).with("/current/working/directory/config/solr.yml").and_return(true)
-          subject.get_config_path(:solr).should eql("/current/working/directory/config/solr.yml")
+          allow(Dir).to receive_messages(:getwd => "/current/working/directory")
+          expect(File).to receive(:file?).with("/current/working/directory/config/solr.yml").and_return(true)
+          expect(subject.get_config_path(:solr)).to eql("/current/working/directory/config/solr.yml")
         end
 
         it "should return the default solr.yml file that ships with active-fedora if no other option is set" do
-          Dir.stub(:getwd => "/current/working/directory")
-          File.should_receive(:file?).with("/current/working/directory/config/solr.yml").and_return(false)
-          File.should_receive(:file?).with(File.expand_path(File.join(File.dirname("__FILE__"),'config','solr.yml'))).and_return(true)
+          allow(Dir).to receive_messages(:getwd => "/current/working/directory")
+          expect(File).to receive(:file?).with("/current/working/directory/config/solr.yml").and_return(false)
+          expect(File).to receive(:file?).with(File.expand_path(File.join(File.dirname("__FILE__"),'config','solr.yml'))).and_return(true)
           expect(ActiveFedora::Base.logger).to receive(:warn).with("Using the default solr.yml that comes with active-fedora.  If you want to override this, pass the path to solr.yml to ActiveFedora - ie. ActiveFedora.init(:solr_config_path => '/path/to/solr.yml') - or set Rails.root and put solr.yml into \#{Rails.root}/config.")
-          subject.get_config_path(:solr).should eql(File.expand_path(File.join(File.dirname("__FILE__"),'config','solr.yml')))
+          expect(subject.get_config_path(:solr)).to eql(File.expand_path(File.join(File.dirname("__FILE__"),'config','solr.yml')))
         end
       end
 
@@ -177,30 +177,30 @@ describe ActiveFedora::FileConfigurator do
         subject.reset!
       end
       it "should load the file specified in fedora_config_path" do
-        subject.stub(:load_solrizer_config)
-        subject.should_receive(:get_config_path).with(:fedora).and_return("/path/to/fedora.yml")
-        subject.should_receive(:load_solr_config)
-        IO.should_receive(:read).with("/path/to/fedora.yml").and_return("development:\n url: http://devfedora:8983\ntest:\n  url: http://myfedora:8080")
-        subject.load_fedora_config.should == {:url=>"http://myfedora:8080"}
-        subject.fedora_config.should == {:url=>"http://myfedora:8080"}
+        allow(subject).to receive(:load_solrizer_config)
+        expect(subject).to receive(:get_config_path).with(:fedora).and_return("/path/to/fedora.yml")
+        expect(subject).to receive(:load_solr_config)
+        expect(IO).to receive(:read).with("/path/to/fedora.yml").and_return("development:\n url: http://devfedora:8983\ntest:\n  url: http://myfedora:8080")
+        expect(subject.load_fedora_config).to eq({:url=>"http://myfedora:8080"})
+        expect(subject.fedora_config).to eq({:url=>"http://myfedora:8080"})
       end
 
       it "should allow sharding" do
-        subject.stub(:load_solrizer_config)
-        subject.should_receive(:get_config_path).with(:fedora).and_return("/path/to/fedora.yml")
-        subject.should_receive(:load_solr_config)
-        IO.should_receive(:read).with("/path/to/fedora.yml").and_return("development:\n  url: http://devfedora:8983\ntest:\n- url: http://myfedora:8080\n- url: http://myfedora:8081")
-        subject.load_fedora_config.should == [{:url=>"http://myfedora:8080"}, {:url=>"http://myfedora:8081"}]
-        subject.fedora_config.should == [{:url=>"http://myfedora:8080"}, {:url=>"http://myfedora:8081"}]
+        allow(subject).to receive(:load_solrizer_config)
+        expect(subject).to receive(:get_config_path).with(:fedora).and_return("/path/to/fedora.yml")
+        expect(subject).to receive(:load_solr_config)
+        expect(IO).to receive(:read).with("/path/to/fedora.yml").and_return("development:\n  url: http://devfedora:8983\ntest:\n- url: http://myfedora:8080\n- url: http://myfedora:8081")
+        expect(subject.load_fedora_config).to eq([{:url=>"http://myfedora:8080"}, {:url=>"http://myfedora:8081"}])
+        expect(subject.fedora_config).to eq([{:url=>"http://myfedora:8080"}, {:url=>"http://myfedora:8081"}])
       end
 
       it "should parse the file using ERb" do
-        subject.stub(:load_solrizer_config)
-        subject.should_receive(:get_config_path).with(:fedora).and_return("/path/to/fedora.yml")
-        subject.should_receive(:load_solr_config)
-        IO.should_receive(:read).with("/path/to/fedora.yml").and_return("development:\n  url: http://devfedora:<%= 8983 %>\ntest:\n  url: http://myfedora:<%= 8081 %>")
-        subject.load_fedora_config.should == {:url=>"http://myfedora:8081"}
-        subject.fedora_config.should == {:url=>"http://myfedora:8081"}
+        allow(subject).to receive(:load_solrizer_config)
+        expect(subject).to receive(:get_config_path).with(:fedora).and_return("/path/to/fedora.yml")
+        expect(subject).to receive(:load_solr_config)
+        expect(IO).to receive(:read).with("/path/to/fedora.yml").and_return("development:\n  url: http://devfedora:<%= 8983 %>\ntest:\n  url: http://myfedora:<%= 8081 %>")
+        expect(subject.load_fedora_config).to eq({:url=>"http://myfedora:8081"})
+        expect(subject.fedora_config).to eq({:url=>"http://myfedora:8081"})
       end
     end
 
@@ -209,21 +209,21 @@ describe ActiveFedora::FileConfigurator do
         subject.reset!
       end
       it "should load the file specified in solr_config_path" do
-        subject.stub(:load_solrizer_config)
-        subject.should_receive(:get_config_path).with(:solr).and_return("/path/to/solr.yml")
-        subject.should_receive(:load_fedora_config)
-        IO.should_receive(:read).with("/path/to/solr.yml").and_return("development:\n  default:\n    url: http://devsolr:8983\ntest:\n  default:\n    url: http://mysolr:8080")
-        subject.load_solr_config.should == {:url=>"http://mysolr:8080"}
-        subject.solr_config.should == {:url=>"http://mysolr:8080"}
+        allow(subject).to receive(:load_solrizer_config)
+        expect(subject).to receive(:get_config_path).with(:solr).and_return("/path/to/solr.yml")
+        expect(subject).to receive(:load_fedora_config)
+        expect(IO).to receive(:read).with("/path/to/solr.yml").and_return("development:\n  default:\n    url: http://devsolr:8983\ntest:\n  default:\n    url: http://mysolr:8080")
+        expect(subject.load_solr_config).to eq({:url=>"http://mysolr:8080"})
+        expect(subject.solr_config).to eq({:url=>"http://mysolr:8080"})
       end
 
       it "should parse the file using ERb" do
-        subject.stub(:load_solrizer_config)
-        subject.should_receive(:get_config_path).with(:solr).and_return("/path/to/solr.yml")
-        subject.should_receive(:load_fedora_config)
-        IO.should_receive(:read).with("/path/to/solr.yml").and_return("development:\n  default:\n    url: http://devsolr:<%= 8983 %>\ntest:\n  default:\n    url: http://mysolr:<%= 8081 %>")
-        subject.load_solr_config.should == {:url=>"http://mysolr:8081"}
-        subject.solr_config.should == {:url=>"http://mysolr:8081"}
+        allow(subject).to receive(:load_solrizer_config)
+        expect(subject).to receive(:get_config_path).with(:solr).and_return("/path/to/solr.yml")
+        expect(subject).to receive(:load_fedora_config)
+        expect(IO).to receive(:read).with("/path/to/solr.yml").and_return("development:\n  default:\n    url: http://devsolr:<%= 8983 %>\ntest:\n  default:\n    url: http://mysolr:<%= 8081 %>")
+        expect(subject.load_solr_config).to eq({:url=>"http://mysolr:8081"})
+        expect(subject.solr_config).to eq({:url=>"http://mysolr:8081"})
       end
     end
 
@@ -233,9 +233,9 @@ describe ActiveFedora::FileConfigurator do
           subject.instance_variable_set :@config_loaded, nil
         end
         it "should load the fedora and solr configs" do
-          subject.config_loaded?.should be_false
+          expect(subject.config_loaded?).to be_falsey
           subject.load_configs
-          subject.config_loaded?.should be_true
+          expect(subject.config_loaded?).to be_truthy
         end
       end
       describe "when config is loaded" do
@@ -243,24 +243,24 @@ describe ActiveFedora::FileConfigurator do
           subject.instance_variable_set :@config_loaded, true
         end
         it "should load the fedora and solr configs" do
-          subject.should_receive(:load_config).never
-          subject.config_loaded?.should be_true
+          expect(subject).to receive(:load_config).never
+          expect(subject.config_loaded?).to be_truthy
           subject.load_configs
-          subject.config_loaded?.should be_true
+          expect(subject.config_loaded?).to be_truthy
         end
       end
     end
 
     describe "check_fedora_path_for_solr" do
       it "should find the solr.yml file and return it if it exists" do
-        subject.should_receive(:path).and_return("/path/to/fedora/fedora.yml")
-        File.should_receive(:file?).with("/path/to/fedora/solr.yml").and_return(true)
-        subject.check_fedora_path_for_solr.should == "/path/to/fedora/solr.yml"
+        expect(subject).to receive(:path).and_return("/path/to/fedora/fedora.yml")
+        expect(File).to receive(:file?).with("/path/to/fedora/solr.yml").and_return(true)
+        expect(subject.check_fedora_path_for_solr).to eq("/path/to/fedora/solr.yml")
       end
       it "should return nil if the solr.yml file is not there" do
-        subject.should_receive(:path).and_return("/path/to/fedora/fedora.yml")
-        File.should_receive(:file?).with("/path/to/fedora/solr.yml").and_return(false)
-        subject.check_fedora_path_for_solr.should be_nil
+        expect(subject).to receive(:path).and_return("/path/to/fedora/fedora.yml")
+        expect(File).to receive(:file?).with("/path/to/fedora/solr.yml").and_return(false)
+        expect(subject.check_fedora_path_for_solr).to be_nil
       end
     end
   end
@@ -280,29 +280,29 @@ describe ActiveFedora::FileConfigurator do
   
     it "can tell its config paths" do
       subject.init
-      subject.should respond_to(:solr_config_path)
+      expect(subject).to respond_to(:solr_config_path)
     end
     it "loads a config from the current working directory as a second choice" do
-      subject.stub(:load_solrizer_config)
-      Dir.stub(:getwd).and_return(@fake_rails_root)
+      allow(subject).to receive(:load_solrizer_config)
+      allow(Dir).to receive(:getwd).and_return(@fake_rails_root)
       subject.init
-      subject.get_config_path(:fedora).should eql("#{@fake_rails_root}/config/fedora.yml")
-      subject.solr_config_path.should eql("#{@fake_rails_root}/config/solr.yml")
+      expect(subject.get_config_path(:fedora)).to eql("#{@fake_rails_root}/config/fedora.yml")
+      expect(subject.solr_config_path).to eql("#{@fake_rails_root}/config/solr.yml")
     end
     it "loads the config that ships with this gem as a last choice" do
-      Dir.stub(:getwd).and_return("/fake/path")
-      subject.stub(:load_solrizer_config)
+      allow(Dir).to receive(:getwd).and_return("/fake/path")
+      allow(subject).to receive(:load_solrizer_config)
       expect(ActiveFedora::Base.logger).to receive(:warn).with("Using the default fedora.yml that comes with active-fedora.  If you want to override this, pass the path to fedora.yml to ActiveFedora - ie. ActiveFedora.init(:fedora_config_path => '/path/to/fedora.yml') - or set Rails.root and put fedora.yml into \#{Rails.root}/config.").exactly(3).times
       subject.init
       expected_config = File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config"))
-      subject.get_config_path(:fedora).should eql(expected_config+'/fedora.yml')
-      subject.solr_config_path.should eql(expected_config+'/solr.yml')
+      expect(subject.get_config_path(:fedora)).to eql(expected_config+'/fedora.yml')
+      expect(subject.solr_config_path).to eql(expected_config+'/solr.yml')
     end
     it "raises an error if you pass in a string" do
-      lambda{ subject.init("#{@fake_rails_root}/config/fake_fedora.yml") }.should raise_exception(ArgumentError)
+      expect{ subject.init("#{@fake_rails_root}/config/fake_fedora.yml") }.to raise_exception(ArgumentError)
     end
     it "raises an error if you pass in a non-existant config file" do
-      lambda{ subject.init(:fedora_config_path=>"really_fake_fedora.yml") }.should raise_exception(ActiveFedora::ConfigurationError)
+      expect{ subject.init(:fedora_config_path=>"really_fake_fedora.yml") }.to raise_exception(ActiveFedora::ConfigurationError)
     end
     
     describe "within Rails" do
@@ -315,16 +315,16 @@ describe ActiveFedora::FileConfigurator do
       end
       
       it "loads a config from Rails.root as a first choice" do
-        subject.stub(:load_solrizer_config)
+        allow(subject).to receive(:load_solrizer_config)
         subject.init
-        subject.get_config_path(:fedora).should eql("#{Rails.root}/config/fedora.yml")
-        subject.solr_config_path.should eql("#{Rails.root}/config/solr.yml")
+        expect(subject.get_config_path(:fedora)).to eql("#{Rails.root}/config/fedora.yml")
+        expect(subject.solr_config_path).to eql("#{Rails.root}/config/solr.yml")
       end
       
       it "can tell what environment it is set to run in" do
         stub_rails(:env=>"development")
         subject.init
-        ActiveFedora.environment.should eql("development")
+        expect(ActiveFedora.environment).to eql("development")
       end
       
     end
@@ -334,7 +334,7 @@ describe ActiveFedora::FileConfigurator do
   
   describe ".build_predicate_config_path" do
     it "should return the path to the default config/predicate_mappings.yml if no valid path is given" do
-      subject.send(:build_predicate_config_path).should == default_predicate_mapping_file
+      expect(subject.send(:build_predicate_config_path)).to eq(default_predicate_mapping_file)
     end
   end
 
@@ -343,29 +343,29 @@ describe ActiveFedora::FileConfigurator do
       subject.instance_variable_set :@config_loaded, nil
     end
     it "should return the default mapping if it has not been initialized" do
-      subject.predicate_config().should == Psych.load(File.read(default_predicate_mapping_file))
+      expect(subject.predicate_config()).to eq(Psych.load(File.read(default_predicate_mapping_file)))
     end
   end
 
   describe ".valid_predicate_mapping" do
     it "should return true if the predicate mapping has the appropriate keys and value types" do
-      subject.send(:valid_predicate_mapping?,default_predicate_mapping_file).should be_true
+      expect(subject.send(:valid_predicate_mapping?,default_predicate_mapping_file)).to be_truthy
     end
     it "should return false if the mapping is missing the :default_namespace" do
       mock_yaml({:default_namespace0=>"my_namespace",:predicate_mapping=>{:key0=>"value0", :key1=>"value1"}},"/path/to/predicate_mappings.yml")
-      subject.send(:valid_predicate_mapping?,"/path/to/predicate_mappings.yml").should be_false
+      expect(subject.send(:valid_predicate_mapping?,"/path/to/predicate_mappings.yml")).to be_falsey
     end
     it "should return false if the :default_namespace is not a string" do
       mock_yaml({:default_namespace=>{:foo=>"bar"}, :predicate_mapping=>{:key0=>"value0", :key1=>"value1"}},"/path/to/predicate_mappings.yml")
-      subject.send(:valid_predicate_mapping?,"/path/to/predicate_mappings.yml").should be_false
+      expect(subject.send(:valid_predicate_mapping?,"/path/to/predicate_mappings.yml")).to be_falsey
     end
     it "should return false if the :predicate_mappings key is missing" do
       mock_yaml({:default_namespace=>"a string"},"/path/to/predicate_mappings.yml")
-      subject.send(:valid_predicate_mapping?,"/path/to/predicate_mappings.yml").should be_false
+      expect(subject.send(:valid_predicate_mapping?,"/path/to/predicate_mappings.yml")).to be_falsey
     end
     it "should return false if the :predicate_mappings key is not a hash" do
       mock_yaml({:default_namespace=>"a string",:predicate_mapping=>"another string"},"/path/to/predicate_mappings.yml")
-      subject.send(:valid_predicate_mapping?,"/path/to/predicate_mappings.yml").should be_false
+      expect(subject.send(:valid_predicate_mapping?,"/path/to/predicate_mappings.yml")).to be_falsey
     end
 
   end

--- a/spec/unit/has_and_belongs_to_many_collection_spec.rb
+++ b/spec/unit/has_and_belongs_to_many_collection_spec.rb
@@ -15,15 +15,15 @@ describe ActiveFedora::Associations::HasAndBelongsToManyAssociation do
 
   it "should call add_relationship" do
     subject = Book.new(pid: 'subject:a')
-    subject.stub(:new_record? => false, save: true)
+    allow(subject).to receive_messages(:new_record? => false, save: true)
     predicate = Book.create_reflection(:has_and_belongs_to_many, 'pages', {:property=>'predicate'}, nil)
-    ActiveFedora::SolrService.stub(:query).and_return([])
+    allow(ActiveFedora::SolrService).to receive(:query).and_return([])
     ac = ActiveFedora::Associations::HasAndBelongsToManyAssociation.new(subject, predicate)
-    ac.should_receive(:callback).twice
+    expect(ac).to receive(:callback).twice
     object = Page.new(:pid => 'object:b')
-    object.stub(:new_record? => false, save: true)
+    allow(object).to receive_messages(:new_record? => false, save: true)
   
-    subject.should_receive(:add_relationship).with('predicate', object)
+    expect(subject).to receive(:add_relationship).with('predicate', object)
  
     ac << object
 
@@ -31,17 +31,17 @@ describe ActiveFedora::Associations::HasAndBelongsToManyAssociation do
 
   it "should call add_relationship on subject and object when inverse_of given" do
     subject = Book.new(pid: 'subject:a')
-    subject.stub(:new_record? => false, save: true)
+    allow(subject).to receive_messages(:new_record? => false, save: true)
     predicate = Book.create_reflection(:has_and_belongs_to_many, 'pages', {:property=>'predicate', :inverse_of => 'inverse_predicate'}, nil)
-    ActiveFedora::SolrService.stub(:query).and_return([])
+    allow(ActiveFedora::SolrService).to receive(:query).and_return([])
     ac = ActiveFedora::Associations::HasAndBelongsToManyAssociation.new(subject, predicate)
-    ac.should_receive(:callback).twice
+    expect(ac).to receive(:callback).twice
     object = Page.new(:pid => 'object:b')
-    object.stub(:new_record? => false, save: true)
+    allow(object).to receive_messages(:new_record? => false, save: true)
   
-    subject.should_receive(:add_relationship).with('predicate', object)
+    expect(subject).to receive(:add_relationship).with('predicate', object)
  
-    object.should_receive(:add_relationship).with('inverse_predicate', subject)
+    expect(object).to receive(:add_relationship).with('inverse_predicate', subject)
  
     ac << object
 
@@ -50,15 +50,15 @@ describe ActiveFedora::Associations::HasAndBelongsToManyAssociation do
   it "should call solr query multiple times" do
 
     subject = Book.new(pid: 'subject:a')
-    subject.stub(:new_record? => false, save: true)
+    allow(subject).to receive_messages(:new_record? => false, save: true)
     predicate = Book.create_reflection(:has_and_belongs_to_many, 'pages', {:property=>'predicate', :solr_page_size => 10}, nil)
     ids = []
     0.upto(15) {|i| ids << i.to_s}
     query1 = ids.slice(0,10).map {|i| "_query_:\"{!raw f=id}#{i}\""}.join(" OR ")
     query2 = ids.slice(10,10).map {|i| "_query_:\"{!raw f=id}#{i}\""}.join(" OR ")
-    subject.should_receive(:ids_for_outbound).and_return(ids)
-    ActiveFedora::SolrService.should_receive(:query).with(query1, {:rows=>10}).and_return([])
-    ActiveFedora::SolrService.should_receive(:query).with(query2, {:rows=>10}).and_return([])
+    expect(subject).to receive(:ids_for_outbound).and_return(ids)
+    expect(ActiveFedora::SolrService).to receive(:query).with(query1, {:rows=>10}).and_return([])
+    expect(ActiveFedora::SolrService).to receive(:query).with(query2, {:rows=>10}).and_return([])
 
     ac = ActiveFedora::Associations::HasAndBelongsToManyAssociation.new(subject, predicate)
     ac.find_target

--- a/spec/unit/has_many_collection_spec.rb
+++ b/spec/unit/has_many_collection_spec.rb
@@ -15,18 +15,18 @@ describe ActiveFedora::Associations::HasManyAssociation do
 
   subject { Book.new(pid: 'subject:a') }
   before {
-    subject.stub(:new_record? => false, save: true)
+    allow(subject).to receive_messages(:new_record? => false, save: true)
   }
 
   it "should call add_relationship" do
     reflection = Book.create_reflection(:has_many, 'pages', {:property=>'predicate'}, Book)
-    ActiveFedora::SolrService.stub(:query).and_return([])
+    allow(ActiveFedora::SolrService).to receive(:query).and_return([])
     ac = ActiveFedora::Associations::HasManyAssociation.new(subject, reflection)
-    ac.should_receive(:callback).twice
+    expect(ac).to receive(:callback).twice
     object = Page.new(:pid => 'object:b')
-    object.stub(:new_record? => false, save: true)
+    allow(object).to receive_messages(:new_record? => false, save: true)
   
-    object.should_receive(:add_relationship).with('predicate', subject)
+    expect(object).to receive(:add_relationship).with('predicate', subject)
  
     ac << object
 

--- a/spec/unit/inheritance_spec.rb
+++ b/spec/unit/inheritance_spec.rb
@@ -17,17 +17,17 @@ describe ActiveFedora::Base do
 
   it "doesn't overwrite stream specs" do
     f = Foo.new
-    f.datastreams.size.should == 3
+    expect(f.datastreams.size).to eq(3)
     streams = f.datastreams.values.map{|x| x.class.to_s}.sort
-    streams.pop.should == "ActiveFedora::SimpleDatastream"
-    streams.pop.should == "ActiveFedora::RelsExtDatastream"
-    streams.pop.should == "ActiveFedora::QualifiedDublinCoreDatastream"
+    expect(streams.pop).to eq("ActiveFedora::SimpleDatastream")
+    expect(streams.pop).to eq("ActiveFedora::RelsExtDatastream")
+    expect(streams.pop).to eq("ActiveFedora::QualifiedDublinCoreDatastream")
   end
 
   it "should work for multiple types" do
     b = Foo.new
     f = Bar.new
-    b.class.ds_specs.should_not == f.class.ds_specs
+    expect(b.class.ds_specs).not_to eq(f.class.ds_specs)
   end
   after do
     Object.send(:remove_const, :Bar)

--- a/spec/unit/model_spec.rb
+++ b/spec/unit/model_spec.rb
@@ -20,11 +20,11 @@ describe ActiveFedora::Model do
       SpecModel::Basic.solr_query_handler = 'standard'
     end
     it "should have a default" do
-      SpecModel::Basic.solr_query_handler.should == 'standard'
+      expect(SpecModel::Basic.solr_query_handler).to eq('standard')
     end
     it "should be settable" do
       SpecModel::Basic.solr_query_handler = 'search'
-      SpecModel::Basic.solr_query_handler.should == 'search'
+      expect(SpecModel::Basic.solr_query_handler).to eq('search')
     end
   end
   
@@ -44,13 +44,13 @@ describe ActiveFedora::Model do
   
     describe ".classname_from_uri" do 
       it "should turn an afmodel URI into a Model class name" do
-        ActiveFedora::Model.classname_from_uri('info:fedora/afmodel:SpecModel_CamelCased').should == ['SpecModel::CamelCased', 'afmodel']
+        expect(ActiveFedora::Model.classname_from_uri('info:fedora/afmodel:SpecModel_CamelCased')).to eq(['SpecModel::CamelCased', 'afmodel'])
       end
       it "should not change plurality" do
-        ActiveFedora::Model.classname_from_uri('info:fedora/afmodel:MyMetadata').should == ['MyMetadata', 'afmodel']
+        expect(ActiveFedora::Model.classname_from_uri('info:fedora/afmodel:MyMetadata')).to eq(['MyMetadata', 'afmodel'])
       end
       it "should capitalize the first letter" do
-        ActiveFedora::Model.classname_from_uri('info:fedora/afmodel:image').should == ['Image', 'afmodel']
+        expect(ActiveFedora::Model.classname_from_uri('info:fedora/afmodel:image')).to eq(['Image', 'afmodel'])
       end
     end
   end

--- a/spec/unit/nom_datastream_spec.rb
+++ b/spec/unit/nom_datastream_spec.rb
@@ -15,16 +15,16 @@ describe ActiveFedora::NomDatastream do
     }
 
     it "should work" do
-      subject.a.should include("123")
+      expect(subject.a).to include("123")
     end
 
     it "should to_solr" do
-      subject.to_solr['a_s'].should include('123')
-      subject.to_solr['b_s'].should include('asdf')
+      expect(subject.to_solr['a_s']).to include('123')
+      expect(subject.to_solr['b_s']).to include('asdf')
     end
 
     it "should be a managed datastream" do
-      subject.controlGroup.should == 'M'
+      expect(subject.controlGroup).to eq('M')
     end
   end
 
@@ -54,7 +54,7 @@ describe ActiveFedora::NomDatastream do
     }
 
     it "should scope #a attribute to only the dc namespace" do
-      subject.a.should == ["123"]
+      expect(subject.a).to eq(["123"])
     end
 
   end

--- a/spec/unit/ntriples_datastream_spec.rb
+++ b/spec/unit/ntriples_datastream_spec.rb
@@ -19,59 +19,59 @@ describe ActiveFedora::NtriplesRDFDatastream do
       Object.send(:remove_const, :MyDatastream)
     end
     it "should have a subject" do
-      @subject.rdf_subject.should == "info:fedora/test:1"
+      expect(@subject.rdf_subject).to eq("info:fedora/test:1")
     end
     it "should have controlGroup" do
-      @subject.controlGroup.should == 'M'
+      expect(@subject.controlGroup).to eq('M')
     end
     it "should have mimeType" do
-      @subject.mimeType.should == 'application/n-triples'
+      expect(@subject.mimeType).to eq('application/n-triples')
     end
     it "should have dsid" do
-      @subject.dsid.should == 'descMetadata'
+      expect(@subject.dsid).to eq('descMetadata')
     end
     it "should have fields" do
-      @subject.created.should == [Date.parse('2010-12-31')]
-      @subject.title.should == ["Title of work"]
-      @subject.publisher.should == ["Penn State"]
-      @subject.based_near.should == ["New York, NY, US"]
-      @subject.related_url.length.should == 1
-      @subject.related_url.first.rdf_subject.should == "http://google.com/"
+      expect(@subject.created).to eq([Date.parse('2010-12-31')])
+      expect(@subject.title).to eq(["Title of work"])
+      expect(@subject.publisher).to eq(["Penn State"])
+      expect(@subject.based_near).to eq(["New York, NY, US"])
+      expect(@subject.related_url.length).to eq(1)
+      expect(@subject.related_url.first.rdf_subject).to eq("http://google.com/")
     end
 
     it "should be able to call enumerable methods on the fields" do
-      @subject.title.join(', ').should == "Title of work"
-      @subject.title.count.should == 1
-      @subject.title.size.should == 1
-      @subject.title[0].should == "Title of work"
-      @subject.title.to_a.should == ["Title of work"]
+      expect(@subject.title.join(', ')).to eq("Title of work")
+      expect(@subject.title.count).to eq(1)
+      expect(@subject.title.size).to eq(1)
+      expect(@subject.title[0]).to eq("Title of work")
+      expect(@subject.title.to_a).to eq(["Title of work"])
       val = []
       @subject.title.each_with_index {|v, i| val << "#{i}. #{v}"}
-      val.should == ["0. Title of work"]
+      expect(val).to eq(["0. Title of work"])
     end
 
     it "should return fields that are not TermProxies" do
-      @subject.created.should be_kind_of Array
+      expect(@subject.created).to be_kind_of Array
     end
     it "should have method missing" do
-      lambda{@subject.frank}.should raise_exception NoMethodError
+      expect{@subject.frank}.to raise_exception NoMethodError
     end
 
     it "should set fields" do
       @subject.publisher = "St. Martin's Press"
-      @subject.publisher.should == ["St. Martin's Press"]
+      expect(@subject.publisher).to eq(["St. Martin's Press"])
     end
     it "should set rdf literal fields" do
       @subject.creator = RDF.Literal("Geoff Ryman")
-      @subject.creator.should == ["Geoff Ryman"]
+      expect(@subject.creator).to eq(["Geoff Ryman"])
     end
     it "should append fields" do
       @subject.publisher << "St. Martin's Press"
-      @subject.publisher.should == ["Penn State", "St. Martin's Press"]
+      expect(@subject.publisher).to eq(["Penn State", "St. Martin's Press"])
     end
     it "should delete fields" do
       @subject.related_url.delete(RDF::URI("http://google.com/"))
-      @subject.related_url.should == []
+      expect(@subject.related_url).to eq([])
     end
   end
 
@@ -81,8 +81,8 @@ describe ActiveFedora::NtriplesRDFDatastream do
       @two = ActiveFedora::RDFDatastream.new('fakepid', 'myQuix')
     end
     it "should generate predictable prexies" do
-      @one.apply_prefix("baz").should == 'my_foobar__baz'
-      @two.apply_prefix("baz").should == 'my_quix__baz'
+      expect(@one.apply_prefix("baz")).to eq('my_foobar__baz')
+      expect(@two.apply_prefix("baz")).to eq('my_quix__baz')
     end
   end
 
@@ -98,8 +98,8 @@ describe ActiveFedora::NtriplesRDFDatastream do
       end
       @inner_object = double('inner object', pid: 'test:1', :new_record? => true)
       @subject = MyDatastream.new(@inner_object, 'mixed_rdf')
-      @subject.stub(pid: 'test:1')
-      @subject.stub(:new_record? => false)
+      allow(@subject).to receive_messages(pid: 'test:1')
+      allow(@subject).to receive_messages(:new_record? => false)
       @subject.content = File.new('spec/fixtures/mixed_rdf_descMetadata.nt').read
     end
 
@@ -108,11 +108,11 @@ describe ActiveFedora::NtriplesRDFDatastream do
     end
 
     it "should have fields" do
-      @subject.title.should == ["Title of datastream"]
+      expect(@subject.title).to eq(["Title of datastream"])
     end
 
     it "should have a custom subject" do
-      @subject.rdf_subject.should == 'info:fedora/test:1/content'
+      expect(@subject.rdf_subject).to eq('info:fedora/test:1/content')
     end
   end
 
@@ -122,17 +122,17 @@ describe ActiveFedora::NtriplesRDFDatastream do
         property :publisher, predicate: RDF::DC.publisher
       end
       @subject = MyDatastream.new(@inner_object, 'mixed_rdf')
-      @subject.stub(pid: 'test:1', repository: ActiveFedora::Base.connection_for_pid(0))
+      allow(@subject).to receive_messages(pid: 'test:1', repository: ActiveFedora::Base.connection_for_pid(0))
     end
     after(:each) do
       Object.send(:remove_const, :MyDatastream)
     end
     it "should support to_s method" do
-      @subject.publisher.to_s.should == [].to_s
+      expect(@subject.publisher.to_s).to eq([].to_s)
       @subject.publisher = "Bob"
-      @subject.publisher.to_s.should == ["Bob"].to_s
+      expect(@subject.publisher.to_s).to eq(["Bob"].to_s)
       @subject.publisher << "Jim"
-      @subject.publisher.to_s.should == ["Bob", "Jim"].to_s
+      expect(@subject.publisher.to_s).to eq(["Bob", "Jim"].to_s)
     end
  end
 
@@ -166,12 +166,12 @@ describe ActiveFedora::NtriplesRDFDatastream do
       Object.send(:remove_const, :MyDatastream)
     end
     before(:each) do
-      @subject.stub(pid: 'test:1')
+      allow(@subject).to receive_messages(pid: 'test:1')
       @subject.serialize
     end
     it "should provide .to_solr and return a SolrDocument" do
-      @subject.should respond_to(:to_solr)
-      @subject.to_solr.should be_kind_of(Hash)
+      expect(@subject).to respond_to(:to_solr)
+      expect(@subject.to_solr).to be_kind_of(Hash)
     end
 
     it "should have a solr_name method" do
@@ -181,20 +181,20 @@ describe ActiveFedora::NtriplesRDFDatastream do
 
     it "should optionally allow you to provide the Solr::Document to add fields to and return that document when done" do
       doc = Hash.new
-      @subject.to_solr(doc).should == doc
+      expect(@subject.to_solr(doc)).to eq(doc)
     end
     it "should iterate through @fields hash" do
       solr_doc = @subject.to_solr
-      solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__publisher", type: :string)].should == ["publisher1"]
-      solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__publisher", :sortable)].should == "publisher1"
-      solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__publisher", :facetable)].should == ["publisher1"]
-      solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__based_near", type: :string)].should == ["coverage1", "coverage2"]
-      solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__based_near", :facetable)].should == ["coverage1", "coverage2"]
-      solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__created", :sortable, type: :date)].should == "2009-10-10T00:00:00Z"
-      solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__created", :displayable)].should == ["2009-10-10"]
-      solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__title", type: :string)].should == ["fake-title"]
-      solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__title", :sortable)].should == "fake-title"
-      solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__related_url", type: :string)].should == ["http://example.org/"]
+      expect(solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__publisher", type: :string)]).to eq(["publisher1"])
+      expect(solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__publisher", :sortable)]).to eq("publisher1")
+      expect(solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__publisher", :facetable)]).to eq(["publisher1"])
+      expect(solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__based_near", type: :string)]).to eq(["coverage1", "coverage2"])
+      expect(solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__based_near", :facetable)]).to eq(["coverage1", "coverage2"])
+      expect(solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__created", :sortable, type: :date)]).to eq("2009-10-10T00:00:00Z")
+      expect(solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__created", :displayable)]).to eq(["2009-10-10"])
+      expect(solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__title", type: :string)]).to eq(["fake-title"])
+      expect(solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__title", :sortable)]).to eq("fake-title")
+      expect(solr_doc[ActiveFedora::SolrService.solr_name("solr_rdf__related_url", type: :string)]).to eq(["http://example.org/"])
     end
 
     describe "with an actual object" do
@@ -205,9 +205,9 @@ describe ActiveFedora::NtriplesRDFDatastream do
         end
         @obj = MyDatastream.new(@inner_object, 'solr_rdf')
         repository = double()
-          @obj.stub(repository: repository, pid: 'test:1')
-          repository.stub(:modify_datastream)
-          repository.stub(:add_datastream)
+          allow(@obj).to receive_messages(repository: repository, pid: 'test:1')
+          allow(repository).to receive(:modify_datastream)
+          allow(repository).to receive(:add_datastream)
         @obj.created = Date.parse("2012-03-04")
         @obj.title = "Of Mice and Men, The Sequel"
         @obj.publisher = "Bob's Blogtastic Publishing"
@@ -223,21 +223,21 @@ describe ActiveFedora::NtriplesRDFDatastream do
 
       describe ".fields()" do
         it "should return the right fields" do
-          @obj.send(:fields).keys.should == ["created", "title", "publisher", "based_near", "related_url"]
+          expect(@obj.send(:fields).keys).to eq(["created", "title", "publisher", "based_near", "related_url"])
         end
         it "should return the right values" do
           fields = @obj.send(:fields)
-          fields[:related_url][:values].should == ["http://example.org/blogtastic/"]
-          fields[:based_near][:values].should == ["Tacoma, WA", "Renton, WA"]
+          expect(fields[:related_url][:values]).to eq(["http://example.org/blogtastic/"])
+          expect(fields[:based_near][:values]).to eq(["Tacoma, WA", "Renton, WA"])
         end
         it "should return the right type information" do
           fields = @obj.send(:fields)
-          fields[:created][:type].should == :date
+          expect(fields[:created][:type]).to eq(:date)
         end
       end
       describe ".to_solr()" do
         it "should return the right fields" do
-          @obj.to_solr.keys.should include(ActiveFedora::SolrService.solr_name("solr_rdf__related_url", type: :string),
+          expect(@obj.to_solr.keys).to include(ActiveFedora::SolrService.solr_name("solr_rdf__related_url", type: :string),
                 ActiveFedora::SolrService.solr_name("solr_rdf__publisher", type: :string),
                 ActiveFedora::SolrService.solr_name("solr_rdf__publisher", :sortable),
                 ActiveFedora::SolrService.solr_name("solr_rdf__publisher", :facetable),
@@ -251,8 +251,8 @@ describe ActiveFedora::NtriplesRDFDatastream do
         end
 
         it "should return the right values" do
-          @obj.to_solr[ActiveFedora::SolrService.solr_name("solr_rdf__related_url", type: :string)].should == ["http://example.org/blogtastic/"]
-          @obj.to_solr[ActiveFedora::SolrService.solr_name("solr_rdf__based_near", type: :string)].should == ["Tacoma, WA","Renton, WA"]
+          expect(@obj.to_solr[ActiveFedora::SolrService.solr_name("solr_rdf__related_url", type: :string)]).to eq(["http://example.org/blogtastic/"])
+          expect(@obj.to_solr[ActiveFedora::SolrService.solr_name("solr_rdf__based_near", type: :string)]).to eq(["Tacoma, WA","Renton, WA"])
         end
       end
     end

--- a/spec/unit/om_datastream_spec.rb
+++ b/spec/unit/om_datastream_spec.rb
@@ -21,14 +21,14 @@ describe ActiveFedora::OmDatastream do
   before(:each) do
     @mock_inner = double('inner object')
     @mock_repo = double('repository')
-    @mock_repo.stub(:datastream_dissemination=>'My Content', :config=>{}, :datastream_profile=>{})
-    @mock_inner.stub(:repository).and_return(@mock_repo)
-    @mock_inner.stub(:pid)
-    @mock_inner.stub(:new_record? => false)
+    allow(@mock_repo).to receive_messages(:datastream_dissemination=>'My Content', :config=>{}, :datastream_profile=>{})
+    allow(@mock_inner).to receive(:repository).and_return(@mock_repo)
+    allow(@mock_inner).to receive(:pid)
+    allow(@mock_inner).to receive_messages(:new_record? => false)
     @test_ds = ActiveFedora::OmDatastream.new(@mock_inner, "descMetadata")
-    @test_ds.stub(:new? => false, :profile => {}, :datastream_content => '<test_xml/>')
+    allow(@test_ds).to receive_messages(:new? => false, :profile => {}, :datastream_content => '<test_xml/>')
     @test_ds.content="<test_xml/>"
-    @test_ds.stub(:new? => false)
+    allow(@test_ds).to receive_messages(:new? => false)
   end
   
   its(:metadata?) { should be true}
@@ -36,36 +36,36 @@ describe ActiveFedora::OmDatastream do
   its(:controlGroup) { should == "M"}
 
   it "should include the Solrizer::XML::TerminologyBasedSolrizer for .to_solr support" do
-    ActiveFedora::OmDatastream.included_modules.should include(OM::XML::TerminologyBasedSolrizer)
+    expect(ActiveFedora::OmDatastream.included_modules).to include(OM::XML::TerminologyBasedSolrizer)
   end
   
   describe '#new' do
     it 'should provide #new' do
-      ActiveFedora::OmDatastream.should respond_to(:new)
-      @test_ds.ng_xml.should be_instance_of(Nokogiri::XML::Document)
+      expect(ActiveFedora::OmDatastream).to respond_to(:new)
+      expect(@test_ds.ng_xml).to be_instance_of(Nokogiri::XML::Document)
     end
     it 'should load xml from blob if provided' do
       test_ds1 = ActiveFedora::OmDatastream.new(nil, 'ds1')
       test_ds1.content="<xml><foo/></xml>"
-      test_ds1.ng_xml.to_xml.should be_equivalent_to("<?xml version=\"1.0\"?>\n<xml>\n  <foo/>\n</xml>\n")
+      expect(test_ds1.ng_xml.to_xml).to be_equivalent_to("<?xml version=\"1.0\"?>\n<xml>\n  <foo/>\n</xml>\n")
     end
     it "should initialize from #xml_template if no xml is provided" do
-      ActiveFedora::OmDatastream.should_receive(:xml_template).and_return("<fake template/>")
+      expect(ActiveFedora::OmDatastream).to receive(:xml_template).and_return("<fake template/>")
       n = ActiveFedora::OmDatastream.new
-      n.ng_xml.should be_equivalent_to("<fake template/>")
+      expect(n.ng_xml).to be_equivalent_to("<fake template/>")
     end
   end
 
   describe "#prefix" do
     subject { ActiveFedora::OmDatastream.new(nil, 'descMetadata') }
     it "should be \"\#{dsid.underscore}__\"" do
-      subject.send(:prefix).should == "desc_metadata__"
+      expect(subject.send(:prefix)).to eq("desc_metadata__")
     end
   end
   
   describe '#xml_template' do
     it "should return an empty xml document" do
-      ActiveFedora::OmDatastream.xml_template.to_xml.should be_equivalent_to("<?xml version=\"1.0\"?>\n<xml/>\n")
+      expect(ActiveFedora::OmDatastream.xml_template.to_xml).to be_equivalent_to("<?xml version=\"1.0\"?>\n<xml/>\n")
     end
   end
 
@@ -116,25 +116,25 @@ describe ActiveFedora::OmDatastream do
     
     it "should apply submitted hash to corresponding datastream field values" do
       result = @mods_ds.update_indexed_attributes( {[{":person"=>"0"}, "role"]=>{"0"=>"role1", "1"=>"role2", "2"=>"role3"} })
-      result.should == {"person_0_role"=>["role1", "role2", "role3"]}
-      @mods_ds.property_values('//oxns:name[@type="personal"][1]/oxns:role').should == ["role1","role2","role3"]
+      expect(result).to eq({"person_0_role"=>["role1", "role2", "role3"]})
+      expect(@mods_ds.property_values('//oxns:name[@type="personal"][1]/oxns:role')).to eq(["role1","role2","role3"])
     end
     it "should support single-value arguments (as opposed to a hash of values with array indexes as keys)" do
       # In other words, { "fubar"=>"dork" } should have the same effect as { "fubar"=>{"0"=>"dork"} }
       result = @mods_ds.update_indexed_attributes( { [{":person"=>"0"}, "role"]=>"the role" } )
-      result.should == {"person_0_role"=>["the role"]}
-      @mods_ds.term_values('//oxns:name[@type="personal"][1]/oxns:role').first.should == "the role"
+      expect(result).to eq({"person_0_role"=>["the role"]})
+      expect(@mods_ds.term_values('//oxns:name[@type="personal"][1]/oxns:role').first).to eq("the role")
     end
     it "should do nothing if field key is a string (must be an array or symbol).  Will not accept xpath queries!" do
       xml_before = @mods_ds.to_xml
       expect(ActiveFedora::Base.logger).to receive(:warn).with "WARNING: descMetadata ignoring {\"fubar\" => \"the role\"} because \"fubar\" is a String (only valid OM Term Pointers will be used).  Make sure your html has the correct field_selector tags in it."
-      @mods_ds.update_indexed_attributes( { "fubar"=>"the role" } ).should == {}
-      @mods_ds.to_xml.should == xml_before
+      expect(@mods_ds.update_indexed_attributes( { "fubar"=>"the role" } )).to eq({})
+      expect(@mods_ds.to_xml).to eq(xml_before)
     end
     it "should do nothing if there is no accessor corresponding to the given field key" do
       xml_before = @mods_ds.to_xml
-      @mods_ds.update_indexed_attributes( { [{"fubar"=>"0"}]=>"the role" } ).should == {}
-      @mods_ds.to_xml.should == xml_before
+      expect(@mods_ds.update_indexed_attributes( { [{"fubar"=>"0"}]=>"the role" } )).to eq({})
+      expect(@mods_ds.to_xml).to eq(xml_before)
     end
     
     ### Examples copied over form metadata_datastream_spec
@@ -142,30 +142,30 @@ describe ActiveFedora::OmDatastream do
     it "should work for text fields" do 
       att= {[{"person"=>"0"},"description"]=>{"-1"=>"mork", "1"=>"york"}}
       result = @mods_ds.update_indexed_attributes(att)
-      result.should == {"person_0_description"=>["mork","york"]}
-      @mods_ds.get_values([{:person=>0},:description]).should == ['mork', 'york']
+      expect(result).to eq({"person_0_description"=>["mork","york"]})
+      expect(@mods_ds.get_values([{:person=>0},:description])).to eq(['mork', 'york'])
       att= {[{"person"=>"0"},"description"]=>{"-1"=>"dork"}}
       result2 = @mods_ds.update_indexed_attributes(att)
-      result2.should == {"person_0_description"=>["dork"]}
-      @mods_ds.get_values([{:person=>0},:description]).should == ['dork']
+      expect(result2).to eq({"person_0_description"=>["dork"]})
+      expect(@mods_ds.get_values([{:person=>0},:description])).to eq(['dork'])
     end
     
     it "should allow deleting of values and should delete values so that to_xml does not return emtpy nodes" do
       att= {[{"person"=>"0"},"description"]=>{"0"=>"york", "1"=>"mangle","2"=>"mork"}}
       @mods_ds.update_indexed_attributes(att)
-      @mods_ds.get_values([{"person"=>"0"},"description"]).should == ['york', 'mangle', 'mork']
+      expect(@mods_ds.get_values([{"person"=>"0"},"description"])).to eq(['york', 'mangle', 'mork'])
       
       @mods_ds.update_indexed_attributes({[{"person"=>"0"},{"description" => '1'} ]=> nil})
-      @mods_ds.get_values([{"person"=>"0"},"description"]).should == ['york', 'mork']
+      expect(@mods_ds.get_values([{"person"=>"0"},"description"])).to eq(['york', 'mork'])
       
       @mods_ds.update_indexed_attributes({[{"person"=>"0"},{"description" => '0'}]=>:delete})
-      @mods_ds.get_values([{"person"=>"0"},"description"]).should == ['mork']
+      expect(@mods_ds.get_values([{"person"=>"0"},"description"])).to eq(['mork'])
     end
     
     it "should set changed to true" do
-      @mods_ds.get_values([{:title_info=>0},:main_title]).should == ["ARTICLE TITLE", "TITLE OF HOST JOURNAL"]
+      expect(@mods_ds.get_values([{:title_info=>0},:main_title])).to eq(["ARTICLE TITLE", "TITLE OF HOST JOURNAL"])
       @mods_ds.update_indexed_attributes [{"title_info"=>"0"},"main_title"]=>{"-1"=>"mork"}
-      @mods_ds.should be_changed
+      expect(@mods_ds).to be_changed
     end
   end
   
@@ -177,92 +177,92 @@ describe ActiveFedora::OmDatastream do
     end
     
     it "should call lookup with field_name and return the text values from each resulting node" do
-      @mods_ds.should_receive(:term_values).with("--my xpath--").and_return(["value1", "value2"])
-      @mods_ds.get_values("--my xpath--").should == ["value1", "value2"]
+      expect(@mods_ds).to receive(:term_values).with("--my xpath--").and_return(["value1", "value2"])
+      expect(@mods_ds.get_values("--my xpath--")).to eq(["value1", "value2"])
     end
     it "should assume that field_names that are strings are xpath queries" do
-      ActiveFedora::OmDatastream.should_receive(:accessor_xpath).never
-      @mods_ds.should_receive(:term_values).with("--my xpath--").and_return(["abstract1", "abstract2"])
-      @mods_ds.get_values("--my xpath--").should == ["abstract1", "abstract2"]
+      expect(ActiveFedora::OmDatastream).to receive(:accessor_xpath).never
+      expect(@mods_ds).to receive(:term_values).with("--my xpath--").and_return(["abstract1", "abstract2"])
+      expect(@mods_ds.get_values("--my xpath--")).to eq(["abstract1", "abstract2"])
     end
   end
 
   describe '.save' do
     it "should provide .save" do
-      @test_ds.should respond_to(:save)
+      expect(@test_ds).to respond_to(:save)
     end
     it "should persist the product of .to_xml in fedora" do
-      @mock_repo.stub(:datastream).and_return('')
-      @test_ds.stub(:new? => true)
-      @test_ds.stub(:ng_xml_changed? => true)
-      @test_ds.stub(:to_xml => "fake xml")
-      @mock_repo.should_receive(:add_datastream).with(:pid => nil, :dsid => 'descMetadata', :versionable => true, :content => 'fake xml', :controlGroup => 'M', :dsState => 'A', :mimeType=>'text/xml')
+      allow(@mock_repo).to receive(:datastream).and_return('')
+      allow(@test_ds).to receive_messages(:new? => true)
+      allow(@test_ds).to receive_messages(:ng_xml_changed? => true)
+      allow(@test_ds).to receive_messages(:to_xml => "fake xml")
+      expect(@mock_repo).to receive(:add_datastream).with(:pid => nil, :dsid => 'descMetadata', :versionable => true, :content => 'fake xml', :controlGroup => 'M', :dsState => 'A', :mimeType=>'text/xml')
 
       @test_ds.serialize!
       @test_ds.save
-      @test_ds.mimeType.should == 'text/xml'
+      expect(@test_ds.mimeType).to eq('text/xml')
     end
   end
   
   describe 'setting content' do
     subject { ActiveFedora::OmDatastream.new(@mock_inner, "descMetadata") }
     it "should update the content" do
-      subject.stub(:new? => false )
+      allow(subject).to receive_messages(:new? => false )
       subject.content = "<a />"
-      subject.content.should == '<a/>'
+      expect(subject.content).to eq('<a/>')
     end
 
     it "should mark the object as changed" do
-      subject.stub(:new? => false, :controlGroup => 'M')
+      allow(subject).to receive_messages(:new? => false, :controlGroup => 'M')
       subject.content = "<a />"
-      subject.should be_changed
+      expect(subject).to be_changed
     end
 
     it "update ngxml and mark the xml as loaded" do
-      subject.stub(:new? => false )
+      allow(subject).to receive_messages(:new? => false )
       subject.content = "<a />"
-      subject.ng_xml.to_xml.should =~ /<a\/>/
-      subject.xml_loaded.should be true
+      expect(subject.ng_xml.to_xml).to match(/<a\/>/)
+      expect(subject.xml_loaded).to be true
     end
   end
   
   describe 'ng_xml=' do
     before do
-      @mock_inner.stub(:new_record? => true)
+      allow(@mock_inner).to receive_messages(:new_record? => true)
       @test_ds2 = ActiveFedora::OmDatastream.new(@mock_inner, "descMetadata")
     end
     it "should parse raw xml for you" do
       @test_ds2.ng_xml = @sample_raw_xml
-      @test_ds2.ng_xml.class.should == Nokogiri::XML::Document
-      @test_ds2.ng_xml.to_xml.should be_equivalent_to(@sample_raw_xml)
+      expect(@test_ds2.ng_xml.class).to eq(Nokogiri::XML::Document)
+      expect(@test_ds2.ng_xml.to_xml).to be_equivalent_to(@sample_raw_xml)
     end
 
     it "Should always set a document when an Element is passed" do
       @test_ds2.ng_xml = Nokogiri::XML(@sample_raw_xml).xpath('//xmlelement').first
-      @test_ds2.ng_xml.should be_kind_of Nokogiri::XML::Document
-      @test_ds2.ng_xml.to_xml.should be_equivalent_to("<xmlelement/>")
+      expect(@test_ds2.ng_xml).to be_kind_of Nokogiri::XML::Document
+      expect(@test_ds2.ng_xml.to_xml).to be_equivalent_to("<xmlelement/>")
     end
     it "should mark the datastream as changed" do
-      @test_ds2.stub(:new? => false, :controlGroup => 'M')
-      @test_ds2.should_not be_changed 
+      allow(@test_ds2).to receive_messages(:new? => false, :controlGroup => 'M')
+      expect(@test_ds2).not_to be_changed 
       @test_ds2.ng_xml = @sample_raw_xml
-      @test_ds2.should be_changed
+      expect(@test_ds2).to be_changed
     end
   end
   
   describe '.to_xml' do
     it "should provide .to_xml" do
-      @test_ds.should respond_to(:to_xml)
+      expect(@test_ds).to respond_to(:to_xml)
     end
     
     it "should ng_xml.to_xml" do
-      @test_ds.stub(:ng_xml => Nokogiri::XML::Document.parse("<text_document/>"))
-      @test_ds.to_xml.should == "<text_document/>"       
+      allow(@test_ds).to receive_messages(:ng_xml => Nokogiri::XML::Document.parse("<text_document/>"))
+      expect(@test_ds.to_xml).to eq("<text_document/>")       
     end
     
     it 'should accept an optional Nokogiri::XML Document as an argument and insert its fields into that (mocked test)' do
       doc = Nokogiri::XML::Document.parse("<test_document/>")
-      doc.root.should_receive(:add_child)#.with(@test_ds.ng_xml.root)
+      expect(doc.root).to receive(:add_child)#.with(@test_ds.ng_xml.root)
       @test_ds.to_xml(doc)
     end
     
@@ -270,15 +270,15 @@ describe ActiveFedora::OmDatastream do
       expected_result = "<test_document><foo/><test_xml/></test_document>"
       doc = Nokogiri::XML::Document.parse("<test_document><foo/></test_document>")
       result = @test_ds.to_xml(doc)
-      doc.should be_equivalent_to expected_result
-      result.should be_equivalent_to expected_result
+      expect(doc).to be_equivalent_to expected_result
+      expect(result).to be_equivalent_to expected_result
     end
     
     it 'should add to root of Nokogiri::XML::Documents, but add directly to the elements if a Nokogiri::XML::Node is passed in' do
       doc = Nokogiri::XML::Document.parse("<test_document/>")
       el = Nokogiri::XML::Node.new("test_element", Nokogiri::XML::Document.new)
-      @test_ds.to_xml(doc).should be_equivalent_to "<test_document><test_xml/></test_document>"
-      @test_ds.to_xml(el).should be_equivalent_to "<test_element/>"
+      expect(@test_ds.to_xml(doc)).to be_equivalent_to "<test_document><test_xml/></test_document>"
+      expect(@test_ds.to_xml(el)).to be_equivalent_to "<test_element/>"
     end
     
   end
@@ -286,7 +286,7 @@ describe ActiveFedora::OmDatastream do
   describe '.from_solr' do
     it "should set the internal_solr_doc attribute to the solr document passed in" do 
       @test_ds.from_solr(@solr_doc)
-      @test_ds.internal_solr_doc.should == @solr_doc
+      expect(@test_ds.internal_solr_doc).to eq(@solr_doc)
     end
   end
 
@@ -302,47 +302,47 @@ describe ActiveFedora::OmDatastream do
  
     it "should return correct values from solr_doc given different term pointers" do
       mock_term = double("OM::XML::Term")
-      mock_term.stub(:type).and_return(:text)
+      allow(mock_term).to receive(:type).and_return(:text)
       mock_terminology = double("OM::XML::Terminology")
-      mock_terminology.stub(:retrieve_term).and_return(mock_term)
-      ActiveFedora::OmDatastream.stub(:terminology).and_return(mock_terminology)
+      allow(mock_terminology).to receive(:retrieve_term).and_return(mock_term)
+      allow(ActiveFedora::OmDatastream).to receive(:terminology).and_return(mock_terminology)
       @mods_ds.from_solr(@solr_doc)
       term_pointer = [:name,:role,:roleTerm]
-      @mods_ds.get_values_from_solr(:name,:role,:roleTerm).should == ["creator","submitter","teacher"]
+      expect(@mods_ds.get_values_from_solr(:name,:role,:roleTerm)).to eq(["creator","submitter","teacher"])
       ar = @mods_ds.get_values_from_solr({:name=>0},:role,:roleTerm)
-      ar.length.should == 2
-      ar.include?("creator").should == true
-      ar.include?("submitter").should == true
-      @mods_ds.get_values_from_solr({:name=>1},:role,:roleTerm).should == ["teacher"]
-      @mods_ds.get_values_from_solr({:name=>0},{:role=>0},:roleTerm).should == ["creator"]
-      @mods_ds.get_values_from_solr({:name=>0},{:role=>1},:roleTerm).should == ["submitter"]
-      @mods_ds.get_values_from_solr({:name=>0},{:role=>2},:roleTerm).should == []
-      @mods_ds.get_values_from_solr({:name=>1},{:role=>0},:roleTerm).should == ["teacher"]
-      @mods_ds.get_values_from_solr({:name=>1},{:role=>1},:roleTerm).should == []
+      expect(ar.length).to eq(2)
+      expect(ar.include?("creator")).to eq(true)
+      expect(ar.include?("submitter")).to eq(true)
+      expect(@mods_ds.get_values_from_solr({:name=>1},:role,:roleTerm)).to eq(["teacher"])
+      expect(@mods_ds.get_values_from_solr({:name=>0},{:role=>0},:roleTerm)).to eq(["creator"])
+      expect(@mods_ds.get_values_from_solr({:name=>0},{:role=>1},:roleTerm)).to eq(["submitter"])
+      expect(@mods_ds.get_values_from_solr({:name=>0},{:role=>2},:roleTerm)).to eq([])
+      expect(@mods_ds.get_values_from_solr({:name=>1},{:role=>0},:roleTerm)).to eq(["teacher"])
+      expect(@mods_ds.get_values_from_solr({:name=>1},{:role=>1},:roleTerm)).to eq([])
       ar = @mods_ds.get_values_from_solr(:name,{:role=>0},:roleTerm)
-      ar.length.should == 2
-      ar.include?("creator").should == true
-      ar.include?("teacher").should == true
-      @mods_ds.get_values_from_solr(:name,{:role=>1},:roleTerm).should == ["submitter"]
+      expect(ar.length).to eq(2)
+      expect(ar.include?("creator")).to eq(true)
+      expect(ar.include?("teacher")).to eq(true)
+      expect(@mods_ds.get_values_from_solr(:name,{:role=>1},:roleTerm)).to eq(["submitter"])
     end
   end
 
   describe '.has_solr_name?' do
     it "should return true if the given key exists in the solr document passed in" do
-      @test_ds.has_solr_name?(ActiveFedora::SolrService.solr_name("test_ds__name_0_role_0_roleTerm", type: :string),@solr_doc).should == true
-      @test_ds.has_solr_name?(ActiveFedora::SolrService.solr_name("test_ds__name_0_role_0_roleTerm", type: :string).to_sym,@solr_doc).should == true
-      @test_ds.has_solr_name?(ActiveFedora::SolrService.solr_name("test_ds__name_1_role_1_roleTerm", type: :string),@solr_doc).should == false
+      expect(@test_ds.has_solr_name?(ActiveFedora::SolrService.solr_name("test_ds__name_0_role_0_roleTerm", type: :string),@solr_doc)).to eq(true)
+      expect(@test_ds.has_solr_name?(ActiveFedora::SolrService.solr_name("test_ds__name_0_role_0_roleTerm", type: :string).to_sym,@solr_doc)).to eq(true)
+      expect(@test_ds.has_solr_name?(ActiveFedora::SolrService.solr_name("test_ds__name_1_role_1_roleTerm", type: :string),@solr_doc)).to eq(false)
       #if not doc passed in should be new empty solr doc and always return false
-      @test_ds.has_solr_name?(ActiveFedora::SolrService.solr_name("test_ds__name_0_role_0_roleTerm", type: :string)).should == false
+      expect(@test_ds.has_solr_name?(ActiveFedora::SolrService.solr_name("test_ds__name_0_role_0_roleTerm", type: :string))).to eq(false)
     end
   end
 
   describe '.is_hierarchical_term_pointer?' do
     it "should return true only if the pointer passed in is an array that contains a hash" do
-      @test_ds.is_hierarchical_term_pointer?(*[:image,{:tag1=>1},:tag2]).should == true
-      @test_ds.is_hierarchical_term_pointer?(*[:image,:tag1,{:tag2=>1}]).should == true
-      @test_ds.is_hierarchical_term_pointer?(*[:image,:tag1,:tag2]).should == false
-      @test_ds.is_hierarchical_term_pointer?(nil).should == false      
+      expect(@test_ds.is_hierarchical_term_pointer?(*[:image,{:tag1=>1},:tag2])).to eq(true)
+      expect(@test_ds.is_hierarchical_term_pointer?(*[:image,:tag1,{:tag2=>1}])).to eq(true)
+      expect(@test_ds.is_hierarchical_term_pointer?(*[:image,:tag1,:tag2])).to eq(false)
+      expect(@test_ds.is_hierarchical_term_pointer?(nil)).to eq(false)      
     end
   end
 
@@ -360,11 +360,11 @@ describe ActiveFedora::OmDatastream do
       rescue
         found_exception = true
       end
-      found_exception.should == true
+      expect(found_exception).to eq(true)
     end
 
     it "should update a value internally call OM::XML::TermValueOperators::update_values if internal_solr_doc is not set" do
-      @mods_ds.stub(:om_update_values).once()
+      allow(@mods_ds).to receive(:om_update_values).once()
       term_pointer = [:name,:role,:roleTerm]
       @mods_ds.update_values([{":person"=>"0"}, "role", "text"]=>{"0"=>"role1", "1"=>"role2", "2"=>"role3"})
     end
@@ -373,7 +373,7 @@ describe ActiveFedora::OmDatastream do
       mods_ds = Hydra::ModsArticleDatastream.new
       mods_ds.content=fixture(File.join("mods_articles","mods_article1.xml")).read
       mods_ds.update_values([{":person"=>"0"}, "role", "text"]=>{"0"=>"role1", "1"=>"role2", "2"=>"role3"})
-      mods_ds.should be_changed
+      expect(mods_ds).to be_changed
     end
   end
 
@@ -385,7 +385,7 @@ describe ActiveFedora::OmDatastream do
     end
 
     it "should call OM::XML::term_values if internal_solr_doc is not set and return values from xml" do
-      @mods_ds.stub(:om_term_values).once()
+      allow(@mods_ds).to receive(:om_term_values).once()
       term_pointer = [:name,:role,:roleTerm]
       @mods_ds.term_values(*term_pointer)
     end
@@ -394,7 +394,7 @@ describe ActiveFedora::OmDatastream do
     it "should call get_values_from_solr if internal_solr_doc is set" do
       @mods_ds.from_solr(@solr_doc)
       term_pointer = [:name,:role,:roleTerm]
-      @mods_ds.stub(:get_values_from_solr).once()
+      allow(@mods_ds).to receive(:get_values_from_solr).once()
       @mods_ds.term_values(*term_pointer)
     end
   end
@@ -414,8 +414,8 @@ describe ActiveFedora::OmDatastream do
       Object.send(:remove_const, :MyObj)
     end
     it "should not load the descMetadata datastream when calling content_changed?" do
-      @obj.inner_object.repository.should_not_receive(:datastream_dissemination).with(hash_including(:dsid=>'descMetadata'))
-      @obj.descMetadata.should_not be_content_changed
+      expect(@obj.inner_object.repository).not_to receive(:datastream_dissemination).with(hash_including(:dsid=>'descMetadata'))
+      expect(@obj.descMetadata).not_to be_content_changed
     end
   end
 end

--- a/spec/unit/persistence_spec.rb
+++ b/spec/unit/persistence_spec.rb
@@ -15,13 +15,13 @@ describe ActiveFedora::Persistence do
 
     describe "#create_needs_index?" do
       it "should be true" do
-        subject.send(:create_needs_index?).should be_true
+        expect(subject.send(:create_needs_index?)).to be_truthy
       end
     end
 
     describe "#update_needs_index?" do
       it "should be true" do
-        subject.send(:update_needs_index?).should be_true
+        expect(subject.send(:update_needs_index?)).to be_truthy
       end
     end
   end

--- a/spec/unit/predicates_spec.rb
+++ b/spec/unit/predicates_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 describe ActiveFedora::Predicates do
   describe "#short_predicate" do
     it 'should parse strings' do
-      ActiveFedora::Predicates.short_predicate('http://www.openarchives.org/OAI/2.0/itemID').should == :oai_item_id
+      expect(ActiveFedora::Predicates.short_predicate('http://www.openarchives.org/OAI/2.0/itemID')).to eq(:oai_item_id)
     end
     it 'should parse uris' do
-      ActiveFedora::Predicates.short_predicate(RDF::DC.creator).should == 'dc_terms_creator'
-      ActiveFedora::Predicates.short_predicate(RDF::SKOS.hasTopConcept).should == '2004_02_skos_core_has_top_concept'
+      expect(ActiveFedora::Predicates.short_predicate(RDF::DC.creator)).to eq('dc_terms_creator')
+      expect(ActiveFedora::Predicates.short_predicate(RDF::SKOS.hasTopConcept)).to eq('2004_02_skos_core_has_top_concept')
     end
     before(:all) do
       @original_mapping = ActiveFedora::Predicates.predicate_config[:predicate_mapping]
@@ -21,25 +21,25 @@ describe ActiveFedora::Predicates do
         "http://example.org/zoo/wolves/"=>{:alpha => 'Manager'},
         "http://example.org/zoo/"=>{:keeper => 'Manager'}
         }
-      ActiveFedora::Predicates.short_predicate("http://example.org/zoo/Manager").should == :keeper
-      ActiveFedora::Predicates.short_predicate("http://example.org/zoo/wolves/Manager").should == :alpha
-      ActiveFedora::Predicates.short_predicate("http://example.org/Manager").should == :ceo
+      expect(ActiveFedora::Predicates.short_predicate("http://example.org/zoo/Manager")).to eq(:keeper)
+      expect(ActiveFedora::Predicates.short_predicate("http://example.org/zoo/wolves/Manager")).to eq(:alpha)
+      expect(ActiveFedora::Predicates.short_predicate("http://example.org/Manager")).to eq(:ceo)
     end
   end
   
   it 'should provide .default_predicate_namespace' do
-    ActiveFedora::Predicates.default_predicate_namespace.should == 'info:fedora/fedora-system:def/relations-external#'
+    expect(ActiveFedora::Predicates.default_predicate_namespace).to eq('info:fedora/fedora-system:def/relations-external#')
   end
  
   describe "#predicate_mappings" do 
 
     it 'should return a hash' do
-      ActiveFedora::Predicates.predicate_mappings.should be_kind_of Hash
+      expect(ActiveFedora::Predicates.predicate_mappings).to be_kind_of Hash
     end
 
     it "should provide mappings to the fedora ontology via the info:fedora/fedora-system:def/relations-external default namespace mapping" do
-      ActiveFedora::Predicates.predicate_mappings.keys.include?(ActiveFedora::Predicates.default_predicate_namespace).should be_true
-      ActiveFedora::Predicates.predicate_mappings[ActiveFedora::Predicates.default_predicate_namespace].should be_kind_of Hash
+      expect(ActiveFedora::Predicates.predicate_mappings.keys.include?(ActiveFedora::Predicates.default_predicate_namespace)).to be_truthy
+      expect(ActiveFedora::Predicates.predicate_mappings[ActiveFedora::Predicates.default_predicate_namespace]).to be_kind_of Hash
     end
 
     it 'should provide predicate mappings for entire Fedora Relationship Ontology' do
@@ -67,21 +67,21 @@ describe ActiveFedora::Predicates do
                             :conforms_to => "conformsTo",
                             :has_model => "hasModel"]
       desired_mappings.each_pair do |k,v|
-        ActiveFedora::Predicates.predicate_mappings[ActiveFedora::Predicates.default_predicate_namespace].should have_key(k)
-        ActiveFedora::Predicates.predicate_mappings[ActiveFedora::Predicates.default_predicate_namespace][k].should == v
+        expect(ActiveFedora::Predicates.predicate_mappings[ActiveFedora::Predicates.default_predicate_namespace]).to have_key(k)
+        expect(ActiveFedora::Predicates.predicate_mappings[ActiveFedora::Predicates.default_predicate_namespace][k]).to eq(v)
       end
     end
   end
 
   it 'should provide #predicate_lookup that maps symbols to common RELS-EXT predicates' do
-    ActiveFedora::Predicates.should respond_to(:predicate_lookup)
-    ActiveFedora::Predicates.predicate_lookup(:is_part_of).should == "isPartOf"
-    ActiveFedora::Predicates.predicate_lookup(:is_member_of).should == "isMemberOf"
-    ActiveFedora::Predicates.predicate_lookup("isPartOfCollection").should == "isPartOfCollection"
+    expect(ActiveFedora::Predicates).to respond_to(:predicate_lookup)
+    expect(ActiveFedora::Predicates.predicate_lookup(:is_part_of)).to eq("isPartOf")
+    expect(ActiveFedora::Predicates.predicate_lookup(:is_member_of)).to eq("isMemberOf")
+    expect(ActiveFedora::Predicates.predicate_lookup("isPartOfCollection")).to eq("isPartOfCollection")
     ActiveFedora::Predicates.predicate_config[:predicate_mapping].merge!({"some_namespace"=>{:has_foo=>"hasFOO"}})
-    ActiveFedora::Predicates.find_predicate(:has_foo).should == ["hasFOO","some_namespace"]
-    ActiveFedora::Predicates.predicate_lookup(:has_foo,"some_namespace").should == "hasFOO"
-    lambda { ActiveFedora::Predicates.predicate_lookup(:has_foo) }.should raise_error ActiveFedora::UnregisteredPredicateError
+    expect(ActiveFedora::Predicates.find_predicate(:has_foo)).to eq(["hasFOO","some_namespace"])
+    expect(ActiveFedora::Predicates.predicate_lookup(:has_foo,"some_namespace")).to eq("hasFOO")
+    expect { ActiveFedora::Predicates.predicate_lookup(:has_foo) }.to raise_error ActiveFedora::UnregisteredPredicateError
   end
     
   context 'initialization' do
@@ -94,19 +94,19 @@ describe ActiveFedora::Predicates do
     end
     
     it 'should allow explicit initialization of predicates' do
-      ActiveFedora::Predicates.find_predicate(:is_part_of).should == ["isPartOf", "info:fedora/fedora-system:def/relations-external#"]
+      expect(ActiveFedora::Predicates.find_predicate(:is_part_of)).to eq(["isPartOf", "info:fedora/fedora-system:def/relations-external#"])
       ActiveFedora::Predicates.predicate_config = {
         :default_namespace => 'http://example.com/foo',
         :predicate_mapping => {
           'http://example.com/foo' => { :has_bar => 'hasBAR' }
         }
       }
-      ActiveFedora::Predicates.find_predicate(:has_bar).should == ["hasBAR", "http://example.com/foo"]
-      lambda { ActiveFedora::Predicates.find_predicate(:is_part_of) }.should raise_error ActiveFedora::UnregisteredPredicateError
+      expect(ActiveFedora::Predicates.find_predicate(:has_bar)).to eq(["hasBAR", "http://example.com/foo"])
+      expect { ActiveFedora::Predicates.find_predicate(:is_part_of) }.to raise_error ActiveFedora::UnregisteredPredicateError
     end
     
     it 'should ensure that the configuration has the correct keys' do
-      lambda { ActiveFedora::Predicates.predicate_config = { :foo => 'invalid!' } }.should raise_error TypeError
+      expect { ActiveFedora::Predicates.predicate_config = { :foo => 'invalid!' } }.to raise_error TypeError
     end
 
     it "should allow adding predicates without wiping out existing predicates" do
@@ -118,12 +118,12 @@ describe ActiveFedora::Predicates do
                                                   },
                                               })
       # New & Modified Predicates
-      ActiveFedora::Predicates.find_predicate(:has_profile).should == ["hasProfile", "http://projecthydra.org/ns/relations#"]
-      ActiveFedora::Predicates.find_predicate(:references).should == ["references", "info:fedora/fedora-system:def/relations-external#"]
-      ActiveFedora::Predicates.find_predicate(:has_derivation).should == ["cameFrom", "info:fedora/fedora-system:def/relations-external#"]
+      expect(ActiveFedora::Predicates.find_predicate(:has_profile)).to eq(["hasProfile", "http://projecthydra.org/ns/relations#"])
+      expect(ActiveFedora::Predicates.find_predicate(:references)).to eq(["references", "info:fedora/fedora-system:def/relations-external#"])
+      expect(ActiveFedora::Predicates.find_predicate(:has_derivation)).to eq(["cameFrom", "info:fedora/fedora-system:def/relations-external#"])
       # Pre-Existing predicates should be unharmed
-      ActiveFedora::Predicates.find_predicate(:is_part_of).should == ["isPartOf", "info:fedora/fedora-system:def/relations-external#"]
-      ActiveFedora::Predicates.find_predicate(:is_governed_by).should == ["isGovernedBy", "http://projecthydra.org/ns/relations#"]
+      expect(ActiveFedora::Predicates.find_predicate(:is_part_of)).to eq(["isPartOf", "info:fedora/fedora-system:def/relations-external#"])
+      expect(ActiveFedora::Predicates.find_predicate(:is_governed_by)).to eq(["isGovernedBy", "http://projecthydra.org/ns/relations#"])
     end
 
   end

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -6,27 +6,27 @@ require 'active_fedora/model'
 describe ActiveFedora::Property do
   
   before(:all) do
-    @test_property = ActiveFedora::Property.new(stub("model_stub"),"file_name", :string)
+    @test_property = ActiveFedora::Property.new(double("model_stub"),"file_name", :string)
   end
   
   it 'should provide .new' do
-    ActiveFedora::Property.should respond_to(:new)
+    expect(ActiveFedora::Property).to respond_to(:new)
   end
 
   it 'should provide .name' do
-    ActiveFedora::Property.should respond_to(:name)
+    expect(ActiveFedora::Property).to respond_to(:name)
   end
 
   
   it 'should provide .instance_variable_name' do
     #ActiveFedora::Property.should respond_to(:instance_variable_name)
     
-    @test_property.should respond_to(:instance_variable_name)
+    expect(@test_property).to respond_to(:instance_variable_name)
   end
 
   describe '.instance_variable_name' do
     it 'should return the value of the name attribute with an @ appended' do
-      @test_property.instance_variable_name.should eql("@#{@test_property.name}")
+      expect(@test_property.instance_variable_name).to eql("@#{@test_property.name}")
     end
   end
   

--- a/spec/unit/qualified_dublin_core_datastream_spec.rb
+++ b/spec/unit/qualified_dublin_core_datastream_spec.rb
@@ -41,21 +41,21 @@ describe ActiveFedora::QualifiedDublinCoreDatastream do
 
   end
   it "from_xml should parse everything correctly" do
-    @test_ds.ng_xml.should be_equivalent_to @sample_xml
+    expect(@test_ds.ng_xml).to be_equivalent_to @sample_xml
   end
 
   it "should create the right number of fields" do
-    ActiveFedora::QualifiedDublinCoreDatastream::DCTERMS.size.should == 54
+    expect(ActiveFedora::QualifiedDublinCoreDatastream::DCTERMS.size).to eq(54)
   end
 
   it "should have unmodifiable constants" do
-    proc {ActiveFedora::QualifiedDublinCoreDatastream::DCTERMS<<:foo}.should raise_error((TypeError if RUBY_VERSION < "1.9.0") || RuntimeError, /can't modify frozen array/i)
+    expect {ActiveFedora::QualifiedDublinCoreDatastream::DCTERMS<<:foo}.to raise_error((TypeError if RUBY_VERSION < "1.9.0") || RuntimeError, /can't modify frozen array/i)
 
   end
 
   it "should default dc elements to :multiple=>true" do
     @test_ds.fields.values.each do |s|
-      s.has_key?(:multiple).should == true
+      expect(s.has_key?(:multiple)).to eq(true)
     end
   end
   
@@ -64,7 +64,7 @@ describe ActiveFedora::QualifiedDublinCoreDatastream do
   
   describe '#new' do
     it 'should provide #new' do
-      ActiveFedora::QualifiedDublinCoreDatastream.should respond_to(:new)
+      expect(ActiveFedora::QualifiedDublinCoreDatastream).to respond_to(:new)
     end
     
     
@@ -75,7 +75,7 @@ describe ActiveFedora::QualifiedDublinCoreDatastream do
           pending if el == :type
           value = "Hey #{el}"
           @test_ds.send("#{el.to_s}=", value) 
-          @test_ds.send(el).first.should == value  #Looking at first because creator has 2 nodes
+          expect(@test_ds.send(el).first).to eq(value)  #Looking at first because creator has 2 nodes
         end
       end
     end
@@ -95,7 +95,7 @@ describe ActiveFedora::QualifiedDublinCoreDatastream do
       @test_ds.creator= ["creator1", "creator2"]
       @test_ds.title= ["title1"]
 
-      @test_ds.to_xml.should be_equivalent_to('
+      expect(@test_ds.to_xml).to be_equivalent_to('
         <dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                  <dcterms:publisher>publisher1</dcterms:publisher>
                  <dcterms:creator>creator1</dcterms:creator>
@@ -110,7 +110,7 @@ describe ActiveFedora::QualifiedDublinCoreDatastream do
       @test_ds = ActiveFedora::QualifiedDublinCoreDatastream.new(nil, 'qdc' )
       @test_ds.title = "War and Peace"
       solr = @test_ds.to_solr
-      solr[ActiveFedora::SolrService.solr_name('title', type: :string)].should == "War and Peace"
+      expect(solr[ActiveFedora::SolrService.solr_name('title', type: :string)]).to eq("War and Peace")
     end
 
   end
@@ -120,7 +120,7 @@ describe ActiveFedora::QualifiedDublinCoreDatastream do
       sample_xml = "<dc xmlns:dcterms='http://purl.org/dc/terms/' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'><dcterms:cust>custom</dcterms:cust></dc>"
       test_ds = ActiveFedora::QualifiedDublinCoreDatastream.from_xml(sample_xml )
       test_ds.field :cust
-      test_ds.cust.should == ['custom']
+      expect(test_ds.cust).to eq(['custom'])
     end
   end
 
@@ -128,7 +128,7 @@ describe ActiveFedora::QualifiedDublinCoreDatastream do
     it "should be able to map :dc_type to the path 'type'" do
       test_ds = ActiveFedora::QualifiedDublinCoreDatastream.from_xml(@sample_xml)
       test_ds.field :dc_type, :string, path: "type", multiple: true
-      test_ds.dc_type.should == ['sound']
+      expect(test_ds.dc_type).to eq(['sound'])
     end
   end
 

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -16,27 +16,27 @@ describe ActiveFedora::Base do
   end
 
   describe ":all" do
-    before { ActiveFedora::Base.stub(:relation => relation) }
+    before { allow(ActiveFedora::Base).to receive_messages(:relation => relation) }
     describe "called on a concrete class" do
       let(:relation) { ActiveFedora::Relation.new(SpecModel::Basic) }
       it "should query solr for all objects with :has_model_s of self.class" do
-        relation.should_receive(:load_from_fedora).with("changeme:30", nil).and_return("Fake Object1")
-        relation.should_receive(:load_from_fedora).with("changeme:22", nil).and_return("Fake Object2")
+        expect(relation).to receive(:load_from_fedora).with("changeme:30", nil).and_return("Fake Object1")
+        expect(relation).to receive(:load_from_fedora).with("changeme:22", nil).and_return("Fake Object2")
         mock_docs = [{"id" => "changeme:30"}, {"id" => "changeme:22"}]
-        mock_docs.should_receive(:has_next?).and_return(false)
-        ActiveFedora::SolrService.instance.conn.should_receive(:paginate).with(1, 1000, 'select', :params=>{:q=>@model_query, :qt => 'standard', :sort => [@sort_query], :fl=> 'id', }).and_return('response'=>{'docs'=>mock_docs})
-        SpecModel::Basic.all.should == ["Fake Object1", "Fake Object2"]
+        expect(mock_docs).to receive(:has_next?).and_return(false)
+        expect(ActiveFedora::SolrService.instance.conn).to receive(:paginate).with(1, 1000, 'select', :params=>{:q=>@model_query, :qt => 'standard', :sort => [@sort_query], :fl=> 'id', }).and_return('response'=>{'docs'=>mock_docs})
+        expect(SpecModel::Basic.all).to eq(["Fake Object1", "Fake Object2"])
       end
     end
     describe "called without a specific class" do
       let(:relation) { ActiveFedora::Relation.new(ActiveFedora::Base) }
       it "should specify a q parameter" do
-        relation.should_receive(:load_from_fedora).with("changeme:30", true).and_return("Fake Object1")
-        relation.should_receive(:load_from_fedora).with("changeme:22", true).and_return("Fake Object2")
+        expect(relation).to receive(:load_from_fedora).with("changeme:30", true).and_return("Fake Object1")
+        expect(relation).to receive(:load_from_fedora).with("changeme:22", true).and_return("Fake Object2")
         mock_docs = [{"id" => "changeme:30"},{"id" => "changeme:22"}]
-        mock_docs.should_receive(:has_next?).and_return(false)
-        ActiveFedora::SolrService.instance.conn.should_receive(:paginate).with(1, 1000, 'select', :params=>{:q=>'*:*', :qt => 'standard', :sort => [@sort_query], :fl=> 'id', }).and_return('response'=>{'docs'=>mock_docs})
-        ActiveFedora::Base.all.should == ["Fake Object1", "Fake Object2"]
+        expect(mock_docs).to receive(:has_next?).and_return(false)
+        expect(ActiveFedora::SolrService.instance.conn).to receive(:paginate).with(1, 1000, 'select', :params=>{:q=>'*:*', :qt => 'standard', :sort => [@sort_query], :fl=> 'id', }).and_return('response'=>{'docs'=>mock_docs})
+        expect(ActiveFedora::Base.all).to eq(["Fake Object1", "Fake Object2"])
       end
     end
   end
@@ -46,37 +46,37 @@ describe ActiveFedora::Base do
       describe "and a pid is specified" do
         it "should use SpecModel::Basic.allocate.init_with_object to instantiate an object" do
           allow_any_instance_of(SpecModel::Basic).to receive(:init_with_object).and_return(SpecModel::Basic.new )
-          ActiveFedora::DigitalObject.should_receive(:find).and_return(double("inner obj", :'new?'=>false))
-          SpecModel::Basic.find("_PID_", cast: false).should be_a SpecModel::Basic
+          expect(ActiveFedora::DigitalObject).to receive(:find).and_return(double("inner obj", :'new?'=>false))
+          expect(SpecModel::Basic.find("_PID_", cast: false)).to be_a SpecModel::Basic
         end
         it "should raise an exception if it is not found" do
           allow_any_instance_of(Rubydora::Fc3Service).to receive(:object).and_raise(RestClient::ResourceNotFound)
-          SpecModel::Basic.should_receive(:connection_for_pid).with("_PID_")
-          lambda {SpecModel::Basic.find("_PID_")}.should raise_error ActiveFedora::ObjectNotFoundError
+          expect(SpecModel::Basic).to receive(:connection_for_pid).with("_PID_")
+          expect {SpecModel::Basic.find("_PID_")}.to raise_error ActiveFedora::ObjectNotFoundError
         end
       end
     end
     describe "with default :cast of true" do
       it "should use SpecModel::Basic.allocate.init_with_object to instantiate an object" do
         allow_any_instance_of(SpecModel::Basic).to receive(:init_with_object).and_return(double("Model", :adapt_to_cmodel=>SpecModel::Basic.new ))
-        ActiveFedora::DigitalObject.should_receive(:find).and_return(double("inner obj", :'new?'=>false))
+        expect(ActiveFedora::DigitalObject).to receive(:find).and_return(double("inner obj", :'new?'=>false))
         SpecModel::Basic.find("_PID_")
       end
     end
 
     describe "with conditions" do
       before do
-        ActiveFedora::Base.stub(:relation => relation)
-        relation.stub(clone: relation)
+        allow(ActiveFedora::Base).to receive_messages(:relation => relation)
+        allow(relation).to receive_messages(clone: relation)
       end
       let(:relation) { ActiveFedora::Relation.new(SpecModel::Basic) }
       it "should filter by the provided fields" do
-        relation.should_receive(:load_from_fedora).with("changeme:30", nil).and_return("Fake Object1")
-        relation.should_receive(:load_from_fedora).with("changeme:22", nil).and_return("Fake Object2")
+        expect(relation).to receive(:load_from_fedora).with("changeme:30", nil).and_return("Fake Object1")
+        expect(relation).to receive(:load_from_fedora).with("changeme:22", nil).and_return("Fake Object2")
 
         mock_docs = [{"id" => "changeme:30"},{"id" => "changeme:22"}]
-        mock_docs.should_receive(:has_next?).and_return(false)
-        ActiveFedora::SolrService.instance.conn.should_receive(:paginate).with() { |page, rows, method, hash|
+        expect(mock_docs).to receive(:has_next?).and_return(false)
+        expect(ActiveFedora::SolrService.instance.conn).to receive(:paginate).with() { |page, rows, method, hash|
             page == 1 &&
             rows == 1000 &&
             method == 'select' &&
@@ -88,24 +88,24 @@ describe ActiveFedora::Base do
             hash[:params][:q].split(" AND ").include?("baz:quix") &&
             hash[:params][:q].split(" AND ").include?("baz:quack")
         }.and_return('response'=>{'docs'=>mock_docs})
-        SpecModel::Basic.find({:foo=>'bar', :baz=>['quix','quack']}).should == ["Fake Object1", "Fake Object2"]
+        expect(SpecModel::Basic.find({:foo=>'bar', :baz=>['quix','quack']})).to eq(["Fake Object1", "Fake Object2"])
       end
 
       it "should correctly query for empty strings" do
-        SpecModel::Basic.find( :active_fedora_model_ssi => '').count.should == 0
+        expect(SpecModel::Basic.find( :active_fedora_model_ssi => '').count).to eq(0)
       end
 
       it 'should correctly query for empty arrays' do
-        SpecModel::Basic.find( :active_fedora_model_ssi => []).count.should == 0
+        expect(SpecModel::Basic.find( :active_fedora_model_ssi => []).count).to eq(0)
       end
 
       it "should add options" do
-        relation.should_receive(:load_from_fedora).with("changeme:30", nil).and_return("Fake Object1")
-        relation.should_receive(:load_from_fedora).with("changeme:22", nil).and_return("Fake Object2")
+        expect(relation).to receive(:load_from_fedora).with("changeme:30", nil).and_return("Fake Object1")
+        expect(relation).to receive(:load_from_fedora).with("changeme:22", nil).and_return("Fake Object2")
 
         mock_docs = [{"id" => "changeme:30"},{"id" => "changeme:22"}]
-        mock_docs.should_receive(:has_next?).and_return(false)
-        ActiveFedora::SolrService.instance.conn.should_receive(:paginate).with() { |page, rows, method, hash|
+        expect(mock_docs).to receive(:has_next?).and_return(false)
+        expect(ActiveFedora::SolrService.instance.conn).to receive(:paginate).with() { |page, rows, method, hash|
             page == 1 &&
             rows == 1000 &&
             method == 'select' &&
@@ -117,34 +117,34 @@ describe ActiveFedora::Base do
             hash[:params][:q].split(" AND ").include?("baz:quix") &&
             hash[:params][:q].split(" AND ").include?("baz:quack")
         }.and_return('response'=>{'docs'=>mock_docs})
-        SpecModel::Basic.find({:foo=>'bar', :baz=>['quix','quack']}, :sort=>'title_t desc').should == ["Fake Object1", "Fake Object2"]
+        expect(SpecModel::Basic.find({:foo=>'bar', :baz=>['quix','quack']}, :sort=>'title_t desc')).to eq(["Fake Object1", "Fake Object2"])
       end
     end
   end
 
 
   describe '#find_each' do
-    before { ActiveFedora::Base.stub(:relation => relation) }
+    before { allow(ActiveFedora::Base).to receive_messages(:relation => relation) }
     let(:relation) { ActiveFedora::Relation.new(SpecModel::Basic) }
     it "should query solr for all objects with :active_fedora_model_s of self.class" do
       mock_docs = [{"id" => "changeme:30"},{"id" => "changeme:22"}]
-      mock_docs.should_receive(:has_next?).and_return(false)
-      ActiveFedora::SolrService.instance.conn.should_receive(:paginate).with(1, 1000, 'select', :params=>{:q=>@model_query, :qt => 'standard', :sort => [@sort_query], :fl=> 'id', }).and_return('response'=>{'docs'=>mock_docs})
+      expect(mock_docs).to receive(:has_next?).and_return(false)
+      expect(ActiveFedora::SolrService.instance.conn).to receive(:paginate).with(1, 1000, 'select', :params=>{:q=>@model_query, :qt => 'standard', :sort => [@sort_query], :fl=> 'id', }).and_return('response'=>{'docs'=>mock_docs})
       
-      relation.should_receive(:load_from_fedora).with("changeme:30", nil).and_return(SpecModel::Basic.new(:pid=>'changeme:30'))
-      relation.should_receive(:load_from_fedora).with("changeme:22", nil).and_return(SpecModel::Basic.new(:pid=>'changeme:22'))
+      expect(relation).to receive(:load_from_fedora).with("changeme:30", nil).and_return(SpecModel::Basic.new(:pid=>'changeme:30'))
+      expect(relation).to receive(:load_from_fedora).with("changeme:22", nil).and_return(SpecModel::Basic.new(:pid=>'changeme:22'))
       yielded = double("yielded method")
-      yielded.should_receive(:run).with { |obj| obj.class == SpecModel::Basic}.twice
+      expect(yielded).to receive(:run).with { |obj| obj.class == SpecModel::Basic}.twice
       SpecModel::Basic.find_each(){|obj| yielded.run(obj) }
     end
     describe "with conditions" do
       it "should filter by the provided fields" do
-        relation.should_receive(:load_from_fedora).with("changeme:30", nil).and_return(SpecModel::Basic.new(:pid=>'changeme:30'))
-        relation.should_receive(:load_from_fedora).with("changeme:22", nil).and_return(SpecModel::Basic.new(:pid=>'changeme:22'))
+        expect(relation).to receive(:load_from_fedora).with("changeme:30", nil).and_return(SpecModel::Basic.new(:pid=>'changeme:30'))
+        expect(relation).to receive(:load_from_fedora).with("changeme:22", nil).and_return(SpecModel::Basic.new(:pid=>'changeme:22'))
 
         mock_docs = [{"id" => "changeme:30"},{"id" => "changeme:22"}]
-        mock_docs.should_receive(:has_next?).and_return(false)
-        ActiveFedora::SolrService.instance.conn.should_receive(:paginate).with() { |page, rows, method, hash|
+        expect(mock_docs).to receive(:has_next?).and_return(false)
+        expect(ActiveFedora::SolrService.instance.conn).to receive(:paginate).with() { |page, rows, method, hash|
             page == 1 &&
             rows == 1000 &&
             method == 'select' &&
@@ -157,7 +157,7 @@ describe ActiveFedora::Base do
             hash[:params][:q].split(" AND ").include?("baz:quack")
         }.and_return('response'=>{'docs'=>mock_docs})
         yielded = double("yielded method")
-        yielded.should_receive(:run).with { |obj| obj.class == SpecModel::Basic}.twice
+        expect(yielded).to receive(:run).with { |obj| obj.class == SpecModel::Basic}.twice
         SpecModel::Basic.find_each({:foo=>'bar', :baz=>['quix','quack']}){|obj| yielded.run(obj) }
       end
     end
@@ -167,8 +167,8 @@ describe ActiveFedora::Base do
     describe "with conditions hash" do
       it "should filter by the provided fields" do
         mock_docs = double('docs')
-        mock_docs.should_receive(:has_next?).and_return(false)
-        ActiveFedora::SolrService.instance.conn.should_receive(:paginate).with() { |page, rows, method, hash|
+        expect(mock_docs).to receive(:has_next?).and_return(false)
+        expect(ActiveFedora::SolrService.instance.conn).to receive(:paginate).with() { |page, rows, method, hash|
             page == 1 &&
             rows == 1002 &&
             method == 'select' &&
@@ -181,8 +181,8 @@ describe ActiveFedora::Base do
             hash[:params][:q].split(" AND ").include?("baz:quack")
         }.and_return('response'=>{'docs'=>mock_docs})
         yielded = double("yielded method")
-        yielded.should_receive(:run).with(mock_docs)
-        SpecModel::Basic.find_in_batches({:foo=>'bar', :baz=>['quix','quack']}, {:batch_size=>1002, :fl=>'id'}){|group| yielded.run group }.should
+        expect(yielded).to receive(:run).with(mock_docs)
+        expect(SpecModel::Basic.find_in_batches({:foo=>'bar', :baz=>['quix','quack']}, {:batch_size=>1002, :fl=>'id'}){|group| yielded.run group }).to
       end
     end
   end
@@ -191,19 +191,19 @@ describe ActiveFedora::Base do
     
     it "should return a count" do
       mock_result = {'response'=>{'numFound'=>7}}
-      ActiveFedora::SolrService.should_receive(:query).with(@model_query, :rows=>0, :raw=>true).and_return(mock_result)
-      SpecModel::Basic.count.should == 7
+      expect(ActiveFedora::SolrService).to receive(:query).with(@model_query, :rows=>0, :raw=>true).and_return(mock_result)
+      expect(SpecModel::Basic.count).to eq(7)
     end
     it "should allow conditions" do
       mock_result = {'response'=>{'numFound'=>7}}
-      ActiveFedora::SolrService.should_receive(:query).with("#{@model_query} AND (foo:bar)", :rows=>0, :raw=>true).and_return(mock_result)
-      SpecModel::Basic.count(:conditions=>'foo:bar').should == 7
+      expect(ActiveFedora::SolrService).to receive(:query).with("#{@model_query} AND (foo:bar)", :rows=>0, :raw=>true).and_return(mock_result)
+      expect(SpecModel::Basic.count(:conditions=>'foo:bar')).to eq(7)
     end
 
     it "should count without a class specified" do
       mock_result = {'response'=>{'numFound'=>7}}
-      ActiveFedora::SolrService.should_receive(:query).with("(foo:bar)", :rows=>0, :raw=>true).and_return(mock_result)
-      ActiveFedora::Base.count(:conditions=>'foo:bar').should == 7 
+      expect(ActiveFedora::SolrService).to receive(:query).with("(foo:bar)", :rows=>0, :raw=>true).and_return(mock_result)
+      expect(ActiveFedora::Base.count(:conditions=>'foo:bar')).to eq(7) 
     end
   end
 
@@ -252,7 +252,7 @@ describe ActiveFedora::Base do
   describe '#find_with_conditions' do
     it "should make a query to solr and return the results" do
       mock_result = double('Result')
-           ActiveFedora::SolrService.should_receive(:query).with() { |args|
+           expect(ActiveFedora::SolrService).to receive(:query).with() { |args|
             q = args.first if args.is_a? Array
             q ||= args
             q.split(" AND ").include?(@model_query) &&
@@ -260,12 +260,12 @@ describe ActiveFedora::Base do
             q.split(" AND ").include?("baz:quix") &&
             q.split(" AND ").include?("baz:quack")
         }.and_return(mock_result)
-      SpecModel::Basic.find_with_conditions(:foo=>'bar', :baz=>['quix','quack']).should == mock_result
+      expect(SpecModel::Basic.find_with_conditions(:foo=>'bar', :baz=>['quix','quack'])).to eq(mock_result)
     end
 
     it "should escape quotes" do
       mock_result = double('Result')
-           ActiveFedora::SolrService.should_receive(:query).with() { |args|
+           expect(ActiveFedora::SolrService).to receive(:query).with() { |args|
             q = args.first if args.is_a? Array
             q ||= args
             q.split(" AND ").include?(@model_query) &&
@@ -274,18 +274,18 @@ describe ActiveFedora::Base do
             q.split(" AND ").include?('baz:7\\"\\ version') &&
             q.split(" AND ").include?('baz:quack')
         }.and_return(mock_result)
-      SpecModel::Basic.find_with_conditions(:foo=>'9" Nails', :baz=>['7" version','quack']).should == mock_result
+      expect(SpecModel::Basic.find_with_conditions(:foo=>'9" Nails', :baz=>['7" version','quack'])).to eq(mock_result)
     end
 
     it "shouldn't use the class if it's called on AF:Base " do
       mock_result = double('Result')
-      ActiveFedora::SolrService.should_receive(:query).with('baz:quack', {:sort => [@sort_query]}).and_return(mock_result)
-      ActiveFedora::Base.find_with_conditions(:baz=>'quack').should == mock_result
+      expect(ActiveFedora::SolrService).to receive(:query).with('baz:quack', {:sort => [@sort_query]}).and_return(mock_result)
+      expect(ActiveFedora::Base.find_with_conditions(:baz=>'quack')).to eq(mock_result)
     end
     it "should use the query string if it's provided and wrap it in parentheses" do
       mock_result = double('Result')
-      ActiveFedora::SolrService.should_receive(:query).with('(chunky:monkey)', {:sort => [@sort_query]}).and_return(mock_result)
-      ActiveFedora::Base.find_with_conditions('chunky:monkey').should == mock_result
+      expect(ActiveFedora::SolrService).to receive(:query).with('(chunky:monkey)', {:sort => [@sort_query]}).and_return(mock_result)
+      expect(ActiveFedora::Base.find_with_conditions('chunky:monkey')).to eq(mock_result)
     end
   end
 

--- a/spec/unit/rdf_datastream_spec.rb
+++ b/spec/unit/rdf_datastream_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 
 describe ActiveFedora::RDFDatastream do
   describe "a new instance" do
-    its(:metadata?) { should be_true}
-    its(:content_changed?) { should be_false}
+    its(:metadata?) { should be_truthy}
+    its(:content_changed?) { should be_falsey}
   end
   describe "an instance that exists in the datastore, but hasn't been loaded" do
     before do
@@ -27,30 +27,30 @@ describe ActiveFedora::RDFDatastream do
     end
     subject { @obj.descMetadata }
     it "should not load the descMetadata datastream when calling content_changed?" do
-      @obj.inner_object.repository.should_not_receive(:datastream_dissemination).with(hash_including(:dsid=>'descMetadata'))
-      subject.should_not be_content_changed
+      expect(@obj.inner_object.repository).not_to receive(:datastream_dissemination).with(hash_including(:dsid=>'descMetadata'))
+      expect(subject).not_to be_content_changed
     end
 
     it "should allow asserting an empty string" do
       subject.title = ['']
-      subject.title.should == ['']
+      expect(subject.title).to eq([''])
     end
 
     describe "when multivalue: false" do
       it "should return single values" do
         subject.description = 'my description'
-        subject.description.should == 'my description'
+        expect(subject.description).to eq('my description')
       end
     end
 
     it "should clear stuff" do
       subject.title = ['one', 'two', 'three']
       subject.title.clear
-      subject.graph.query([subject.rdf_subject,  RDF::DC.title, nil]).first.should be_nil
+      expect(subject.graph.query([subject.rdf_subject,  RDF::DC.title, nil]).first).to be_nil
     end
 
     it "should have a list of fields" do
-      MyDatastream.fields.should == [:title, :description]
+      expect(MyDatastream.fields).to eq([:title, :description])
     end
   end
 
@@ -98,8 +98,8 @@ describe ActiveFedora::RDFDatastream do
   describe 'legacy non-utf-8 characters' do
     let(:ds) do
       datastream = ActiveFedora::NtriplesRDFDatastream.new
-      datastream.stub(:new?).and_return(false)
-      datastream.stub(:datastream_content).and_return("<info:fedora/scholarsphere:qv33rx50r> <http://purl.org/dc/terms/description> \"\\n\xE2\x80\x99 \" .\n".force_encoding('ASCII-8BIT'))
+      allow(datastream).to receive(:new?).and_return(false)
+      allow(datastream).to receive(:datastream_content).and_return("<info:fedora/scholarsphere:qv33rx50r> <http://purl.org/dc/terms/description> \"\\n\xE2\x80\x99 \" .\n".force_encoding('ASCII-8BIT'))
       datastream
     end
     it "should not error on access" do

--- a/spec/unit/rdf_resource_datastream_spec.rb
+++ b/spec/unit/rdf_resource_datastream_spec.rb
@@ -159,7 +159,7 @@ describe ActiveFedora::RDFDatastream do
       context "persisted to repository" do
         before do
           DummySubnode.configure :repository => :default
-          DummySubnode.any_instance.stub(:repository).and_return(RDF::Repository.new)
+          allow_any_instance_of(DummySubnode).to receive(:repository).and_return(RDF::Repository.new)
           dummy = DummySubnode.new(RDF::URI('http://example.org/dummy/blah'))
           dummy.title = ['subbla']
           # We want to have to manually persist to the repository.

--- a/spec/unit/rdf_xml_writer_spec.rb
+++ b/spec/unit/rdf_xml_writer_spec.rb
@@ -35,7 +35,7 @@ describe ActiveFedora::RDFXMLWriter do
         writer << statement
       end
     end
-    content.should be_equivalent_to @rdf_xml_with_type
+    expect(content).to be_equivalent_to @rdf_xml_with_type
   end
   
   it 'should serialize graphs without rdf:type equivalently to RDF::RDFXML::Writer' do
@@ -57,7 +57,7 @@ describe ActiveFedora::RDFXMLWriter do
         writer << statement
       end
     end
-    EquivalentXml.equivalent?(local_content, @rdf_xml).should be_true
-    EquivalentXml.equivalent?(local_content, generic_content).should be_true
+    expect(EquivalentXml.equivalent?(local_content, @rdf_xml)).to be_truthy
+    expect(EquivalentXml.equivalent?(local_content, generic_content)).to be_truthy
   end
 end

--- a/spec/unit/rdfxml_rdf_datastream_spec.rb
+++ b/spec/unit/rdfxml_rdf_datastream_spec.rb
@@ -7,14 +7,14 @@ describe ActiveFedora::RdfxmlRDFDatastream do
         property :publisher, :predicate => RDF::DC.publisher
       end
       @subject = MyRdfxmlDatastream.new(@inner_object, 'mixed_rdf')
-      @subject.stub(:pid => 'test:1')
+      allow(@subject).to receive_messages(:pid => 'test:1')
     end
     after(:each) do
       Object.send(:remove_const, :MyRdfxmlDatastream)
     end
     it "should save and reload" do
       @subject.publisher = ["St. Martin's Press"]
-      @subject.serialize.should =~ /<rdf:RDF/
+      expect(@subject.serialize).to match(/<rdf:RDF/)
     end
   end
 
@@ -79,7 +79,7 @@ describe ActiveFedora::RdfxmlRDFDatastream do
     describe "a new instance" do
       subject { MyDatastream.new(double('inner object', :pid=>'test:1', :new_record? =>true), 'descMetadata', about:"http://library.ucsd.edu/ark:/20775/") }
       it "should have a subject" do
-        subject.rdf_subject.to_s.should == "http://library.ucsd.edu/ark:/20775/"
+        expect(subject.rdf_subject.to_s).to eq("http://library.ucsd.edu/ark:/20775/")
       end
 
     end
@@ -91,20 +91,20 @@ describe ActiveFedora::RdfxmlRDFDatastream do
         subject
       end
       it "should have a subject" do
-        subject.rdf_subject.to_s.should == "http://library.ucsd.edu/ark:/20775/"
+        expect(subject.rdf_subject.to_s).to eq("http://library.ucsd.edu/ark:/20775/")
       end
       it "should have controlGroup" do
-        subject.controlGroup.should == 'M'
+        expect(subject.controlGroup).to eq('M')
       end
       it "should have mimeType" do
-        subject.mimeType.should == 'text/xml'
+        expect(subject.mimeType).to eq('text/xml')
       end
       it "should have dsid" do
-        subject.dsid.should == 'descMetadata'
+        expect(subject.dsid).to eq('descMetadata')
       end
       it "should have fields" do
-        subject.resource_type.should == ["image"]
-        subject.title.first.value.should == ["example title"]
+        expect(subject.resource_type).to eq(["image"])
+        expect(subject.title.first.value).to eq(["example title"])
       end
     end
   end

--- a/spec/unit/relationship_graph_spec.rb
+++ b/spec/unit/relationship_graph_spec.rb
@@ -4,17 +4,17 @@ describe ActiveFedora::RelationshipGraph do
   before do 
     @graph = ActiveFedora::RelationshipGraph.new
     @n1 = ActiveFedora::Base.new()
-    @n1.stub(:pid => 'foo:777')
+    allow(@n1).to receive_messages(:pid => 'foo:777')
   end
 
   describe "#relationships" do
     it "should have hash accessors" do
-      @graph.should respond_to(:[])
+      expect(@graph).to respond_to(:[])
     end
 
     it "should initialize new relation keys" do
-      @graph[:has_description].should be_empty
-      @graph[:has_description].should respond_to(:<<)
+      expect(@graph[:has_description]).to be_empty
+      expect(@graph[:has_description]).to respond_to(:<<)
     end
 
   end
@@ -22,94 +22,94 @@ describe ActiveFedora::RelationshipGraph do
   it "should add relationships" do
     @n2 = ActiveFedora::Base.new
     @graph.add(:has_part, @n1)
-    @graph[:has_part].should == [@n1]
+    expect(@graph[:has_part]).to eq([@n1])
     @graph.add(:has_part, @n2)
-    @graph[:has_part].should == [@n1, @n2]
+    expect(@graph[:has_part]).to eq([@n1, @n2])
     @graph.add(:has_part, @n2)
-    @graph[:has_part].should == [@n1, @n2]
-    @graph.dirty.should be_true
+    expect(@graph[:has_part]).to eq([@n1, @n2])
+    expect(@graph.dirty).to be_truthy
   end
 
   it "should create a rdf graph" do
     graph = @graph.to_graph('info:fedora/foo:1')
-    graph.should be_kind_of RDF::Graph
-    graph.statements.to_a.should == []
+    expect(graph).to be_kind_of RDF::Graph
+    expect(graph.statements.to_a).to eq([])
 
     @graph.add(:has_part, @n1)
     graph = @graph.to_graph('info:fedora/foo:1')
     stmts = graph.statements.to_a
-    stmts.size.should == 1
+    expect(stmts.size).to eq(1)
     stmt = stmts.first
-    stmt.subject.to_s.should == 'info:fedora/foo:1'
-    stmt.predicate.to_s.should == 'info:fedora/fedora-system:def/relations-external#hasPart'
-    stmt.object.to_s.should == 'info:fedora/foo:777'
+    expect(stmt.subject.to_s).to eq('info:fedora/foo:1')
+    expect(stmt.predicate.to_s).to eq('info:fedora/fedora-system:def/relations-external#hasPart')
+    expect(stmt.object.to_s).to eq('info:fedora/foo:777')
     
   end
 
   it "should have array accessor" do
     @graph.add(:has_part, @n1)
-    @graph[:has_part].should == [@n1]
+    expect(@graph[:has_part]).to eq([@n1])
   end
 
   describe "has_predicate?" do
     it "should return true when it has it" do
-      @graph.has_predicate?(:has_part).should be_false
+      expect(@graph.has_predicate?(:has_part)).to be_falsey
       @graph.add(:has_part, @n1)
-      @graph.has_predicate?(:has_part).should be_true
+      expect(@graph.has_predicate?(:has_part)).to be_truthy
     end
   end
 
   describe "delete" do
     it "should delete an object when an object is passed" do
       @graph.add(:has_part, @n1)
-      @graph[:has_part].should == [@n1]
+      expect(@graph[:has_part]).to eq([@n1])
       @graph.delete(:has_part, @n1)
-      @graph[:has_part].should == []
+      expect(@graph[:has_part]).to eq([])
     end
     it "should delete an pid when an object is passed" do
       #a reloaded rels-ext is just a list of uris, not inflated.
       @graph.add(:has_part, 'info:fedora/foo:777')
-      @graph[:has_part].should == ['info:fedora/foo:777']
+      expect(@graph[:has_part]).to eq(['info:fedora/foo:777'])
       @graph.delete(:has_part, @n1)
-      @graph[:has_part].should == []
+      expect(@graph[:has_part]).to eq([])
     end
     it "should delete an pid when a string is passed" do
       #a reloaded rels-ext is just a list of uris, not inflated.
       @graph.add(:has_part, 'info:fedora/foo:777')
-      @graph[:has_part].should == ['info:fedora/foo:777']
+      expect(@graph[:has_part]).to eq(['info:fedora/foo:777'])
       @graph.delete(:has_part, 'info:fedora/foo:777')
-      @graph[:has_part].should == []
+      expect(@graph[:has_part]).to eq([])
     end
     it "should delete an object when a pid is passed" do
       #a reloaded rels-ext is just a list of uris, not inflated.
       @graph.add(:has_part, @n1)
-      @graph[:has_part].should == [@n1]
+      expect(@graph[:has_part]).to eq([@n1])
       @graph.delete(:has_part, 'info:fedora/foo:777')
-      @graph[:has_part].should == []
+      expect(@graph[:has_part]).to eq([])
     end
 
     it "should delete all the predicates if only one arg is passed" do
       @graph.add(:has_part, @n1)
-      @graph[:has_part].should == [@n1]
+      expect(@graph[:has_part]).to eq([@n1])
       @graph.delete(:has_part)
-      @graph.has_predicate?(:has_part).should_not be_true
+      expect(@graph.has_predicate?(:has_part)).not_to be_truthy
     end
   end
   describe "build_statement" do
     it "should raise an error when the target is a pid, not a uri" do
-      lambda { @graph.build_statement('info:fedora/spec:9', :is_part_of, 'spec:7') }.should raise_error ArgumentError
+      expect { @graph.build_statement('info:fedora/spec:9', :is_part_of, 'spec:7') }.to raise_error ArgumentError
     end
     it "should run the happy path" do
       stm = @graph.build_statement('info:fedora/spec:9', :is_part_of, 'info:fedora/spec:7')
-      stm.object.to_s.should == "info:fedora/spec:7"
+      expect(stm.object.to_s).to eq("info:fedora/spec:7")
     end
     it "should also be happy with non-info URIs" do
       stm = @graph.build_statement('info:fedora/spec:9', :is_annotation_of, 'http://www.w3.org/standards/techs/rdf')
-      stm.object.to_s.should == "http://www.w3.org/standards/techs/rdf"
+      expect(stm.object.to_s).to eq("http://www.w3.org/standards/techs/rdf")
     end
     it "should also be happy with targets that are URI::Generics" do
       stm = @graph.build_statement('info:fedora/spec:9', :is_annotation_of, URI.parse('http://www.w3.org/standards/techs/rdf'))
-      stm.object.to_s.should == "http://www.w3.org/standards/techs/rdf"
+      expect(stm.object.to_s).to eq("http://www.w3.org/standards/techs/rdf")
     end
   end
 end

--- a/spec/unit/reload_on_save_spec.rb
+++ b/spec/unit/reload_on_save_spec.rb
@@ -4,19 +4,19 @@ describe ActiveFedora::ReloadOnSave do
   let(:file) {  ActiveFedora::Base.new  }
 
   it 'defaults to call not reload' do
-    file.should_not_receive(:reload)
+    expect(file).not_to receive(:reload)
     file.save
   end
 
   it 'reload can be turned on' do
     file.reload_on_save = true
-    file.should_receive(:reload)
+    expect(file).to receive(:reload)
     file.save
   end
 
   it 'allows reload to be turned off and on' do
     file.reload_on_save = true
-    file.should_receive(:reload).once
+    expect(file).to receive(:reload).once
     file.save
     file.reload_on_save = false
     file.save

--- a/spec/unit/rels_ext_datastream_spec.rb
+++ b/spec/unit/rels_ext_datastream_spec.rb
@@ -10,30 +10,30 @@ describe ActiveFedora::RelsExtDatastream do
   before(:each) do
       mock_inner = double('inner object')
       @mock_repo = double('repository')
-      @mock_repo.stub(:datastream_dissemination=>'My Content', :config=>{})
-      mock_inner.stub(:repository).and_return(@mock_repo)
-      mock_inner.stub(:pid).and_return(@pid)
+      allow(@mock_repo).to receive_messages(:datastream_dissemination=>'My Content', :config=>{})
+      allow(mock_inner).to receive(:repository).and_return(@mock_repo)
+      allow(mock_inner).to receive(:pid).and_return(@pid)
       @test_ds = ActiveFedora::RelsExtDatastream.new(mock_inner, "RELS-EXT")
-      @test_ds.stub(:profile).and_return({})
+      allow(@test_ds).to receive(:profile).and_return({})
   end
 
-  its(:metadata?) { should be_true}
+  its(:metadata?) { should be_truthy}
   its(:controlGroup) { should == "X"}
 
   describe "#mimeType" do
     it 'should use the application/rdf+xml mime type' do
-      @test_ds.mimeType.should == 'application/rdf+xml'
+      expect(@test_ds.mimeType).to eq('application/rdf+xml')
     end
   end
 
   describe "#changed?" do
     it "should be false when no changes have been made" do
       subject.model = double(:relationships_are_dirty? => false)
-      subject.changed?.should == false
+      expect(subject.changed?).to eq(false)
     end
     it "should be true when the model has changes" do
       subject.model = double(:relationships_are_dirty? => true)
-      subject.changed?.should == true
+      expect(subject.changed?).to eq(true)
     end
   end
   
@@ -45,9 +45,9 @@ describe ActiveFedora::RelsExtDatastream do
       subject = RDF::URI.new "info:fedora/test:sample_pid"
       graph.insert RDF::Statement.new(subject, ActiveFedora::Predicates.find_graph_predicate(:is_member_of),  RDF::URI.new('demo:10'))
       
-      @test_ds.stub(:new? => true, :relationships => graph, :model => double(:relationships_are_dirty? =>true, :relationships_are_not_dirty! => true))
+      allow(@test_ds).to receive_messages(:new? => true, :relationships => graph, :model => double(:relationships_are_dirty? =>true, :relationships_are_not_dirty! => true))
       @test_ds.serialize!
-      EquivalentXml.equivalent?(@test_ds.content, "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>\n        <rdf:Description rdf:about='info:fedora/test:sample_pid'>\n        <isMemberOf rdf:resource='demo:10' xmlns='info:fedora/fedora-system:def/relations-external#'/></rdf:Description>\n      </rdf:RDF>").should be_true
+      expect(EquivalentXml.equivalent?(@test_ds.content, "<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>\n        <rdf:Description rdf:about='info:fedora/test:sample_pid'>\n        <isMemberOf rdf:resource='demo:10' xmlns='info:fedora/fedora-system:def/relations-external#'/></rdf:Description>\n      </rdf:RDF>")).to be_truthy
     end
   
   end
@@ -78,8 +78,8 @@ describe ActiveFedora::RelsExtDatastream do
       graph.insert RDF::Statement.new(subject, ActiveFedora::Predicates.find_graph_predicate(:has_model),  RDF::URI.new("info:fedora/afmodel:OtherModel"))
       graph.insert RDF::Statement.new(subject, ActiveFedora::Predicates.find_graph_predicate(:has_model),  RDF::URI.new("info:fedora/afmodel:SampleModel"))
 
-      @test_ds.should_receive(:model).and_return(double("model", :relationships=>graph, :relationships_are_dirty= => true))
-      EquivalentXml.equivalent?(@test_ds.to_rels_ext(), @sample_rels_ext_xml).should be_true
+      expect(@test_ds).to receive(:model).and_return(double("model", :relationships=>graph, :relationships_are_dirty= => true))
+      expect(EquivalentXml.equivalent?(@test_ds.to_rels_ext(), @sample_rels_ext_xml)).to be_truthy
     end
     
     it 'should use mapped namespace prefixes when given' do
@@ -91,21 +91,21 @@ describe ActiveFedora::RelsExtDatastream do
       graph.insert RDF::Statement.new(subject, ActiveFedora::Predicates.find_graph_predicate(:has_model),  RDF::URI.new("info:fedora/afmodel:OtherModel"))
       graph.insert RDF::Statement.new(subject, ActiveFedora::Predicates.find_graph_predicate(:has_model),  RDF::URI.new("info:fedora/afmodel:SampleModel"))
 
-      @test_ds.stub(:model).and_return(double("model", :relationships=>graph, :relationships_are_dirty= => true))
+      allow(@test_ds).to receive(:model).and_return(double("model", :relationships=>graph, :relationships_are_dirty= => true))
       rels = @test_ds.to_rels_ext()
-      EquivalentXml.equivalent?(rels, @sample_rels_ext_xml).should be_true
-      rels.should_not =~ /fedora:isMemberOf/
-      rels.should_not =~ /fedora-model:hasModel/
-      rels.should =~ /ns\d:isMemberOf/
-      rels.should =~ /ns\d:hasModel/
+      expect(EquivalentXml.equivalent?(rels, @sample_rels_ext_xml)).to be_truthy
+      expect(rels).not_to match(/fedora:isMemberOf/)
+      expect(rels).not_to match(/fedora-model:hasModel/)
+      expect(rels).to match(/ns\d:isMemberOf/)
+      expect(rels).to match(/ns\d:hasModel/)
       
       ActiveFedora::Predicates.predicate_config[:predicate_namespaces] = {:"fedora-model"=>"info:fedora/fedora-system:def/model#", :fedora=>"info:fedora/fedora-system:def/relations-external#"}
       rels = @test_ds.to_rels_ext()
-      EquivalentXml.equivalent?(rels, @sample_rels_ext_xml).should be_true
-      rels.should =~ /fedora:isMemberOf/
-      rels.should =~ /fedora-model:hasModel/
-      rels.should_not =~ /ns\d:isMemberOf/
-      rels.should_not =~ /ns\d:hasModel/
+      expect(EquivalentXml.equivalent?(rels, @sample_rels_ext_xml)).to be_truthy
+      expect(rels).to match(/fedora:isMemberOf/)
+      expect(rels).to match(/fedora-model:hasModel/)
+      expect(rels).not_to match(/ns\d:isMemberOf/)
+      expect(rels).not_to match(/ns\d:hasModel/)
       ActiveFedora::Predicates.predicate_config[:predicate_namespaces] = nil
     end
     
@@ -125,8 +125,8 @@ describe ActiveFedora::RelsExtDatastream do
     it "should handle un-mapped predicates gracefully" do
       @test_obj.add_relationship("foo", "info:fedora/foo:bar")
       @test_obj.save
-      @test_obj.relationships.size.should == 5 
-      @test_obj.ids_for_outbound("foo").should == ["foo:bar"]
+      expect(@test_obj.relationships.size).to eq(5) 
+      expect(@test_obj.ids_for_outbound("foo")).to eq(["foo:bar"])
     end
     it "should automatically map un-mapped predicates" do
       xml = <<-EOS
@@ -144,8 +144,8 @@ describe ActiveFedora::RelsExtDatastream do
       model = ActiveFedora::Base.new
       new_ds = ActiveFedora::RelsExtDatastream.new
       new_ds.model = model
-      lambda { ActiveFedora::RelsExtDatastream.from_xml(xml, new_ds) }.should_not raise_exception
-      new_ds.to_rels_ext.should =~ /missing:hasOtherRelationship/
+      expect { ActiveFedora::RelsExtDatastream.from_xml(xml, new_ds) }.not_to raise_exception
+      expect(new_ds.to_rels_ext).to match(/missing:hasOtherRelationship/)
     end
     it "should handle un-mapped literals" do
       xml = "
@@ -162,7 +162,7 @@ describe ActiveFedora::RelsExtDatastream do
       new_ds.model = model
       ActiveFedora::RelsExtDatastream.from_xml(xml, new_ds)
       new_ext = new_ds.to_rels_ext()
-      new_ext.should match "<ns2:itemID>oai:hull.ac.uk:hull:2708</ns2:itemID>"
+      expect(new_ext).to match "<ns2:itemID>oai:hull.ac.uk:hull:2708</ns2:itemID>"
       
     end
   end

--- a/spec/unit/rspec_matchers/belong_to_associated_active_fedora_object_matcher_spec.rb
+++ b/spec/unit/rspec_matchers/belong_to_associated_active_fedora_object_matcher_spec.rb
@@ -10,17 +10,17 @@ describe RSpec::Matchers, "belong_to_associated_active_fedora_object_matcher" do
   let(:association) { :association }
 
   it 'should match when association is properly stored in fedora' do
-    subject.class.should_receive(:find).with(pid).and_return(subject)
-    subject.should_receive(association).and_return(object1)
-    subject.should belong_to_associated_active_fedora_object(association).with_object(object1)
+    expect(subject.class).to receive(:find).with(pid).and_return(subject)
+    expect(subject).to receive(association).and_return(object1)
+    expect(subject).to belong_to_associated_active_fedora_object(association).with_object(object1)
   end
 
   it 'should not match when association is different' do
-    subject.class.should_receive(:find).with(pid).and_return(subject)
-    subject.should_receive(association).and_return(object1)
-    lambda {
-      subject.should belong_to_associated_active_fedora_object(association).with_object(object2)
-    }.should (
+    expect(subject.class).to receive(:find).with(pid).and_return(subject)
+    expect(subject).to receive(association).and_return(object1)
+    expect {
+      expect(subject).to belong_to_associated_active_fedora_object(association).with_object(object2)
+    }.to (
       raise_error(
         RSpec::Expectations::ExpectationNotMetError,
         /expected #{subject.class} PID=#{pid} association: #{association.inspect}/
@@ -29,9 +29,9 @@ describe RSpec::Matchers, "belong_to_associated_active_fedora_object_matcher" do
   end
 
   it 'should require :with_object option' do
-    lambda {
-      subject.should belong_to_associated_active_fedora_object(association)
-    }.should(
+    expect {
+      expect(subject).to belong_to_associated_active_fedora_object(association)
+    }.to(
       raise_error(
         ArgumentError,
         "subject.should belong_to_associated_active_fedora_object(<association_name>).with_object(<object>)"

--- a/spec/unit/rspec_matchers/have_many_associated_active_fedora_objects_matcher_spec.rb
+++ b/spec/unit/rspec_matchers/have_many_associated_active_fedora_objects_matcher_spec.rb
@@ -11,17 +11,17 @@ describe RSpec::Matchers, "have_many_associated_active_fedora_objects_matcher" d
   let(:association) { :association }
 
   it 'should match when association is properly stored in fedora' do
-    subject.class.should_receive(:find).with(pid).and_return(subject)
-    subject.should_receive(association).and_return([object1,object2])
-    subject.should have_many_associated_active_fedora_objects(association).with_objects([object1, object2])
+    expect(subject.class).to receive(:find).with(pid).and_return(subject)
+    expect(subject).to receive(association).and_return([object1,object2])
+    expect(subject).to have_many_associated_active_fedora_objects(association).with_objects([object1, object2])
   end
 
   it 'should not match when association is different' do
-    subject.class.should_receive(:find).with(pid).and_return(subject)
-    subject.should_receive(association).and_return([object1,object3])
-    lambda {
-      subject.should have_many_associated_active_fedora_objects(association).with_objects([object1, object2])
-    }.should (
+    expect(subject.class).to receive(:find).with(pid).and_return(subject)
+    expect(subject).to receive(association).and_return([object1,object3])
+    expect {
+      expect(subject).to have_many_associated_active_fedora_objects(association).with_objects([object1, object2])
+    }.to (
       raise_error(
         RSpec::Expectations::ExpectationNotMetError,
         /expected #{subject.class} PID=#{pid} association: #{association.inspect}/
@@ -30,9 +30,9 @@ describe RSpec::Matchers, "have_many_associated_active_fedora_objects_matcher" d
   end
 
   it 'should require :with_objects option' do
-    lambda {
-      subject.should have_many_associated_active_fedora_objects(association)
-    }.should(
+    expect {
+      expect(subject).to have_many_associated_active_fedora_objects(association)
+    }.to(
       raise_error(
         ArgumentError,
         "subject.should have_many_associated_active_fedora_objects(<association_name>).with_objects(<objects[]>)"

--- a/spec/unit/rspec_matchers/have_predicate_matcher_spec.rb
+++ b/spec/unit/rspec_matchers/have_predicate_matcher_spec.rb
@@ -11,17 +11,17 @@ describe RSpec::Matchers, "have_predicate_matcher" do
   let(:predicate) { :predicate }
 
   it 'should match when relationship is "what we have in Fedora"' do
-    subject.class.should_receive(:find).with(pid).and_return(subject)
-    subject.should_receive(:relationships).with(predicate).and_return([object1,object2])
-    subject.should have_predicate(predicate).with_objects([object1, object2])
+    expect(subject.class).to receive(:find).with(pid).and_return(subject)
+    expect(subject).to receive(:relationships).with(predicate).and_return([object1,object2])
+    expect(subject).to have_predicate(predicate).with_objects([object1, object2])
   end
 
   it 'should not match when relationship is different' do
-    subject.class.should_receive(:find).with(pid).and_return(subject)
-    subject.should_receive(:relationships).with(predicate).and_return([object1,object3])
-    lambda {
-      subject.should have_predicate(predicate).with_objects([object1, object2])
-    }.should (
+    expect(subject.class).to receive(:find).with(pid).and_return(subject)
+    expect(subject).to receive(:relationships).with(predicate).and_return([object1,object3])
+    expect {
+      expect(subject).to have_predicate(predicate).with_objects([object1, object2])
+    }.to (
       raise_error(
         RSpec::Expectations::ExpectationNotMetError,
         /expected #{subject.class} PID=#{pid} relationship: #{predicate.inspect}/
@@ -30,9 +30,9 @@ describe RSpec::Matchers, "have_predicate_matcher" do
   end
 
   it 'should require :with_objects option' do
-    lambda {
-      subject.should have_predicate(predicate)
-    }.should(
+    expect {
+      expect(subject).to have_predicate(predicate)
+    }.to(
       raise_error(
         ArgumentError,
         "subject.should have_predicate(<predicate>).with_objects(<objects[]>)"

--- a/spec/unit/rspec_matchers/match_fedora_datastream_matcher_spec.rb
+++ b/spec/unit/rspec_matchers/match_fedora_datastream_matcher_spec.rb
@@ -15,14 +15,14 @@ describe RSpec::Matchers, "match_fedora_datastream" do
 
   it 'should match based on request' do
     stub_request(:get, datastream_url).to_return(:body => expected_xml, :status => 200)
-    subject.should match_fedora_datastream(datastream_name).with(expected_xml)
+    expect(subject).to match_fedora_datastream(datastream_name).with(expected_xml)
   end
 
   it 'should handle non-matching requests' do
     stub_request(:get, datastream_url).to_return(:body => "<parent>#{expected_xml}</parent>", :status => 200)
-    lambda {
-      subject.should match_fedora_datastream(datastream_name).with(expected_xml)
-    }.should(
+    expect {
+      expect(subject).to match_fedora_datastream(datastream_name).with(expected_xml)
+    }.to(
       raise_error(
         RSpec::Expectations::ExpectationNotMetError,
         /expected #{subject.class} PID=#{pid} datastream: #{datastream_name.inspect} to match Fedora/
@@ -32,9 +32,9 @@ describe RSpec::Matchers, "match_fedora_datastream" do
 
   it 'should require :with option' do
     stub_request(:get, datastream_url).to_return(:body => "<parent>#{expected_xml}</parent>", :status => 200)
-    lambda {
-      subject.should match_fedora_datastream(datastream_name)
-    }.should(
+    expect {
+      expect(subject).to match_fedora_datastream(datastream_name)
+    }.to(
       raise_error(
         ArgumentError,
         "match_fedora_datastream(<datastream_name>).with(<expected_xml>)"

--- a/spec/unit/rubydora_connection_spec.rb
+++ b/spec/unit/rubydora_connection_spec.rb
@@ -5,9 +5,9 @@ describe ActiveFedora::RubydoraConnection do
   describe 'initialize' do
     it "should pass through valid options" do
       @instance = ActiveFedora::RubydoraConnection.new :timeout => 3600, :fake_option => :missing, :force => true, :validateChecksum=>true
-      @instance.connection.client.options[:timeout].should == 3600
-      @instance.connection.config[:validateChecksum].should == true
-      @instance.connection.client.options.has_key?(:fake_option).should be_false
+      expect(@instance.connection.client.options[:timeout]).to eq(3600)
+      expect(@instance.connection.config[:validateChecksum]).to eq(true)
+      expect(@instance.connection.client.options.has_key?(:fake_option)).to be_falsey
     end
   end
 end

--- a/spec/unit/semantic_node_spec.rb
+++ b/spec/unit/semantic_node_spec.rb
@@ -22,7 +22,7 @@ describe ActiveFedora::SemanticNode do
       end
 
       @node = SpecNode.new
-      @node.stub(:rels_ext).and_return(double("rels_ext", :content_will_change! => true, :content=>''))
+      allow(@node).to receive(:rels_ext).and_return(double("rels_ext", :content_will_change! => true, :content=>''))
       @node.pid = increment_pid
     end
     
@@ -32,37 +32,37 @@ describe ActiveFedora::SemanticNode do
 
     describe "pid_from_uri" do
       it "should strip the info:fedora/ out of a given string" do 
-        SpecNode.pid_from_uri("info:fedora/FOO:BAR").should == "FOO:BAR"
+        expect(SpecNode.pid_from_uri("info:fedora/FOO:BAR")).to eq("FOO:BAR")
       end
     end
     
     describe ".add_relationship" do
       it "should add relationship to the relationships graph" do
         @node.add_relationship("isMemberOf", 'demo:9')
-        @node.ids_for_outbound("isMemberOf").should == ['demo:9']
+        expect(@node.ids_for_outbound("isMemberOf")).to eq(['demo:9'])
       end
       it "should not be written into the graph until it is saved" do
         @n1 = ActiveFedora::Base.new
         @node.add_relationship(:has_part, @n1)
-        @node.relationships.statements.to_a.first.object.to_s.should == 'info:fedora/' 
+        expect(@node.relationships.statements.to_a.first.object.to_s).to eq('info:fedora/') 
         @n1.save
-        @node.relationships.statements.to_a.first.object.to_s.should == @n1.internal_uri
+        expect(@node.relationships.statements.to_a.first.object.to_s).to eq(@n1.internal_uri)
       end
 
       it "should add a literal relationship to the relationships graph" do
         @node.add_relationship("isMemberOf", 'demo:9', true)
-        @node.relationships("isMemberOf").should == ['demo:9']
+        expect(@node.relationships("isMemberOf")).to eq(['demo:9'])
       end
       
       it "adding relationship to an instance should not affect class-level relationships hash" do 
         local_test_node1 = SpecNode.new
         local_test_node2 = SpecNode.new
-        local_test_node1.stub(:rels_ext).and_return(double("rels_ext", :content_will_change! => true, :content=>''))
+        allow(local_test_node1).to receive(:rels_ext).and_return(double("rels_ext", :content_will_change! => true, :content=>''))
         local_test_node1.add_relationship(:is_member_of, 'demo:10')
-        local_test_node2.stub(:rels_ext).and_return(double('rels-ext', :content=>''))
+        allow(local_test_node2).to receive(:rels_ext).and_return(double('rels-ext', :content=>''))
         
-        local_test_node1.relationships(:is_member_of).should == ["demo:10"]
-        local_test_node2.relationships(:is_member_of).should == []
+        expect(local_test_node1.relationships(:is_member_of)).to eq(["demo:10"])
+        expect(local_test_node2.relationships(:is_member_of)).to eq([])
       end
       
     end
@@ -75,28 +75,28 @@ describe ActiveFedora::SemanticNode do
       end
       it "should clear the specified relationship" do
         @node.clear_relationship(:is_member_of)
-        @node.relationships(:is_member_of).should == []
-        @node.relationships(:has_description).should == ['demo:9']
+        expect(@node.relationships(:is_member_of)).to eq([])
+        expect(@node.relationships(:has_description)).to eq(['demo:9'])
       end
     end
     
     describe '#remove_relationship' do
       it 'should remove a relationship from the relationships hash' do
-        @node.stub(:rels_ext).and_return(double("rels_ext", :content_will_change! => true, :content=>''))
+        allow(@node).to receive(:rels_ext).and_return(double("rels_ext", :content_will_change! => true, :content=>''))
         @node.add_relationship(:has_part, "info:fedora/3")
         @node.add_relationship(:has_part, "info:fedora/4")
         #check both are there
-        @node.ids_for_outbound(:has_part).should include "3", "4"
+        expect(@node.ids_for_outbound(:has_part)).to include "3", "4"
         @node.remove_relationship(:has_part, "info:fedora/3")
         #check returns false if relationship does not exist and does nothing with different predicate
         @node.remove_relationship(:has_member,"info:fedora/4")
         #check only one item removed
-        @node.ids_for_outbound(:has_part).should == ['4']
+        expect(@node.ids_for_outbound(:has_part)).to eq(['4'])
         @node.remove_relationship(:has_part,"info:fedora/4")
         #check last item removed and predicate removed since now emtpy
-        @node.ids_for_outbound(:has_part).should == []
+        expect(@node.ids_for_outbound(:has_part)).to eq([])
 
-        @node.relationships_are_dirty.should == true
+        expect(@node.relationships_are_dirty).to eq(true)
         
       end
     end

--- a/spec/unit/serializers_spec.rb
+++ b/spec/unit/serializers_spec.rb
@@ -14,7 +14,7 @@ describe ActiveFedora::Attributes::Serializers do
     subject { Foo.new }
     it "should deserialize dates" do
       subject.attributes = {'birthday(1i)' =>'2012', 'birthday(2i)' =>'10', 'birthday(3i)' => '31'}
-      subject.birthday.should == '2012-10-31'
+      expect(subject.birthday).to eq('2012-10-31')
     end
   end
 

--- a/spec/unit/service_definitions_spec.rb
+++ b/spec/unit/service_definitions_spec.rb
@@ -14,50 +14,50 @@ describe ActiveFedora::ServiceDefinitions do
 </fmm:MethodMap>
     MMAP
     @repository = ActiveFedora::Base.connection_for_pid(0)
-    @repository.stub(:datastream_dissemination).with({:pid=>'test:12',:dsid=>'METHODMAP'}).and_return mmap
+    allow(@repository).to receive(:datastream_dissemination).with({:pid=>'test:12',:dsid=>'METHODMAP'}).and_return mmap
     Test.has_service_definition "test:12"
   end
 
   subject { 
       obj = Test.new()
-      obj.stub(:pid).and_return('monkey:99')
+      allow(obj).to receive(:pid).and_return('monkey:99')
       obj
     }
   describe "method lookup" do
     it "should find method keys in the YAML config" do
-      ActiveFedora::ServiceDefinitions.lookup_method("fedora-system:3", "viewObjectProfile").should == :object_profile
+      expect(ActiveFedora::ServiceDefinitions.lookup_method("fedora-system:3", "viewObjectProfile")).to eq(:object_profile)
     end
   end
   describe "method creation" do
     it "should create the system sdef methods" do
-      subject.should respond_to(:object_profile)
+      expect(subject).to respond_to(:object_profile)
     end
     it "should create the declared sdef methods" do
-      subject.should respond_to(:document_style_1)
+      expect(subject).to respond_to(:document_style_1)
     end
   end
   describe "generated method" do
     it "should call the appropriate rubydora rest api method" do
-      @repository.should_receive(:dissemination).with({:pid=>'monkey:99',:sdef=>'test:12', :method=>'getDocumentStyle1'})
+      expect(@repository).to receive(:dissemination).with({:pid=>'monkey:99',:sdef=>'test:12', :method=>'getDocumentStyle1'})
       #@mock_client.stub(:[]).with('objects/monkey%3A99/methods/test%3A12/getDocumentStyle1')
 
       subject.document_style_1
     end
     it "should call the appropriate rubydora rest api method with parameters" do
-      @repository.should_receive(:dissemination).with({:pid=>'monkey:99',:sdef=>'test:12', :method=>'getDocumentStyle1', :format=>'xml'})
+      expect(@repository).to receive(:dissemination).with({:pid=>'monkey:99',:sdef=>'test:12', :method=>'getDocumentStyle1', :format=>'xml'})
       obj = Test.new()
-      obj.stub(:pid).and_return('monkey:99')
+      allow(obj).to receive(:pid).and_return('monkey:99')
       obj.document_style_1({:format=>'xml'})
     end
     it "should call the appropriate rubydora rest api method with a block" do
-      @repository.stub(:dissemination).with({:pid=>'monkey:99',:sdef=>'test:12', :method=>'getDocumentStyle1'}).and_yield "ping!","pang!"
+      allow(@repository).to receive(:dissemination).with({:pid=>'monkey:99',:sdef=>'test:12', :method=>'getDocumentStyle1'}).and_yield "ping!","pang!"
       obj = Test.new()
-      obj.stub(:pid).and_return('monkey:99')
+      allow(obj).to receive(:pid).and_return('monkey:99')
       block_response = ""
       obj.document_style_1 {|res,req|
         block_response += 'pong!' if res == "ping!" and req == "pang!"
       }
-      block_response.should == "pong!"
+      expect(block_response).to eq("pong!")
     end
   end
 end

--- a/spec/unit/simple_datastream_spec.rb
+++ b/spec/unit/simple_datastream_spec.rb
@@ -12,7 +12,7 @@ describe ActiveFedora::SimpleDatastream do
 
   end
   it "from_xml should parse everything correctly" do
-    @test_ds.ng_xml.should be_equivalent_to @sample_xml
+    expect(@test_ds.ng_xml).to be_equivalent_to @sample_xml
   end
 
   
@@ -23,14 +23,14 @@ describe ActiveFedora::SimpleDatastream do
         it "should respond to getters and setters for the string typed #{el} element" do
           value = "Hey #{el}"
           @test_ds.send("#{el.to_s}=", value) 
-          @test_ds.send(el).first.should == value  #Looking at first because creator has 2 nodes
+          expect(@test_ds.send(el).first).to eq(value)  #Looking at first because creator has 2 nodes
         end
       end
 
       it "should set date elements" do
         d = Date.parse('1939-05-23')
         @test_ds.creation_date = d
-        @test_ds.creation_date.first.should == d
+        expect(@test_ds.creation_date.first).to eq(d)
       end
     end
   end
@@ -40,7 +40,7 @@ describe ActiveFedora::SimpleDatastream do
       @test_ds.publisher= "charlie"
       @test_ds.coverage= ["80%", "20%"]
 
-      @test_ds.to_xml.should be_equivalent_to('
+      expect(@test_ds.to_xml).to be_equivalent_to('
         <fields>
           <coverage>80%</coverage>
           <coverage>20%</coverage>
@@ -54,8 +54,8 @@ describe ActiveFedora::SimpleDatastream do
   describe "#to_solr" do
     it "should have title" do
       solr = @test_ds.to_solr
-      solr[ActiveFedora::SolrService.solr_name('publisher', type: :string)].should == "publisher1"
-      solr[ActiveFedora::SolrService.solr_name('creation_date', type: :date)].should == "2012-01-15"
+      expect(solr[ActiveFedora::SolrService.solr_name('publisher', type: :string)]).to eq("publisher1")
+      expect(solr[ActiveFedora::SolrService.solr_name('creation_date', type: :date)]).to eq("2012-01-15")
     end
   end
 

--- a/spec/unit/solr_config_options_spec.rb
+++ b/spec/unit/solr_config_options_spec.rb
@@ -24,17 +24,17 @@ describe ActiveFedora do
       SOLR_DOCUMENT_ID = "id"
     end
     it "should be used by ActiveFedora::Base.to_solr" do
-      @test_object.stub(pid: 'changeme:123')
+      allow(@test_object).to receive_messages(pid: 'changeme:123')
       SOLR_DOCUMENT_ID = "MY_SAMPLE_ID"
-      @test_object.to_solr[SOLR_DOCUMENT_ID.to_sym].should == 'changeme:123'
-      @test_object.to_solr[:id].should be_nil
+      expect(@test_object.to_solr[SOLR_DOCUMENT_ID.to_sym]).to eq('changeme:123')
+      expect(@test_object.to_solr[:id]).to be_nil
     end
 
     it "should be used by ActiveFedora::Base#find_with_conditions" do
       mock_response = double("SolrResponse")
-      ActiveFedora::SolrService.should_receive(:query).with("_query_:\"{!raw f=#{ActiveFedora::SolrService.solr_name("has_model", :symbol)}}info:fedora/afmodel:SolrSpecModel_Basic\" AND " + SOLR_DOCUMENT_ID + ':changeme\\:30', {:sort => ["#{ActiveFedora::SolrService.solr_name("system_create", :stored_sortable, type: :date)} asc"]}).and_return(mock_response)
+      expect(ActiveFedora::SolrService).to receive(:query).with("_query_:\"{!raw f=#{ActiveFedora::SolrService.solr_name("has_model", :symbol)}}info:fedora/afmodel:SolrSpecModel_Basic\" AND " + SOLR_DOCUMENT_ID + ':changeme\\:30', {:sort => ["#{ActiveFedora::SolrService.solr_name("system_create", :stored_sortable, type: :date)} asc"]}).and_return(mock_response)
   
-      SolrSpecModel::Basic.find_with_conditions(:id=>"changeme:30").should equal(mock_response)
+      expect(SolrSpecModel::Basic.find_with_conditions(:id=>"changeme:30")).to equal(mock_response)
     end
   end
   
@@ -50,14 +50,14 @@ describe ActiveFedora do
     it "should prevent Base.save from calling update_index if false" do
       dirty_ds = ActiveFedora::SimpleDatastream.new(@test_object.inner_object, 'ds1')
       @test_object.datastreams['ds1'] = dirty_ds
-      @test_object.stub(:datastreams).and_return({:ds1 => dirty_ds})
-      @test_object.should_receive(:update_index).never
-      @test_object.should_receive(:refresh)
+      allow(@test_object).to receive(:datastreams).and_return({:ds1 => dirty_ds})
+      expect(@test_object).to receive(:update_index).never
+      expect(@test_object).to receive(:refresh)
       @test_object.save
     end
     it "should prevent Base.delete from deleting the corresponding Solr document if false" do
-      ActiveFedora::SolrService.instance.conn.should_receive(:delete).with(@test_object.pid).never 
-      @test_object.inner_object.should_receive(:delete)
+      expect(ActiveFedora::SolrService.instance.conn).to receive(:delete).with(@test_object.pid).never 
+      expect(@test_object.inner_object).to receive(:delete)
       @test_object.delete
     end
   end

--- a/spec/unit/solr_digital_object_spec.rb
+++ b/spec/unit/solr_digital_object_spec.rb
@@ -5,7 +5,7 @@ describe ActiveFedora::SolrDigitalObject do
     subject { ActiveFedora::SolrDigitalObject.new({},{'datastreams'=>{}}) }
     describe "when not finished" do
       it "should not respond_to? :repository" do
-        subject.should_not respond_to :repository
+        expect(subject).not_to respond_to :repository
       end
     end
     describe "when finished" do
@@ -13,7 +13,7 @@ describe ActiveFedora::SolrDigitalObject do
         subject.freeze
       end
       it "should respond_to? :repository" do
-        subject.should respond_to :repository
+        expect(subject).to respond_to :repository
       end
     end
   end
@@ -71,10 +71,10 @@ describe ActiveFedora::SolrDigitalObject do
       end
       subject { ActiveFedora::SolrDigitalObject.new({}, {'datastreams'=>{'properties'=>{'dsMIME'=>'text/xml'}}},WithoutMetadataDs) }
       it "should create an xml datastream" do
-        subject.datastreams['properties'].should be_kind_of ActiveFedora::OmDatastream
+        expect(subject.datastreams['properties']).to be_kind_of ActiveFedora::OmDatastream
       end
 
-      its(:new_record?) { should be_false }
+      its(:new_record?) { should be_falsey }
     end
     
     describe "with a ds spec that's not part of the solrized object" do

--- a/spec/unit/solr_service_spec.rb
+++ b/spec/unit/solr_service_spec.rb
@@ -10,28 +10,28 @@ describe ActiveFedora::SolrService do
   end
   
   it "should take a narg constructor and configure for localhost" do
-    RSolr.should_receive(:connect).with(:read_timeout => 120, :open_timeout => 120, :url => 'http://localhost:8080/solr')
+    expect(RSolr).to receive(:connect).with(:read_timeout => 120, :open_timeout => 120, :url => 'http://localhost:8080/solr')
     ActiveFedora::SolrService.register
   end
   it "should accept host arg into constructor" do
-    RSolr.should_receive(:connect).with(:read_timeout => 120, :open_timeout => 120, :url => 'http://fubar')
+    expect(RSolr).to receive(:connect).with(:read_timeout => 120, :open_timeout => 120, :url => 'http://fubar')
     ActiveFedora::SolrService.register('http://fubar')
   end
   it "should clobber options" do
-    RSolr.should_receive(:connect).with(:read_timeout => 120, :open_timeout => 120, :url => 'http://localhost:8080/solr', :autocommit=>:off, :foo=>:bar)
+    expect(RSolr).to receive(:connect).with(:read_timeout => 120, :open_timeout => 120, :url => 'http://localhost:8080/solr', :autocommit=>:off, :foo=>:bar)
     ActiveFedora::SolrService.register(nil, {:autocommit=>:off, :foo=>:bar})
   end
 
   it "should set the threadlocal solr service" do
-    RSolr.should_receive(:connect).with(:read_timeout => 120, :open_timeout => 120, :url => 'http://localhost:8080/solr', :autocommit=>:off, :foo=>:bar)
+    expect(RSolr).to receive(:connect).with(:read_timeout => 120, :open_timeout => 120, :url => 'http://localhost:8080/solr', :autocommit=>:off, :foo=>:bar)
     ss = ActiveFedora::SolrService.register(nil, {:autocommit=>:off, :foo=>:bar})
-    Thread.current[:solr_service].should == ss
-    ActiveFedora::SolrService.instance.should == ss
+    expect(Thread.current[:solr_service]).to eq(ss)
+    expect(ActiveFedora::SolrService.instance).to eq(ss)
   end
   it "should try to initialize if the service not initialized, and fail if it does not succeed" do
-    Thread.current[:solr_service].should be_nil
-    ActiveFedora::SolrService.should_receive(:register)
-    proc{ActiveFedora::SolrService.instance}.should raise_error(ActiveFedora::SolrNotInitialized)
+    expect(Thread.current[:solr_service]).to be_nil
+    expect(ActiveFedora::SolrService).to receive(:register)
+    expect{ActiveFedora::SolrService.instance}.to raise_error(ActiveFedora::SolrNotInitialized)
   end
 
   describe "reify solr results" do
@@ -51,42 +51,42 @@ describe ActiveFedora::SolrService do
     end
     describe ".reify_solr_result" do
       it "should use .find to instantiate objects" do
-        AudioRecord.should_receive(:find).with("my:_PID1_", cast: true)
+        expect(AudioRecord).to receive(:find).with("my:_PID1_", cast: true)
         ActiveFedora::SolrService.reify_solr_result(@sample_solr_hits.first)
       end
       it "should use .load_instance_from_solr when called with :load_from_solr option" do
-        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID1_", @sample_solr_hits.first)
-        ActiveFedora::SolrService.should_not_receive(:query)
+        expect(AudioRecord).to receive(:load_instance_from_solr).with("my:_PID1_", @sample_solr_hits.first)
+        expect(ActiveFedora::SolrService).not_to receive(:query)
         ActiveFedora::SolrService.reify_solr_result(@sample_solr_hits.first, load_from_solr: true)
       end
     end
     describe ".reify_solr_results" do
       it "should use AudioRecord.find to instantiate objects" do
-        AudioRecord.should_receive(:find).with("my:_PID1_", cast: true)
-        AudioRecord.should_receive(:find).with("my:_PID2_", cast: true)
-        AudioRecord.should_receive(:find).with("my:_PID3_", cast: true)
+        expect(AudioRecord).to receive(:find).with("my:_PID1_", cast: true)
+        expect(AudioRecord).to receive(:find).with("my:_PID2_", cast: true)
+        expect(AudioRecord).to receive(:find).with("my:_PID3_", cast: true)
         ActiveFedora::SolrService.reify_solr_results(@sample_solr_hits)
       end
       it "should use AudioRecord.load_instance_from_solr when called with :load_from_solr option" do
-        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID1_", @sample_solr_hits[0])
-        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID2_", @sample_solr_hits[1])
-        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID3_", @sample_solr_hits[2])
-        ActiveFedora::SolrService.should_not_receive(:query)
+        expect(AudioRecord).to receive(:load_instance_from_solr).with("my:_PID1_", @sample_solr_hits[0])
+        expect(AudioRecord).to receive(:load_instance_from_solr).with("my:_PID2_", @sample_solr_hits[1])
+        expect(AudioRecord).to receive(:load_instance_from_solr).with("my:_PID3_", @sample_solr_hits[2])
+        expect(ActiveFedora::SolrService).not_to receive(:query)
         ActiveFedora::SolrService.reify_solr_results(@sample_solr_hits, load_from_solr: true)
       end
     end
     describe ".lazy_reify_solr_results" do
       it "should lazily reify solr results" do
-        AudioRecord.should_receive(:find).with("my:_PID1_", cast: true)
-        AudioRecord.should_receive(:find).with("my:_PID2_", cast: true)
-        AudioRecord.should_receive(:find).with("my:_PID3_", cast: true)
+        expect(AudioRecord).to receive(:find).with("my:_PID1_", cast: true)
+        expect(AudioRecord).to receive(:find).with("my:_PID2_", cast: true)
+        expect(AudioRecord).to receive(:find).with("my:_PID3_", cast: true)
         ActiveFedora::SolrService.lazy_reify_solr_results(@sample_solr_hits).each {|r| r}
       end
       it "should use AudioRecord.load_instance_from_solr when called with :load_from_solr option" do
-        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID1_", @sample_solr_hits[0])
-        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID2_", @sample_solr_hits[1])
-        AudioRecord.should_receive(:load_instance_from_solr).with("my:_PID3_", @sample_solr_hits[2])
-        ActiveFedora::SolrService.should_not_receive(:query)
+        expect(AudioRecord).to receive(:load_instance_from_solr).with("my:_PID1_", @sample_solr_hits[0])
+        expect(AudioRecord).to receive(:load_instance_from_solr).with("my:_PID2_", @sample_solr_hits[1])
+        expect(AudioRecord).to receive(:load_instance_from_solr).with("my:_PID3_", @sample_solr_hits[2])
+        expect(ActiveFedora::SolrService).not_to receive(:query)
         ActiveFedora::SolrService.lazy_reify_solr_results(@sample_solr_hits, load_from_solr: true).each {|r| r}
       end
     end
@@ -100,11 +100,11 @@ describe ActiveFedora::SolrService do
   
   describe '#construct_query_for_pids' do
     it "should generate a useable solr query from an array of Fedora pids" do
-      ActiveFedora::SolrService.construct_query_for_pids(["my:_PID1_", "my:_PID2_", "my:_PID3_"]).should == '_query_:"{!raw f=id}my:_PID1_" OR _query_:"{!raw f=id}my:_PID2_" OR _query_:"{!raw f=id}my:_PID3_"'
+      expect(ActiveFedora::SolrService.construct_query_for_pids(["my:_PID1_", "my:_PID2_", "my:_PID3_"])).to eq('_query_:"{!raw f=id}my:_PID1_" OR _query_:"{!raw f=id}my:_PID2_" OR _query_:"{!raw f=id}my:_PID3_"')
 
     end
     it "should return a valid solr query even if given an empty array as input" do
-      ActiveFedora::SolrService.construct_query_for_pids([""]).should == "id:NEVER_USE_THIS_ID"
+      expect(ActiveFedora::SolrService.construct_query_for_pids([""])).to eq("id:NEVER_USE_THIS_ID")
       
     end
   end
@@ -113,33 +113,33 @@ describe ActiveFedora::SolrService do
     it "should call solr" do 
       mock_conn = double("Connection")
       stub_result = double("Result")
-      mock_conn.should_receive(:get).with('select', :params=>{:q=>'querytext', :qt=>'standard'}).and_return(stub_result)
-      ActiveFedora::SolrService.stub(:instance =>double("instance", :conn=>mock_conn))
-      ActiveFedora::SolrService.query('querytext', :raw=>true).should == stub_result
+      expect(mock_conn).to receive(:get).with('select', :params=>{:q=>'querytext', :qt=>'standard'}).and_return(stub_result)
+      allow(ActiveFedora::SolrService).to receive_messages(:instance =>double("instance", :conn=>mock_conn))
+      expect(ActiveFedora::SolrService.query('querytext', :raw=>true)).to eq(stub_result)
     end
   end
   describe ".count" do
     it "should return a count of matching records" do 
       mock_conn = double("Connection")
       stub_result = {'response' => {'numFound'=>'7'}}
-      mock_conn.should_receive(:get).with('select', :params=>{:rows=>0, :q=>'querytext', :qt=>'standard'}).and_return(stub_result)
-      ActiveFedora::SolrService.stub(:instance =>double("instance", :conn=>mock_conn))
-      ActiveFedora::SolrService.count('querytext').should == 7 
+      expect(mock_conn).to receive(:get).with('select', :params=>{:rows=>0, :q=>'querytext', :qt=>'standard'}).and_return(stub_result)
+      allow(ActiveFedora::SolrService).to receive_messages(:instance =>double("instance", :conn=>mock_conn))
+      expect(ActiveFedora::SolrService.count('querytext')).to eq(7) 
     end
     it "should accept query args" do
       mock_conn = double("Connection")
       stub_result = {'response' => {'numFound'=>'7'}}
-      mock_conn.should_receive(:get).with('select', :params=>{:rows=>0, :q=>'querytext', :qt=>'standard', :fq=>'filter'}).and_return(stub_result)
-      ActiveFedora::SolrService.stub(:instance =>double("instance", :conn=>mock_conn))
-      ActiveFedora::SolrService.count('querytext', :fq=>'filter', :rows=>10).should == 7 
+      expect(mock_conn).to receive(:get).with('select', :params=>{:rows=>0, :q=>'querytext', :qt=>'standard', :fq=>'filter'}).and_return(stub_result)
+      allow(ActiveFedora::SolrService).to receive_messages(:instance =>double("instance", :conn=>mock_conn))
+      expect(ActiveFedora::SolrService.count('querytext', :fq=>'filter', :rows=>10)).to eq(7) 
     end
   end
   describe ".add" do
     it "should call solr" do 
       mock_conn = double("Connection")
       doc = {'id' => '1234'}
-      mock_conn.should_receive(:add).with(doc, {:params=>{}})
-      ActiveFedora::SolrService.stub(:instance =>double("instance", :conn=>mock_conn))
+      expect(mock_conn).to receive(:add).with(doc, {:params=>{}})
+      allow(ActiveFedora::SolrService).to receive_messages(:instance =>double("instance", :conn=>mock_conn))
       ActiveFedora::SolrService.add(doc)
     end
   end
@@ -147,8 +147,8 @@ describe ActiveFedora::SolrService do
     it "should call solr" do 
       mock_conn = double("Connection")
       doc = {'id' => '1234'}
-      mock_conn.should_receive(:commit)
-      ActiveFedora::SolrService.stub(:instance =>double("instance", :conn=>mock_conn))
+      expect(mock_conn).to receive(:commit)
+      allow(ActiveFedora::SolrService).to receive_messages(:instance =>double("instance", :conn=>mock_conn))
       ActiveFedora::SolrService.commit()
     end
   end

--- a/spec/unit/unsaved_digital_object_spec.rb
+++ b/spec/unit/unsaved_digital_object_spec.rb
@@ -5,24 +5,24 @@ describe ActiveFedora::UnsavedDigitalObject do
   describe "an unsaved instance" do
     subject { ActiveFedora::UnsavedDigitalObject.new(ActiveFedora::Base, 'bar') }
 
-    it { should be_new_record}
+    it { is_expected.to be_new_record}
 
     it "should have ownerId property" do
       subject.ownerId = 'fooo'
-      subject.ownerId.should == 'fooo'
+      expect(subject.ownerId).to eq('fooo')
     end
 
     it "should have state" do
       subject.ownerId = 'D'
-      subject.ownerId.should == 'D'
+      expect(subject.ownerId).to eq('D')
     end
 
     it "should not have a default pid" do
-      subject.pid.should be_nil
+      expect(subject.pid).to be_nil
     end
     it "should be able to set the pid" do
       subject.pid = "my:new_object"
-      subject.pid.should == "my:new_object"
+      expect(subject.pid).to eq("my:new_object")
     end
   end
 
@@ -35,13 +35,13 @@ describe ActiveFedora::UnsavedDigitalObject do
       @saved_obj = obj.save
     end
     it "should be a digital object" do
-      @saved_obj.should be_kind_of ActiveFedora::DigitalObject
+      expect(@saved_obj).to be_kind_of ActiveFedora::DigitalObject
     end
     it "should set the ownerId property" do
-      @saved_obj.ownerId.should == 'fooo'
+      expect(@saved_obj.ownerId).to eq('fooo')
     end
     it "should set the label property" do
-      @saved_obj.label.should == 'my label'
+      expect(@saved_obj.label).to eq('my label')
     end
   end
 

--- a/spec/unit/validations_spec.rb
+++ b/spec/unit/validations_spec.rb
@@ -27,23 +27,23 @@ describe ActiveFedora::Base do
       subject.attributes = { fubar: ['here'], swank: 'long enough' }
     end
     
-    it { should be_valid}
+    it { is_expected.to be_valid}
   end
   describe "an invalid object" do
     before do
       subject.attributes = { swank: 'smal' }
     end
     it "should have errors" do
-      subject.should_not be_valid
-      subject.errors[:fubar].should == ["can't be blank"]
-      subject.errors[:swank].should == ["is too short (minimum is 5 characters)"]
+      expect(subject).not_to be_valid
+      expect(subject.errors[:fubar]).to eq(["can't be blank"])
+      expect(subject.errors[:swank]).to eq(["is too short (minimum is 5 characters)"])
     end
   end
 
   describe "required terms" do
     it "should be required" do
-       subject.required?(:fubar).should be true
-       subject.required?(:swank).should be false
+       expect(subject.required?(:fubar)).to be true
+       expect(subject.required?(:swank)).to be false
     end
   end
 


### PR DESCRIPTION
This conversion is done by Transpec 3.2.2 with the following command:
    transpec -f

* 1005 conversions
    from: obj.should
      to: expect(obj).to

* 692 conversions
    from: == expected
      to: eq(expected)

* 249 conversions
    from: obj.should_receive(:message)
      to: expect(obj).to receive(:message)

* 107 conversions
    from: obj.stub(:message)
      to: allow(obj).to receive(:message)

* 70 conversions
    from: obj.stub(:message => value)
      to: allow(obj).to receive_messages(:message => value)

* 45 conversions
    from: obj.should_not
      to: expect(obj).not_to

* 43 conversions
    from: be_true
      to: be_truthy

* 33 conversions
    from: be_false
      to: be_falsey

* 22 conversions
    from: lambda { }.should
      to: expect { }.to

* 16 conversions
    from: Klass.any_instance.should_receive(:message)
      to: expect_any_instance_of(Klass).to receive(:message)

* 11 conversions
    from: =~ /pattern/
      to: match(/pattern/)

* 11 conversions
    from: it { should ... }
      to: it { is_expected.to ... }

* 9 conversions
    from: obj.should_not_receive(:message)
      to: expect(obj).not_to receive(:message)

* 4 conversions
    from: Klass.any_instance.stub(:message)
      to: allow_any_instance_of(Klass).to receive(:message)

* 4 conversions
    from: lambda { }.should_not
      to: expect { }.not_to

* 2 conversions
    from: > expected
      to: be > expected

* 2 conversions
    from: proc { }.should
      to: expect { }.to

* 1 conversion
    from: === expected
      to: be === expected

* 1 conversion
    from: Klass.any_instance.should_not_receive(:message)
      to: expect_any_instance_of(Klass).not_to receive(:message)

* 1 conversion
    from: collection.should have(n).items
      to: expect(collection.size).to eq(n)

* 1 conversion
    from: it { should_not ... }
      to: it { is_expected.not_to ... }

* 1 conversion
    from: stub('something')
      to: double('something')

For more details: https://github.com/yujinakayama/transpec#supported-conversions