### PR TITLE
Pass nil instead of a nil RDF::URI as subject to Ldp::Resource to avoid head request

### DIFF
--- a/lib/active_fedora/with_metadata/metadata_node.rb
+++ b/lib/active_fedora/with_metadata/metadata_node.rb
@@ -36,6 +36,7 @@ module ActiveFedora
       end
 
       def ldp_source
+        @ldp_source ||= LdpResource.new(ldp_connection, nil) if file.new_record?
         @ldp_source ||= LdpResource.new(ldp_connection, metadata_uri)
       end
 

--- a/spec/unit/with_metadata/metadata_node_spec.rb
+++ b/spec/unit/with_metadata/metadata_node_spec.rb
@@ -41,4 +41,11 @@ describe ActiveFedora::WithMetadata::MetadataNode do
       end
     end
   end
+
+  describe ".new" do
+    it "does not make a request when parent file is new" do
+      expect(file.ldp_source.client).not_to receive(:head)
+      described_class.new(file)
+    end
+  end
 end


### PR DESCRIPTION
I discovered this when working on external files.  Ldp::Resource is checking for subject.nil? which is not true for RDF::URI.new(nil).
https://github.com/projecthydra/ldp/blob/master/lib/ldp/resource.rb#L42

This should avoid some head requests and speed up the spec tests a little.