### PR TITLE
Ensuring NullLogger responds to logging questions

### DIFF
--- a/lib/active_fedora/null_logger.rb
+++ b/lib/active_fedora/null_logger.rb
@@ -6,5 +6,10 @@ module ActiveFedora
     # allows all the usual logger method calls (warn, info, error, etc.)
     def add(*)
     end
+
+    # In the NullLogger there are no levels, so none of these should be true.
+    [:debug?, :info?, :warn?, :error?, :fatal?].each do |method_name|
+      define_method(method_name) { false }
+    end
   end
 end

--- a/spec/lib/active_fedora/null_logger_spec.rb
+++ b/spec/lib/active_fedora/null_logger_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::NullLogger do
+  [:debug?, :info?, :warn?, :error?, :fatal?].each do |method_name|
+    describe "##{method_name}" do
+      subject { described_class.new.public_send(method_name) }
+      it { is_expected.to be_falsey }
+    end
+  end
+end


### PR DESCRIPTION
Adding the standard logging level questions:

* `#debug?`
* `#info?`
* `#warn?`
* `#error?`
* `#fatal?`

Closes #1184