### PR TITLE
[EXPERIMENTAL] ActiveFedora::RuntimeRegistry - use thread_mattr_accessor

### DIFF
--- a/lib/active_fedora/runtime_registry.rb
+++ b/lib/active_fedora/runtime_registry.rb
@@ -1,9 +1,7 @@
-require 'active_support/per_thread_registry'
+require 'active_support/core_ext/module/attribute_accessors_per_thread'
 
 module ActiveFedora
   class RuntimeRegistry
-    extend ActiveSupport::PerThreadRegistry
-
-    attr_accessor :solr_service, :fedora_connection
+    thread_mattr_accessor :solr_service, :fedora_connection
   end
 end


### PR DESCRIPTION
Fix #1244 

```
$ git grep 'PerThreadRegistry'
lib/active_fedora/runtime_registry.rb:    extend ActiveSupport::PerThreadRegistry
lib/active_fedora/scoping.rb:      extend ActiveSupport::PerThreadRegistry
```

- [ ] lib/active_fedora/runtime_registry.rb
  - attempted to use `thread_mattr_accessor`, but I don't fully understand it and the implications
  - specs passed on my laptop, but there may be no threading specs that test the behavior fully
- [ ] lib/active_fedora/scoping.rb
  - not obvious how to apply it on the `ScopeRegistry` class, because it has no attrs, only implemented methods
