### PR TITLE
Ensuring up to date system gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,7 @@ matrix:
     - env: "RSOLR_VERSION=2.0.0.pre1"
 global_env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+before_install:
+  - gem update --system
 before_script:
   - jdk_switcher use oraclejdk8


### PR DESCRIPTION
This fixes the following error:

```console
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    can't modify frozen String
```

Related to sickill/rainbow#48

Referencing Blacklight's workaround

https://github.com/projectblacklight/blacklight/blob/master/.travis.yml#L21