### PR TITLE
Raise expected RuntimeError by using correct variable

### DIFF
--- a/lib/active_fedora/file.rb
+++ b/lib/active_fedora/file.rb
@@ -40,7 +40,7 @@ module ActiveFedora
           id = ActiveFedora::Associations::IDComposite.new([identifier], translate_uri_to_id).first
           @ldp_source = build_ldp_resource id
         else
-          raise "The first argument to #{self} must be a Hash, String or RDF::URI. You provided a #{uri.class}"
+          raise "The first argument to #{self} must be a Hash, String or RDF::URI. You provided a #{identifier.class}"
         end
 
         @attributes = {}.with_indifferent_access

--- a/spec/unit/file_spec.rb
+++ b/spec/unit/file_spec.rb
@@ -451,7 +451,7 @@ describe ActiveFedora::File do
 
     context "when Array passed to new" do
       it "raises an expection" do
-        expect { described_class.new([]) }.to raise_error
+        expect { described_class.new([]) }.to raise_error(RuntimeError)
       end
     end
   end


### PR DESCRIPTION
uri is actually a method on file but since this file is still running initialize and obviously doesn't have a uri it throws a NoMethodError for subject_uri inside that method instead of raising the exception on line 43.  This PR uses the indentifier param to make the correct error message and narrows the unit test to expect a RuntimeError instead of any error.