### PR TITLE
Fix ActiveFedora::Inheritance.base_class for deep File descendants

### DIFF
--- a/lib/active_fedora/inheritance.rb
+++ b/lib/active_fedora/inheritance.rb
@@ -12,7 +12,7 @@ module ActiveFedora
       # If B < A and C < B and if A is an abstract_class then both B.base_class
       # and C.base_class would return B as the answer since A is an abstract_class.
       def base_class
-        return File if self == File || superclass == File
+        return File if self <= File
 
         unless self <= Base
           raise ActiveFedoraError, "#{name} doesn't belong in a hierarchy descending from ActiveFedora"

--- a/spec/unit/inheritance_spec.rb
+++ b/spec/unit/inheritance_spec.rb
@@ -8,6 +8,9 @@ describe ActiveFedora::Base do
     class MySample < ActiveFedora::File
     end
 
+    class MyDeepSample < MySample
+    end
+
     class Foo < ActiveFedora::Base
       has_subresource 'foostream', class_name: 'MyDS'
       has_subresource 'dcstream', class_name: 'MySample'
@@ -15,6 +18,9 @@ describe ActiveFedora::Base do
 
     class Bar < ActiveFedora::Base
       has_subresource 'barstream', class_name: 'MyDS'
+    end
+
+    class Baz < Bar
     end
   end
 
@@ -25,10 +31,30 @@ describe ActiveFedora::Base do
     expect(attached_files.values).to match_array [MyDS, MySample]
   end
 
+  context 'base_class' do
+    it 'shallow < Base' do
+      expect(Bar.base_class).to eq(Bar)
+    end
+
+    it 'deep < Base' do
+      expect(Baz.base_class).to eq(Bar)
+    end
+
+    it 'shallow < File' do
+      expect(MySample.base_class).to eq(ActiveFedora::File)
+    end
+
+    it 'deep < File' do
+      expect(MyDeepSample.base_class).to eq(ActiveFedora::File)
+    end
+  end
+
   after do
+    Object.send(:remove_const, :Baz)
     Object.send(:remove_const, :Bar)
     Object.send(:remove_const, :Foo)
     Object.send(:remove_const, :MyDS)
+    Object.send(:remove_const, :MyDeepSample)
     Object.send(:remove_const, :MySample)
   end
 end


### PR DESCRIPTION
Fixes and adds tests for the following issue:

Given:
```
class A < ActiveFedora::File
end

class B < A
end
```

Expected:
```
> A.base_class
=> ActiveFedora::File
> B.base_class
=> ActiveFedora::File
```

Actual:
```
> A.base_class
=> ActiveFedora::File
> B.base_class
ActiveFedora::ActiveFedoraError: B doesn't belong in a hierarchy descending from ActiveFedora
from /Users/mbk836/Workspace/hydra/active_fedora/lib/active_fedora/inheritance.rb:18:in `base_class'
```