### PR TITLE
Indexing::Map::IndexObject takes behaviors as a parameter

### DIFF
--- a/lib/active_fedora/indexing/map.rb
+++ b/lib/active_fedora/indexing/map.rb
@@ -19,8 +19,8 @@ module ActiveFedora::Indexing
       attr_accessor :data_type, :behaviors, :term
       attr_reader :key
 
-      def initialize(name, &_block)
-        @behaviors = []
+      def initialize(name, behaviors: [], &_block)
+        @behaviors = behaviors
         @data_type = :string
         @key = name
         yield self if block_given?

--- a/spec/unit/indexing/map/index_object_spec.rb
+++ b/spec/unit/indexing/map/index_object_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Indexing::Map::IndexObject do
+  describe "with a block" do
+    subject(:instance) do
+      described_class.new(:name) do |index|
+        index.as :stored_searchable, :facetable
+      end
+    end
+
+    it "can set behaviors" do
+      expect(instance.behaviors).to eq [:stored_searchable, :facetable]
+    end
+  end
+
+  describe "with an initializer parameters" do
+    subject(:instance) do
+      described_class.new(:name, behaviors: [:stored_searchable, :facetable])
+    end
+
+    it "can set behaviors" do
+      expect(instance.behaviors).to eq [:stored_searchable, :facetable]
+    end
+  end
+end


### PR DESCRIPTION
Previously we were resricted to setting behaviors in a block.

This new way is useful if we want to construct the index map manually,
not using the index hints on the model parameters