### PR TITLE
YAML.safe_load - allow YAML aliases - loading solr.yml and fedora.yml

### DIFF
--- a/lib/active_fedora/file_configurator.rb
+++ b/lib/active_fedora/file_configurator.rb
@@ -108,7 +108,7 @@ module ActiveFedora
       end
 
       begin
-        fedora_yml = YAML.safe_load(config_erb)
+        fedora_yml = YAML.safe_load(config_erb, [], [], true) # allow YAML aliases
       rescue Psych::SyntaxError => e
         raise "fedora.yml was found, but could not be parsed. " \
               "Error #{e.message}"
@@ -132,7 +132,7 @@ module ActiveFedora
       end
 
       begin
-        solr_yml = YAML.safe_load(config_erb)
+        solr_yml = YAML.safe_load(config_erb, [], [], true) # allow YAML aliases
       rescue StandardError
         raise("solr.yml was found, but could not be parsed.\n")
       end


### PR DESCRIPTION
I bumped into this while working on https://github.com/projecthydra-labs/hyku/pull/1052