### PR TITLE
Add Indexing::Map#merge

### DIFF
--- a/lib/active_fedora/indexing/map.rb
+++ b/lib/active_fedora/indexing/map.rb
@@ -11,7 +11,15 @@ module ActiveFedora::Indexing
     end
 
     def dup
-      self.class.new(@hash.deep_dup)
+      self.class.new(to_hash)
+    end
+
+    def merge(new_hash)
+      self.class.new(to_hash.merge(new_hash))
+    end
+
+    def to_hash
+      @hash.deep_dup
     end
 
     # this enables a cleaner API for solr integration

--- a/spec/unit/indexing/map_spec.rb
+++ b/spec/unit/indexing/map_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe ActiveFedora::Indexing::Map do
+  describe ".merge" do
+    subject(:merged) { first_map.merge(extra) }
+    let(:index_object1) { instance_double(described_class::IndexObject) }
+    let(:index_object2) { instance_double(described_class::IndexObject) }
+    let(:index_object3) { instance_double(described_class::IndexObject) }
+    let(:first_map) { described_class.new(one: index_object1, two: index_object2) }
+
+    context "with a hash" do
+      let(:extra) { { three: index_object3 } }
+      it "merges with a hash" do
+        expect(merged).to be_instance_of described_class
+        expect(merged.keys).to match_array [:one, :two, :three]
+      end
+    end
+
+    context "with another Indexing::Map" do
+      let(:extra) { described_class.new(three: index_object3) }
+      it "merges with the other map" do
+        expect(merged).to be_instance_of described_class
+        expect(merged.keys).to match_array [:one, :two, :three]
+      end
+    end
+  end
+end


### PR DESCRIPTION
This enables you to construct a custom indexing map:

```ruby
class MyIndexer < ActiveFedora::RDF::IndexingService
  protected
    # This method overrides ActiveFedora::RDF::IndexingService
    # @return [ActiveFedora::Indexing::Map]
    def index_config
      super.merge(my_indexing_behavior)
    end

    def my_indexing_behavior
      { my_field: ActiveFedora::Indexing::Map::IndexObject.new ... }
    end
end
```