### PR TITLE
Make solr.yml consistent w/ blacklight.yml (and itself)

### DIFF
--- a/lib/generators/active_fedora/config/solr/templates/solr.yml
+++ b/lib/generators/active_fedora/config/solr/templates/solr.yml
@@ -1,7 +1,7 @@
 # This is a sample config file that points to a solr server for each environment
 development:
-  url: http://127.0.0.1:<%= ENV['SOLR_TEST_PORT'] || 8983 %>/solr/hydra-development
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/hydra-development" %>
 test:
-  url: http://127.0.0.1:<%= ENV['SOLR_TEST_PORT'] || 8985 %>/solr/hydra-test
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_TEST_PORT', 8985)}/solr/hydra-test" %>
 production:
-  url: http://your.production.server:8080/bl_solr/core0
+  url: <%= ENV['SOLR_URL'] || "http://your.production.server:8080/bl_solr/core0" %>


### PR DESCRIPTION
- honor SOLR_URL in all 3 environments
- Use 127.0.0.1 for both dev and test
- fix copy/paste error repetition of SOLR_TEST_PORT in dev environment

See also: 
- https://github.com/projecthydra-labs/hyrax/issues/1016
- https://github.com/projecthydra/hydra-head/pull/411