### PR TITLE
Don't populate attached_files when using idiomatic basic containment

### DIFF
--- a/lib/active_fedora/attached_files.rb
+++ b/lib/active_fedora/attached_files.rb
@@ -33,7 +33,11 @@ module ActiveFedora
       resource.query(subject: resource, predicate: ::RDF::Vocab::LDP.contains).objects.map(&:to_s)
     end
 
+    # Load any undeclared relationships or has_subresource relationships.  These are non-idiomatic LDP
+    # because we are going to find the subresource by knowing it's subpath ahead of time.
+    # Does nothing if this object is using idiomatic basic containment, by declaring `is_a_container`
     def load_attached_files
+      return if reflections[:contains] && reflections[:contains].macro == :is_a_container
       contains_assertions.each do |file_uri|
         path = file_uri.to_s.sub(uri + '/', '')
         next if association(path.to_sym)

--- a/lib/active_fedora/version.rb
+++ b/lib/active_fedora/version.rb
@@ -1,3 +1,3 @@
 module ActiveFedora
-  VERSION = "11.1.3".freeze
+  VERSION = "11.1.4".freeze
 end

--- a/spec/unit/attached_files_spec.rb
+++ b/spec/unit/attached_files_spec.rb
@@ -187,4 +187,27 @@ describe ActiveFedora::AttachedFiles do
       expect(af_base.metadata_streams).to_not include(file_ds)
     end
   end
+
+  context "When the resource is using idiomatic basic containment" do
+    before do
+      class Sample1 < ActiveFedora::Base
+        is_a_container
+      end
+    end
+    after do
+      Object.send(:remove_const, :Sample1)
+    end
+
+    before do
+      child = obj.contains.build
+      child.content = "Stuff"
+      child.save!
+    end
+    let(:obj) { Sample1.create! }
+    let(:obj2) { Sample1.find(obj.id) }
+
+    it "doesn't conflate attached_file and contains" do
+      expect(obj2.attached_files.keys).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Also bumped the version because this is a critical fix.