### PR TITLE
Eager load ActiveFedora

### DIFF
--- a/lib/active_fedora.rb
+++ b/lib/active_fedora.rb
@@ -72,7 +72,6 @@ module ActiveFedora #:nodoc:
     autoload :FilePersistence
     autoload :FileRelation
     autoload :FilesHash
-    autoload :Filter
     autoload :FixityService
     autoload :Identifiable
     autoload :Indexers

--- a/lib/active_fedora/railtie.rb
+++ b/lib/active_fedora/railtie.rb
@@ -2,6 +2,7 @@ module ActiveFedora
   class Railtie < Rails::Railtie
     config.app_middleware.insert_after ::ActionDispatch::Callbacks,
                                        ActiveFedora::LdpCache
+    config.eager_load_namespaces << ActiveFedora
 
     initializer 'active_fedora.autoload', before: :set_autoload_paths do |app|
       app.config.autoload_paths << 'app/models/datastreams'


### PR DESCRIPTION
Previously eagerloading was not occuring, and on a threaded server we
could see errors like this:

```
NameError: uninitialized constant ActiveFedora::Fedora Did you mean?
ActiveFedora::Fedora
```

This also removes an autoload to a constant that didn't exist (`Filter`)