### PR TITLE
Removing an exclusion for a non-existent file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,7 +106,6 @@ Style/AndOr:
 Style/AccessorMethodName:
   Exclude:
     - 'lib/active_fedora/with_metadata/metadata_node.rb'
-    - 'lib/active_fedora/predicates.rb'
     - 'lib/active_fedora/fedora_attributes.rb'
     - 'lib/active_fedora/attribute_methods/dirty.rb'
     - 'lib/active_fedora/associations/has_many_association.rb'
@@ -207,7 +206,6 @@ Style/ClassVars:
     - 'spec/unit/finder_methods_spec.rb'
     - 'spec/unit/base_spec.rb'
     - 'spec/integration/indexing_spec.rb'
-    - 'lib/active_fedora/predicates.rb'
     - 'lib/active_fedora/identifiable.rb'
 
 Style/SignalException:


### PR DESCRIPTION
```ruby
require 'psych'
['.rubocop.yml', '.rubocop_todo.yml'].each do |filename|
  begin
    yaml = Psych.load_file(filename)

    def read(node)
      if node.is_a?(Hash)
        node.each_pair do |key, value|
          read(value)
        end
      elsif node.is_a?(Array)
        node.each do |value|
          read(value)
        end
      elsif node.is_a?(String)
        return unless node =~ /.rb\Z/
        return if node =~ /\*/
        return if File.exist?(node)
        puts node
      end
    end
    read(yaml)
  rescue
  end
end
```