### PR TITLE
Refresh container resource triples

### DIFF
--- a/lib/active_fedora/associations/basic_contains_association.rb
+++ b/lib/active_fedora/associations/basic_contains_association.rb
@@ -17,6 +17,16 @@ module ActiveFedora
         record.base_path_for_resource = owner.uri.to_s
         super
       end
+
+      def reset
+        # Update the membership triples (and no other triples) on the the owner's resource
+        if owner.persisted?
+          pattern = ::RDF::Query::Pattern.new(predicate: options[:predicate])
+          new_resource = owner.dup.reload.resource
+          owner.resource.delete_insert([pattern], new_resource.query(pattern))
+        end
+        super
+      end
     end
   end
 end

--- a/spec/integration/basic_contains_association_spec.rb
+++ b/spec/integration/basic_contains_association_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
-describe ActiveFedora::Base do
-  let(:model) { Source.new }
-
+describe ActiveFedora::Associations::BasicContainsAssociation do
   context "with a file" do
     before do
       class Source < ActiveFedora::Base
         is_a_container
       end
     end
+
+    let(:model) { Source.new }
 
     after do
       Object.send(:remove_const, :Source)
@@ -102,6 +102,19 @@ describe ActiveFedora::Base do
         expect { model.contains.destroy_all }
           .to change { model.contains.size }.by(-2)
           .and change { Thing.count }.by(-2)
+      end
+    end
+
+    describe "#reload" do
+      before do
+        model.save!
+        child = model.contains.create(title: ['title 1'])
+        model.reload # Cause the model to load its graph that contains the child ids.
+        ActiveFedora::Base.find(child.id).destroy
+      end
+
+      it "can reload without attempting to load any deleted objects" do
+        expect { model.contains.reload }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
When doing a refresh of a basic container relationship, refresh the
membership triples on the parent object. This prevents an attempt to
load resources that have been deleted.  We're careful to only update the
membership triples, because we don't want to overwrite any in-memory
changes on the parent object.

Fixes https://github.com/projecthydra/hydra-head/issues/401
Fixes https://github.com/projecthydra/sufia/issues/3065