### PR TITLE
Metadata node save

### DIFF
--- a/lib/active_fedora/with_metadata/metadata_node.rb
+++ b/lib/active_fedora/with_metadata/metadata_node.rb
@@ -48,6 +48,7 @@ module ActiveFedora
         raise "Save the file first" if file.new_record?
         SparqlInsert.new(changes_for_update, file.uri).execute(metadata_uri)
         @ldp_source = nil
+        @metadata_uri = nil
         true
       end
 

--- a/spec/unit/with_metadata/metadata_node_spec.rb
+++ b/spec/unit/with_metadata/metadata_node_spec.rb
@@ -48,4 +48,22 @@ describe ActiveFedora::WithMetadata::MetadataNode do
       described_class.new(file)
     end
   end
+
+  describe ".save" do
+    it "resets metadata_uri" do
+      expect(node.metadata_uri).to eq ::RDF::URI.new(nil)
+      file.content = "test"
+      file.save!
+      node.save
+      expect(node.metadata_uri).not_to eq ::RDF::URI.new(nil)
+    end
+
+    it "resets ldp_source" do
+      expect(node.ldp_source.new?).to be_truthy
+      file.content = "test"
+      file.save!
+      node.save
+      expect(node.ldp_source.new?).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
This PR builds on #1233 and fixes the resetting of metadata_uri so if you call save on the metadata node it will reinitialize with the described_by uri from it's parent file.