### PR TITLE
Fix reindex_everything for use with active_fedora-noid

### DIFF
--- a/lib/active_fedora/fedora.rb
+++ b/lib/active_fedora/fedora.rb
@@ -23,11 +23,15 @@ module ActiveFedora
     end
 
     def host
-      @config[:url]
+      @config[:url].sub(/\/$/, BLANK)
     end
 
     def base_path
-      @config[:base_path] || '/'
+      @config[:base_path] || SLASH
+    end
+
+    def base_uri
+      host + base_path.sub(/\/$/, BLANK)
     end
 
     def user

--- a/lib/active_fedora/indexing.rb
+++ b/lib/active_fedora/indexing.rb
@@ -83,7 +83,7 @@ module ActiveFedora
         end
 
         def reindex_everything
-          descendants = descendant_uris(ActiveFedora::Base.id_to_uri(''))
+          descendants = descendant_uris(ActiveFedora.fedora.base_uri)
           descendants.shift # Discard the root uri
           descendants.each do |uri|
             logger.debug "Re-index everything ... #{uri}"

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -253,7 +253,7 @@ describe ActiveFedora::Base do
             end
 
             it "updates the resource" do
-              expect(test_object.resource.rdf_subject).to eq ::RDF::URI.new("#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{@this_id}")
+              expect(test_object.resource.rdf_subject).to eq ::RDF::URI.new("#{ActiveFedora.fedora.base_uri}/#{@this_id}")
               expect(test_object.title).to eq ['foo']
             end
           end

--- a/spec/unit/core/fedora_id_translator_spec.rb
+++ b/spec/unit/core/fedora_id_translator_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ActiveFedora::Core::FedoraIdTranslator do
   describe ".call" do
     let(:result) { described_class.call(id) }
     context "when given an id" do
-      let(:good_uri) { ActiveFedora.fedora.host + ActiveFedora.fedora.base_path + "/banana" }
+      let(:good_uri) { ActiveFedora.fedora.base_uri + "/banana" }
       let(:id) { "banana" }
       it "returns a fedora URI" do
         expect(result).to eq good_uri
@@ -18,7 +18,7 @@ RSpec.describe ActiveFedora::Core::FedoraIdTranslator do
       end
 
       context "with characters that need escaping" do
-        let(:good_uri) { ActiveFedora.fedora.host + ActiveFedora.fedora.base_path + "/%5Bfrob%5D" }
+        let(:good_uri) { ActiveFedora.fedora.base_uri + "/%5Bfrob%5D" }
         let(:id) { "[frob]" }
         it "returns a good fedora URI" do
           expect(result).to eq good_uri

--- a/spec/unit/core/fedora_uri_translator_spec.rb
+++ b/spec/unit/core/fedora_uri_translator_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe ActiveFedora::Core::FedoraUriTranslator do
   describe ".call" do
     let(:result) { described_class.call(uri) }
     context "when given a Fedora URI" do
-      let(:uri) { ActiveFedora.fedora.host + ActiveFedora.fedora.base_path + "/6" }
+      let(:uri) { ActiveFedora.fedora.base_uri + "/6" }
       it "returns the id" do
         expect(result).to eq '6'
       end
     end
     context "when given a URI missing a slash" do
-      let(:uri) { ActiveFedora.fedora.host + ActiveFedora.fedora.base_path + "602-a" }
+      let(:uri) { ActiveFedora.fedora.base_uri + "602-a" }
       it "returns the id" do
         expect(result).to eq "602-a"
       end

--- a/spec/unit/core_spec.rb
+++ b/spec/unit/core_spec.rb
@@ -109,7 +109,7 @@ describe ActiveFedora::Base do
     subject(:uri) { described_class.id_to_uri(id) }
 
     context "with no custom proc is set" do
-      it { is_expected.to eq "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/123456w" }
+      it { is_expected.to eq "#{ActiveFedora.fedora.base_uri}/123456w" }
       it "justs call #translate_id_to_uri" do
         allow(described_class).to receive(:translate_id_to_uri).and_call_original
         allow(ActiveFedora::Core::FedoraIdTranslator).to receive(:call).and_call_original
@@ -122,11 +122,11 @@ describe ActiveFedora::Base do
 
     context "when custom proc is set" do
       before do
-        described_class.translate_id_to_uri = lambda { |id| "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/foo/#{id}" }
+        described_class.translate_id_to_uri = lambda { |id| "#{ActiveFedora.fedora.base_uri}/foo/#{id}" }
       end
       after { described_class.translate_id_to_uri = nil }
 
-      it { is_expected.to eq "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/foo/123456w" }
+      it { is_expected.to eq "#{ActiveFedora.fedora.base_uri}/foo/123456w" }
     end
 
     context "with an empty base path" do
@@ -145,7 +145,7 @@ describe ActiveFedora::Base do
   end
 
   describe "uri_to_id" do
-    let(:uri) { "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/foo/123456w" }
+    let(:uri) { "#{ActiveFedora.fedora.base_uri}/foo/123456w" }
     subject(:uri_id) { described_class.uri_to_id(uri) }
 
     context "with no custom proc is set" do

--- a/spec/unit/file_spec.rb
+++ b/spec/unit/file_spec.rb
@@ -51,14 +51,14 @@ describe ActiveFedora::File do
       context "and it's initialized with the URI" do
         let(:file) { described_class.new(parent.uri + "/FOO1") }
         it "works" do
-          expect(uri.to_s).to eq "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/1234/FOO1"
+          expect(uri.to_s).to eq "#{ActiveFedora.fedora.base_uri}/1234/FOO1"
         end
       end
 
       context "and it's initialized with an ID" do
         let(:file) { described_class.new(parent.id + "/FOO1") }
         it "works" do
-          expect(uri.to_s).to eq "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/1234/FOO1"
+          expect(uri.to_s).to eq "#{ActiveFedora.fedora.base_uri}/1234/FOO1"
         end
       end
     end


### PR DESCRIPTION
reindex_everything relies on id_to_uri('') to return the base uri which is undocumented and untested.  active_fedora-noid throws an exception when attempting to call id_to_uri with the empty string.  This PR adds a base_uri method to ActiveFedora.fedora and uses this in reindex_everything instead of id_to_uri.