### PR TITLE
Removing invalid namespaces from tests

### DIFF
--- a/spec/integration/base_spec.rb
+++ b/spec/integration/base_spec.rb
@@ -130,7 +130,7 @@ describe ActiveFedora::Base do
       expect(described_class.exists?(obj.id)).to be true
     end
     it "returns false for ids that don't exist" do
-      expect(described_class.exists?('test:missing_object')).to be false
+      expect(described_class.exists?('test_missing_object')).to be false
     end
     it "returns false for nil" do
       expect(described_class.exists?(nil)).to be false

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -298,10 +298,10 @@ describe ActiveFedora::Base do
 
   describe "#load_from_fedora" do
     let(:relation) { ActiveFedora::Relation.new(described_class) }
-    before { @obj = SpecModel::Basic.create(id: "test:123") }
+    before { @obj = SpecModel::Basic.create(id: "test_123") }
     after { @obj.destroy }
     it "casts when klass == ActiveFedora::Base and cast argument is nil" do
-      expect(relation.send(:load_from_fedora, "test:123", nil)).to be_a SpecModel::Basic
+      expect(relation.send(:load_from_fedora, "test_123", nil)).to be_a SpecModel::Basic
     end
   end
 end


### PR DESCRIPTION
* Removing invalid namespaces from test ids that causes test failures in Fedora 4.7.1-RC-1