### PR TITLE
#reindex_everything improvements

### DIFF
--- a/active-fedora.gemspec
+++ b/active-fedora.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "active-triples", '~> 0.11.0'
   s.add_dependency "deprecation"
   s.add_dependency "ldp", '~> 0.6.0'
+  s.add_dependency "ruby-progressbar", '~> 1.0'
 
   s.add_development_dependency "rails"
   s.add_development_dependency "rdoc"

--- a/lib/active_fedora/indexing.rb
+++ b/lib/active_fedora/indexing.rb
@@ -89,16 +89,14 @@ module ActiveFedora
 
           batch = []
 
-          progress_bar_controller = if progress_bar
-            ProgressBar.create(:total => descendants.count, format: "%t: |%B| %p%% %e")
-          end
+          progress_bar_controller = ProgressBar.create(total: descendants.count, format: "%t: |%B| %p%% %e") if progress_bar
 
           descendants.each do |uri|
             logger.debug "Re-index everything ... #{uri}"
 
             batch << ActiveFedora::Base.find(ActiveFedora::Base.uri_to_id(uri)).to_solr
 
-            if batch.count % batch_size == 0
+            if (batch.count % batch_size).zero?
               SolrService.add(batch, softCommit: softCommit)
               batch.clear
             end

--- a/lib/active_fedora/indexing.rb
+++ b/lib/active_fedora/indexing.rb
@@ -83,7 +83,7 @@ module ActiveFedora
                             end
         end
 
-        def reindex_everything(batch_size: 50)
+        def reindex_everything(batch_size: 50, softCommit: true)
           descendants = descendant_uris(ActiveFedora.fedora.base_uri)
           descendants.shift # Discard the root uri
 
@@ -95,13 +95,13 @@ module ActiveFedora
             batch << ActiveFedora::Base.find(ActiveFedora::Base.uri_to_id(uri)).to_solr
 
             if batch.count % batch_size == 0
-              SolrService.add(batch, softCommit: true)
+              SolrService.add(batch, softCommit: softCommit)
               batch.clear
             end
           end
 
           if batch.present?
-            SolrService.add(batch, softCommit: true)
+            SolrService.add(batch, softCommit: softCommit)
             batch.clear
           end
         end

--- a/lib/active_fedora/indexing.rb
+++ b/lib/active_fedora/indexing.rb
@@ -83,7 +83,11 @@ module ActiveFedora
                             end
         end
 
-        def reindex_everything(batch_size: 50, softCommit: true, progress_bar: false)
+        # @param [Integer] batch_size - The number of Fedora objects to process for each SolrService.add call. Default 50.
+        # @param [Boolean] softCommit - Do we perform a softCommit when we add the to_solr objects to SolrService. Default true.
+        # @param [Boolean] progress_bar - If true output progress bar information. Default false.
+        # @param [Boolean] final_commit - If true perform a hard commit to the Solr service at the completion of the batch of updates. Default false.
+        def reindex_everything(batch_size: 50, softCommit: true, progress_bar: false, final_commit: false)
           descendants = descendant_uris(ActiveFedora.fedora.base_uri)
           descendants.shift # Discard the root uri
 
@@ -107,6 +111,11 @@ module ActiveFedora
           if batch.present?
             SolrService.add(batch, softCommit: softCommit)
             batch.clear
+          end
+
+          if final_commit
+            logger.debug "Solr hard commit..."
+            SolrService.commit
           end
         end
 

--- a/lib/active_fedora/solr_service.rb
+++ b/lib/active_fedora/solr_service.rb
@@ -64,7 +64,7 @@ module ActiveFedora
         SolrService.get(query, args)['response']['numFound'].to_i
       end
 
-      # @param [Hash] doc the document to index
+      # @param [Hash] doc the document to index, or an array of docs
       # @param [Hash] params
       #   :commit => commits immediately
       #   :softCommit => commit to memory, but don't flush to disk


### PR DESCRIPTION
* batched commits, on by default, but you can effectively turning it off by setting it to `1` (default `50`). 

Batched commits seem to very significantly speed up reindex_everything. 

everything else off by default but you can turn it on, other features to make a more pleasant and flexible reindex_everything experience:

* progress bar
* turn off softCommit, which was hard-coded on before
* Do a final hard commit, to ensure your `reindex_everything` is written to Solr disk. 
