### PR TITLE
Indexing#descendant_uris capable of prioritizing at front of list

### DIFF
--- a/lib/active_fedora/indexing.rb
+++ b/lib/active_fedora/indexing.rb
@@ -13,6 +13,7 @@ module ActiveFedora
 
     eager_autoload do
       autoload :Map
+      autoload :DescendantFetcher
     end
 
     included do
@@ -92,16 +93,7 @@ module ActiveFedora
         end
 
         def descendant_uris(uri)
-          resource = Ldp::Resource::RdfSource.new(ActiveFedora.fedora.connection, uri)
-          # GET could be slow if it's a big resource, we're using HEAD to avoid this problem,
-          # but this causes more requests to Fedora.
-          return [] unless resource.head.rdf_source?
-          immediate_descendant_uris = resource.graph.query(predicate: ::RDF::Vocab::LDP.contains).map { |descendant| descendant.object.to_s }
-          all_descendants_uris = [uri]
-          immediate_descendant_uris.each do |descendant_uri|
-            all_descendants_uris += descendant_uris(descendant_uri)
-          end
-          all_descendants_uris
+          DescendantFetcher.new(uri).descendant_and_self_uris
         end
       end
   end

--- a/lib/active_fedora/indexing/descendant_fetcher.rb
+++ b/lib/active_fedora/indexing/descendant_fetcher.rb
@@ -1,0 +1,100 @@
+module ActiveFedora
+  module Indexing
+    # Finds all descendent URIs of a given repo URI (usually the base URI).
+    #
+    # This is a slow and non-performant thing to do, we need to fetch every single
+    # object from the repo.
+    #
+    # The DescendantFetcher is also capable of partitioning the URIs into "priority" URIs
+    # that will be first in the returned list. These prioritized URIs belong to objects
+    # with certain hasModel models. This feature is used in some hydra apps that need to
+    # index 'permissions' objects before other objects to have the solr indexing work right.
+    # And so by default, the prioritized class names are the ones form Hydra::AccessControls,
+    # but you can alter the prioritized model name list, or set it to the empty array.
+    #
+    #     DescendantFetcher.new(ActiveFedora.fedora.base_uri).descendent_and_self_uris
+    #     #=> array including self uri and descendent uris with "prioritized" (by default)
+    #         Hydra::AccessControls permissions) objects FIRST.
+    #
+    # Change the default prioritized hasModel names:
+    #
+    #     ActiveFedora::Indexing::DescendantFetcher.default_priority_models = []
+    class DescendantFetcher
+      HAS_MODEL_PREDICATE = ActiveFedora::RDF::Fcrepo::Model.hasModel
+
+      class_attribute :default_priority_models, instance_accessor: false
+      self.default_priority_models = %w(Hydra::AccessControls Hydra::AccessControls::Permissions).freeze
+
+      attr_reader :uri, :priority_models
+
+      def initialize(uri,
+                     priority_models: self.class.default_priority_models)
+        @uri = uri
+        @priority_models = priority_models
+      end
+
+      def descendant_and_self_uris
+        partitioned = descendant_and_self_uris_partitioned
+        partitioned[:priority] + partitioned[:other]
+      end
+
+      # returns a hash where key :priority is an array of all prioritized
+      # type objects, key :other is an array of the rest.
+      def descendant_and_self_uris_partitioned
+        resource = Ldp::Resource::RdfSource.new(ActiveFedora.fedora.connection, uri)
+        # GET could be slow if it's a big resource, we're using HEAD to avoid this problem,
+        # but this causes more requests to Fedora.
+        return partitioned_uris unless resource.head.rdf_source?
+
+        add_self_to_partitioned_uris
+
+        immediate_descendant_uris = rdf_graph.query(predicate: ::RDF::Vocab::LDP.contains).map { |descendant| descendant.object.to_s }
+        immediate_descendant_uris.each do |descendant_uri|
+          self.class.new(
+            descendant_uri,
+            priority_models: priority_models
+          ).descendant_and_self_uris_partitioned.tap do |descendant_partitioned|
+            partitioned_uris[:priority].concat descendant_partitioned[:priority]
+            partitioned_uris[:other].concat descendant_partitioned[:other]
+          end
+        end
+        partitioned_uris
+      end
+
+      protected
+
+        def rdf_resource
+          @rdf_resource ||= Ldp::Resource::RdfSource.new(ActiveFedora.fedora.connection, uri)
+        end
+
+        def rdf_graph
+          @rdf_graph ||= rdf_resource.graph
+        end
+
+        def partitioned_uris
+          @partitioned_uris ||= {
+            priority: [],
+            other: []
+          }
+        end
+
+        def rdf_graph_models
+          rdf_graph.query(predicate: HAS_MODEL_PREDICATE).collect(&:object).collect do |rdf_object|
+            rdf_object.to_s if rdf_object.literal?
+          end.compact
+        end
+
+        def prioritized_object?
+          priority_models.present? && (rdf_graph_models & priority_models).count > 0
+        end
+
+        def add_self_to_partitioned_uris
+          if prioritized_object?
+            partitioned_uris[:priority] << rdf_resource.subject
+          else
+            partitioned_uris[:other] << rdf_resource.subject
+          end
+        end
+    end
+  end
+end


### PR DESCRIPTION
by prioritizing URIs belonging to objects with certain hasModel literals.

By default the models used for Hydra::AccessControls permissions objects.

Because this method is used by reindex_everything, which in Hydra needs
to index permissions objects first.

The logic of keeping track of partitioned priority URLs got complex enough
that it made sense to pull it all out into it's own class, instead of trying
to add more class methods to the Indexing module.

Even though the use case for this is Hydra, I think it makes sense to put it in ActiveFedora, with Fedora::AccessControl defaults. 

* Many Hydra users are currently indexing with `ActiveFedora::Base.reindex_everything`. It is optimal if they can continue doing so but just have it work right (whether or not they even realized it wasn't indexing permissions right before), instead of needing to change their code.  Also instructions to use this method may be encoded in various hydra guides and docs. 

* The alternative seems to be to create a different `reindex_everything` method in a hydra gem. But I don't want to have to duplicate all the non-priority-related logic in two places, or have two parts of the hydra stack that basically do the same thing in different ways, it's undesirable additional complexity, which isn't really needed because:

* This shouldn't harm anyone, whether using Hydra or not. If you don't have any Hydra::AccessControls objects, then it still works fine, they'll just obviously never be first in the list if they don't exist.  And everything is completely backwards compat in any event (unless someone was relying previous order of ids returned/indexed, which was previously unspecified anyway)
   * The added CPU to make the check is negligible, this operation is slow because of what it has to do with Fedora, any added time from a few simple hasClass checks should disappear in the larger wall time. 
   * If you have a use for prioritizing other hasModel models first in the list, unrelated to Hydra, you can still use this feature. Or you can even set the prioritized models to empty array to effectively disable it. 
   * One example non-hydra app at `https://github.com/sul-dlss/argo` does not seem to use `descendant_uris` or `reindex_everything` at all. I suspect the small number of non-hydra AF-using apps are unlikely to use these features at all, so especially are not disturbed by them. 