### PR TITLE
print IDs in more error messages

### DIFF
--- a/lib/active_fedora/attributes/property_builder.rb
+++ b/lib/active_fedora/attributes/property_builder.rb
@@ -16,7 +16,7 @@ module ActiveFedora::Attributes
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}=(value)
           if value.present? && !value.respond_to?(:each)
-            raise ArgumentError, "You attempted to set the property `#{name}' to a scalar value. However, this property is declared as being multivalued."
+            raise ArgumentError, "You attempted to set the property `#{name}' of \#{id} to a scalar value. However, this property is declared as being multivalued."
           end
           set_value(:#{name}, value)
         end
@@ -28,7 +28,7 @@ module ActiveFedora::Attributes
         def #{name}(*args)
           vals = get_values(:#{name})
           return nil unless vals
-          raise ActiveFedora::ConstraintError, "Expected \\"#{name}\\" to have 0-1 statements, but there are \#{vals.size}" if vals.size > 1
+          raise ActiveFedora::ConstraintError, "Expected \\"#{name}\\" of \#{id} to have 0-1 statements, but there are \#{vals.size}" if vals.size > 1
           vals.first
         end
       CODE
@@ -46,7 +46,7 @@ module ActiveFedora::Attributes
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}=(value)
           if value.respond_to?(:each) # singular
-            raise ArgumentError, "You attempted to set the property `#{name}' to an enumerable value. However, this property is declared as singular."
+            raise ArgumentError, "You attempted to set the property `#{name}' of \#{id} to an enumerable value. However, this property is declared as singular."
           end
           set_value(:#{name}, value)
         end

--- a/lib/active_fedora/relation/finder_methods.rb
+++ b/lib/active_fedora/relation/finder_methods.rb
@@ -189,7 +189,8 @@ module ActiveFedora
     protected
 
       def load_from_fedora(id, cast)
-        raise ActiveFedora::ObjectNotFoundError if id.empty?
+        raise ActiveFedora::ObjectNotFoundError, "No ID provided for #{klass.name}." if id.empty?
+
         resource = ActiveFedora.fedora.ldp_resource_service.build(klass, id)
         raise_record_not_found_exception!(id) if resource.new?
         class_to_load(resource, cast).allocate.init_with_resource(resource) # Triggers the find callback

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -16,7 +16,7 @@ describe ActiveFedora::Base do
     end
 
     subject(:history) { obj }
-    let(:obj) { BarHistory4.new(title: ['test1']) }
+    let(:obj) { BarHistory4.new(title: ['test1'], id: 'test:123') }
 
     describe "#attribute_names" do
       context "on an instance" do
@@ -34,15 +34,7 @@ describe ActiveFedora::Base do
 
     describe "#inspect" do
       it "shows the attributes" do
-        expect(history.inspect).to eq "#<BarHistory4 id: nil, title: [\"test1\"], abstract: nil>"
-      end
-
-      describe "with a id" do
-        before { allow(history).to receive(:id).and_return('test:123') }
-
-        it "shows a id" do
-          expect(history.inspect).to eq "#<BarHistory4 id: \"test:123\", title: [\"test1\"], abstract: nil>"
-        end
+        expect(history.inspect).to eq "#<BarHistory4 id: \"test:123\", title: [\"test1\"], abstract: nil>"
       end
 
       describe "with no attributes" do
@@ -98,7 +90,7 @@ describe ActiveFedora::Base do
               history.resource[:abstract] = ['foo', 'bar']
             end
             it "raises an error if just returning the first value would cause data loss" do
-              expect { history[:abstract] }.to raise_error ActiveFedora::ConstraintError, "Expected \"abstract\" to have 0-1 statements, but there are 2"
+              expect { history[:abstract] }.to raise_error ActiveFedora::ConstraintError, "Expected \"abstract\" of test:123 to have 0-1 statements, but there are 2"
             end
           end
         end
@@ -144,7 +136,7 @@ describe ActiveFedora::Base do
       it "does not allow an enumerable to a unique attribute writer" do
         expect { history.abstract = "Low" }.not_to raise_error
         expect { history.abstract = ["Low"]
-        }.to raise_error ArgumentError, "You attempted to set the property `abstract' to an enumerable value. However, this property is declared as singular."
+        }.to raise_error ArgumentError, "You attempted to set the property `abstract' of test:123 to an enumerable value. However, this property is declared as singular."
         expect { history.abstract = nil }.not_to raise_error
       end
     end


### PR DESCRIPTION
If these changes aren't related enough, I can split them into separate PRs.  But the gist is to print the Fedora object IDs when they are related to an AF error.  I also re-worded the error in `#raise_record_not_found_exception!` and inlined it into the only place where it's used.

I also had to add pry to the Gemfile to avoid this error during `bundle exec rake`:
```
rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb --backtrace
Coverage report generated for RSpec to /Users/alex/clones/active_fedora/coverage. 246 / 477 LOC (51.57%) covered.
/Users/alex/clones/active_fedora/spec/spec_helper.rb:16:in `require': cannot load such file -- pry (LoadError)
        from /Users/alex/clones/active_fedora/spec/spec_helper.rb:16:in `<top (required)>'
        from /Users/alex/clones/active_fedora/spec/integration/associations/rdf_spec.rb:1:in `require'
        from /Users/alex/clones/active_fedora/spec/integration/associations/rdf_spec.rb:1:in `<top (required)>'
        from /Users/alex/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1435:in `load'
        from /Users/alex/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1435:in `block in load_spec_files'
        from /Users/alex/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1433:in `each'
        from /Users/alex/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1433:in `load_spec_files'
        from /Users/alex/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:100:in `setup'
        from /Users/alex/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:86:in `run'
        from /Users/alex/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
        from /Users/alex/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
        from /Users/alex/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<main>'
```