### PR TITLE
Eliminate an unnecessary read of local content

### DIFF
--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -252,17 +252,7 @@ module ActiveFedora
         return @content if new_record?
 
         @content ||= ensure_fetch ? remote_content : @ds_content
-
-        if behaves_like_io?(@content)
-          begin
-            @content.rewind
-            @content.read
-          ensure
-            @content.rewind
-          end
-        else
-          @content
-        end
+        @content.rewind if behaves_like_io?(@content)
         @content
       end
   end


### PR DESCRIPTION
Grabbing Justin's fix and pushing it back to 9.7 as the old code caused large files to be read into memory directly.