### PR TITLE
Update fcrepo_wrapper command in README to use the correct port

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ solr_wrapper
 To start FCRepo, open another shell and run:
 
 ```bash
-fcrepo_wrapper -p 8984
+fcrepo_wrapper -p 8986
 ```
 
 Now you’re ready to run the tests. In the directory where active\_fedora


### PR DESCRIPTION
The tests require Fedora to be running on port 8986, and we can't use a .fcrepo_wrapper config file because it conflicts with the generator integration test.