### PR TITLE
Fixing fcrepo_wrapper behavior in `with_server` task

### DIFF
--- a/lib/active_fedora/rake_support.rb
+++ b/lib/active_fedora/rake_support.rb
@@ -12,7 +12,7 @@ def with_server(environment)
   # setting port: nil assigns a random port.
   solr_defaults = { port: nil, verbose: true, managed: true }
   fcrepo_defaults = { port: nil, verbose: true, managed: true,
-                      enable_jms: false, fcrepo_home_dir: "fcrepo4-#{environment}-data" }
+                      enable_jms: false, fcrepo_home_dir: "tmp/fcrepo4-#{environment}-data" }
 
   SolrWrapper.wrap(load_config(:solr, environment, solr_defaults)) do |solr|
     ENV["SOLR_#{environment.upcase}_PORT"] = solr.port.to_s


### PR DESCRIPTION
The following .internal_test_app/config/fcrepo_wrapper_test.yml was in
the Hyrax internal test application:

```yaml
port: 8986
enable_jms: false
fcrepo_home_dir: tmp/fcrepo4-test-data
```

I was able to run `fcrepo_wrapper -v -p 8986 --no-jms` locally and
Fedora would boot. If I ran `rake ci` Fedora failed to boot (with the
below error message)

Error log for Fedora boot failure via `rake ci` on the Hyrax project:

```console
[main] INFO org.eclipse.jetty.util.log - Logging initialized @1223ms
[main] INFO org.simplericity.jettyconsole.DefaultJettyManager - Added web application on path / from war /private/var/folders/gb/2k95hwkn1xd3zhs_gnmvpzt5xc_94p/T/fcrepo-webapp-4.7.1-jetty-console/fcrepo-webapp-4.7.1-jetty-console.jar
[main] INFO org.simplericity.jettyconsole.DefaultJettyManager - Starting web application on port 53941
[main] INFO org.eclipse.jetty.server.Server - jetty-9.2.3.v20140905
[main] INFO org.eclipse.jetty.webapp.StandardDescriptorProcessor - NO JSP Support for /, did not find org.apache.jasper.servlet.JspServlet
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/private/var/folders/gb/2k95hwkn1xd3zhs_gnmvpzt5xc_94p/T/fcrepo-webapp-4.7.1-jetty-console.jar_53941/webapp/WEB-INF/lib/logback-classic-1.1.7.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/var/folders/gb/2k95hwkn1xd3zhs_gnmvpzt5xc_94p/T/fcrepo-webapp-4.7.1-jetty-console.jar_53941/condi/slf4j-simple-1.7.5.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]
[main] INFO / - 1 Spring WebApplicationInitializers detected on classpath
[main] INFO / - Initializing Spring root WebApplicationContext
ERROR 13:22:19.778 (RepositoryNodeTypeManager) Node types were read from the system content, and appear to be inconsistent or invalid: repo
org.modeshape.jcr.value.ValueFormatException: Error converting "ns010:OriginalFile" from String to a Name
at org.modeshape.jcr.value.basic.NameValueFactory.create(NameValueFactory.java:157)
at org.modeshape.jcr.value.basic.NameValueFactory.create(NameValueFactory.java:46)
at org.modeshape.jcr.cache.document.DocumentTranslator.childReferenceFrom(DocumentTranslator.java:966)
```

After the change, I get the following, and several happy green dots.

```console
[main] INFO org.eclipse.jetty.util.log - Logging initialized @986ms
[main] INFO org.simplericity.jettyconsole.DefaultJettyManager - Added web application on path / from war /private/var/folders/gb/2k95hwkn1xd3zhs_gnmvpzt5xc_94p/T/fcrepo-webapp-4.7.1-jetty-console/fcrepo-webapp-4.7.1-jetty-console.jar
[main] INFO org.simplericity.jettyconsole.DefaultJettyManager - Starting web application on port 54351
[main] INFO org.eclipse.jetty.server.Server - jetty-9.2.3.v20140905
[main] INFO org.eclipse.jetty.webapp.StandardDescriptorProcessor - NO JSP Support for /, did not find org.apache.jasper.servlet.JspServlet
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/private/var/folders/gb/2k95hwkn1xd3zhs_gnmvpzt5xc_94p/T/fcrepo-webapp-4.7.1-jetty-console.jar_54351/webapp/WEB-INF/lib/logback-classic-1.1.7.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/var/folders/gb/2k95hwkn1xd3zhs_gnmvpzt5xc_94p/T/fcrepo-webapp-4.7.1-jetty-console.jar_54351/condi/slf4j-simple-1.7.5.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]
[main] INFO / - 1 Spring WebApplicationInitializers detected on classpath
[main] INFO / - Initializing Spring root WebApplicationContext
INFO 13:27:25.829 (RdfWriterHelper) Loading JENA 3.1.1 Patched RDF Output Writers
[main] INFO org.eclipse.jetty.server.handler.ContextHandler - Started o.s.j.JettyConsoleWebappContext@3b6eb2ec{/,file:/private/var/folders/gb/2k95hwkn1xd3zhs_gnmvpzt5xc_94p/T/fcrepo-webapp-4.7.1-jetty-console.jar_54351/webapp/,AVAILABLE}{/private/var/folders/gb/2k95hwkn1xd3zhs_gnmvpzt5xc_94p/T/fcrepo-webapp-4.7.1-jetty-console/fcrepo-webapp-4.7.1-jetty-console.jar}
[main] INFO org.eclipse.jetty.server.ServerConnector - Started ServerConnector@39374689{HTTP/1.1}{0.0.0.0:54351}
[main] INFO org.eclipse.jetty.server.Server - Started @9590ms
```

Attention @laritakr, @escowles

Closes https://github.com/fcrepo4/fcrepo4/issues/1178